### PR TITLE
Implement PEP 0017: Monitor-Tag Association Management

### DIFF
--- a/admin/pep/0017_monitor_tag_association.md
+++ b/admin/pep/0017_monitor_tag_association.md
@@ -6,7 +6,7 @@
 
 ## Abstract
 
-Extend the tag functionality to support associating tags with monitors, including managing tag values and colors for individual monitor-tag relationships. This completes the tag management API by allowing users to organize and categorize monitors using tags.
+Extend the tag functionality to support associating tags with monitors, including managing tag values for individual monitor-tag relationships. This completes the tag management API by allowing users to organize and categorize monitors using tags.
 
 ## Motivation
 
@@ -122,7 +122,7 @@ The addition of `Tags` field to `monitor.Base` should be backward compatible as 
 
 ### Integration Tests
 
-Add integration tests in `main_test.go` that:
+Add integration tests in `tag_test.go` that:
 
 1. Create multiple tags
 2. Create multiple monitors

--- a/monitor/monitor_base.go
+++ b/monitor/monitor_base.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+
+	"github.com/breml/go-uptime-kuma-client/tag"
 )
 
 type Monitor interface {
@@ -14,18 +16,19 @@ type Monitor interface {
 }
 
 type Base struct {
-	ID              int64   `json:"id"`
-	Name            string  `json:"name"`
-	Description     *string `json:"description"`
-	PathName        string  `json:"pathName"`
-	Parent          *int64  `json:"parent"`
-	Interval        int64   `json:"interval"`
-	RetryInterval   int64   `json:"retryInterval"`
-	ResendInterval  int64   `json:"resendInterval"`
-	MaxRetries      int64   `json:"maxretries"`
-	UpsideDown      bool    `json:"upsideDown"`
-	NotificationIDs []int64 `json:"-"`
-	IsActive        bool    `json:"active"`
+	ID              int64            `json:"id"`
+	Name            string           `json:"name"`
+	Description     *string          `json:"description"`
+	PathName        string           `json:"pathName"`
+	Parent          *int64           `json:"parent"`
+	Interval        int64            `json:"interval"`
+	RetryInterval   int64            `json:"retryInterval"`
+	ResendInterval  int64            `json:"resendInterval"`
+	MaxRetries      int64            `json:"maxretries"`
+	UpsideDown      bool             `json:"upsideDown"`
+	NotificationIDs []int64          `json:"-"`
+	Tags            []tag.MonitorTag `json:"tags"`
+	IsActive        bool             `json:"active"`
 
 	internalType string
 	raw          []byte
@@ -37,19 +40,20 @@ func (b Base) String() string {
 
 func (b *Base) UnmarshalJSON(data []byte) error {
 	raw := struct {
-		ID              int64           `json:"id"`
-		Type            string          `json:"type"`
-		Name            string          `json:"name"`
-		Description     *string         `json:"description"`
-		PathName        string          `json:"pathName"`
-		Parent          *int64          `json:"parent"`
-		Interval        int64           `json:"interval"`
-		RetryInterval   int64           `json:"retryInterval"`
-		ResendInterval  int64           `json:"resendInterval"`
-		MaxRetries      int64           `json:"maxretries"`
-		UpsideDown      bool            `json:"upsideDown"`
-		NotificationIDs map[string]bool `json:"notificationIDList"`
-		IsActive        bool            `json:"active"`
+		ID              int64            `json:"id"`
+		Type            string           `json:"type"`
+		Name            string           `json:"name"`
+		Description     *string          `json:"description"`
+		PathName        string           `json:"pathName"`
+		Parent          *int64           `json:"parent"`
+		Interval        int64            `json:"interval"`
+		RetryInterval   int64            `json:"retryInterval"`
+		ResendInterval  int64            `json:"resendInterval"`
+		MaxRetries      int64            `json:"maxretries"`
+		UpsideDown      bool             `json:"upsideDown"`
+		NotificationIDs map[string]bool  `json:"notificationIDList"`
+		Tags            []tag.MonitorTag `json:"tags"`
+		IsActive        bool             `json:"active"`
 	}{}
 
 	err := json.Unmarshal(data, &raw)
@@ -72,6 +76,11 @@ func (b *Base) UnmarshalJSON(data []byte) error {
 
 		internalType: raw.Type,
 		raw:          data,
+	}
+
+	// Only set Tags if it's not an empty slice to maintain nil semantics
+	if len(raw.Tags) > 0 {
+		b.Tags = raw.Tags
 	}
 
 	for id := range orderedByKey(raw.NotificationIDs) {

--- a/tag.go
+++ b/tag.go
@@ -78,11 +78,183 @@ func (c *Client) UpdateTag(ctx context.Context, t tag.Tag) error {
 }
 
 // DeleteTag deletes a tag by ID.
+// This also removes all monitor-tag associations for this tag via cascade delete.
 func (c *Client) DeleteTag(ctx context.Context, tagID int64) error {
 	_, err := c.syncEmit(ctx, "deleteTag", tagID)
 	if err != nil {
 		return fmt.Errorf("delete tag %d: %v", tagID, err)
 	}
 
+	// Manually remove this tag from all monitors in the cache
+	// The server removes all monitor-tag associations when a tag is deleted
+	c.mu.Lock()
+	for i := range c.state.monitors {
+		filteredTags := make([]tag.MonitorTag, 0, len(c.state.monitors[i].Tags))
+		for _, t := range c.state.monitors[i].Tags {
+			if t.TagID != tagID {
+				filteredTags = append(filteredTags, t)
+			}
+		}
+		c.state.monitors[i].Tags = filteredTags
+	}
+	c.mu.Unlock()
+
 	return nil
+}
+
+// refreshMonitorInCache fetches a monitor and updates it in the cache.
+// This is used by tag operations since the server doesn't emit update events for them.
+// If the monitor is not found in the cache, it will be added.
+func (c *Client) refreshMonitorInCache(ctx context.Context, monitorID int64) error {
+	mon, err := c.GetMonitor(ctx, monitorID)
+	if err != nil {
+		return err
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Try to find and update existing monitor in cache
+	for i, cachedMon := range c.state.monitors {
+		if cachedMon.ID == monitorID {
+			c.state.monitors[i] = mon
+			return nil
+		}
+	}
+
+	// Monitor not found in cache, add it
+	c.state.monitors = append(c.state.monitors, mon)
+
+	return nil
+}
+
+// AddMonitorTag adds a tag to a monitor with an optional value.
+func (c *Client) AddMonitorTag(ctx context.Context, tagID int64, monitorID int64, value string) (*tag.MonitorTag, error) {
+	response, err := c.syncEmit(ctx, "addMonitorTag", tagID, monitorID, value)
+	if err != nil {
+		return nil, fmt.Errorf("add monitor tag (tag %d, monitor %d): %v", tagID, monitorID, err)
+	}
+
+	if !response.OK {
+		return nil, fmt.Errorf("add monitor tag (tag %d, monitor %d): %s", tagID, monitorID, response.Msg)
+	}
+
+	// Refresh the monitor in cache to get the updated tags
+	if err := c.refreshMonitorInCache(ctx, monitorID); err != nil {
+		return nil, fmt.Errorf("add monitor tag (tag %d, monitor %d): failed to refresh cache: %v", tagID, monitorID, err)
+	}
+
+	// Find the tag we just added from the cache
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for _, mon := range c.state.monitors {
+		if mon.ID == monitorID {
+			for _, t := range mon.Tags {
+				if t.TagID == tagID && t.Value == value {
+					return &t, nil
+				}
+			}
+			break
+		}
+	}
+
+	return nil, fmt.Errorf("add monitor tag (tag %d, monitor %d): tag added but not found in monitor tags", tagID, monitorID)
+}
+
+// UpdateMonitorTag updates the value of a monitor-tag association.
+func (c *Client) UpdateMonitorTag(ctx context.Context, tagID int64, monitorID int64, value string) error {
+	response, err := c.syncEmit(ctx, "editMonitorTag", tagID, monitorID, value)
+	if err != nil {
+		return fmt.Errorf("update monitor tag (tag %d, monitor %d): %v", tagID, monitorID, err)
+	}
+
+	if !response.OK {
+		return fmt.Errorf("update monitor tag (tag %d, monitor %d): %s", tagID, monitorID, response.Msg)
+	}
+
+	// Refresh the monitor in cache to get the updated tags
+	if err := c.refreshMonitorInCache(ctx, monitorID); err != nil {
+		return fmt.Errorf("update monitor tag (tag %d, monitor %d): failed to refresh cache: %v", tagID, monitorID, err)
+	}
+
+	return nil
+}
+
+// DeleteMonitorTagWithValue removes a specific tag association from a monitor by value.
+func (c *Client) DeleteMonitorTagWithValue(ctx context.Context, tagID int64, monitorID int64, value string) error {
+	response, err := c.syncEmit(ctx, "deleteMonitorTag", tagID, monitorID, value)
+	if err != nil {
+		return fmt.Errorf("delete monitor tag with value (tag %d, monitor %d, value %q): %v", tagID, monitorID, value, err)
+	}
+
+	if !response.OK {
+		return fmt.Errorf("delete monitor tag with value (tag %d, monitor %d, value %q): %s", tagID, monitorID, value, response.Msg)
+	}
+
+	// Refresh the monitor in cache to get the updated tags
+	if err := c.refreshMonitorInCache(ctx, monitorID); err != nil {
+		return fmt.Errorf("delete monitor tag with value (tag %d, monitor %d, value %q): failed to refresh cache: %v", tagID, monitorID, value, err)
+	}
+
+	return nil
+}
+
+// DeleteMonitorTag removes all associations of a tag from a monitor (all values).
+func (c *Client) DeleteMonitorTag(ctx context.Context, tagID int64, monitorID int64) error {
+	// Get all tags for the monitor
+	tags, err := c.GetMonitorTags(ctx, monitorID)
+	if err != nil {
+		return fmt.Errorf("delete monitor tag (tag %d, monitor %d): failed to fetch tags: %v", tagID, monitorID, err)
+	}
+
+	// Delete all associations with the given tagID
+	for _, t := range tags {
+		if t.TagID == tagID {
+			err := c.DeleteMonitorTagWithValue(ctx, tagID, monitorID, t.Value)
+			if err != nil {
+				return fmt.Errorf("delete monitor tag (tag %d, monitor %d): %v", tagID, monitorID, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// GetMonitorTags retrieves all tags for a specific monitor.
+// This method uses the client's local state cache, which is kept synchronized
+// via socket.io events. The cache is automatically updated by monitorList,
+// updateMonitorIntoList, and deleteMonitorFromList events.
+func (c *Client) GetMonitorTags(ctx context.Context, monitorID int64) ([]tag.MonitorTag, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for _, mon := range c.state.monitors {
+		if mon.ID == monitorID {
+			return mon.Tags, nil
+		}
+	}
+
+	return nil, fmt.Errorf("get monitor tags (monitor %d): %w", monitorID, ErrNotFound)
+}
+
+// GetTagMonitors retrieves all monitor IDs associated with a specific tag.
+// This method uses the client's local state cache, which is kept synchronized
+// via socket.io events. The cache is automatically updated by monitorList,
+// updateMonitorIntoList, and deleteMonitorFromList events.
+func (c *Client) GetTagMonitors(ctx context.Context, tagID int64) ([]int64, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	var monitorIDs []int64
+	for _, mon := range c.state.monitors {
+		for _, t := range mon.Tags {
+			if t.TagID == tagID {
+				monitorIDs = append(monitorIDs, mon.ID)
+				break
+			}
+		}
+	}
+
+	return monitorIDs, nil
 }

--- a/tag/tag.go
+++ b/tag/tag.go
@@ -15,3 +15,30 @@ func (t Tag) String() string {
 func (t Tag) GetID() int64 {
 	return t.ID
 }
+
+// MonitorTag represents the association between a monitor and a tag.
+type MonitorTag struct {
+	ID        int64  `json:"id"`         // Association ID
+	TagID     int64  `json:"tag_id"`     // Tag ID
+	MonitorID int64  `json:"monitor_id"` // Monitor ID
+	Value     string `json:"value"`      // Optional tag value for this monitor
+	Name      string `json:"name"`       // Tag name (from joined tag table)
+	Color     string `json:"color"`      // Tag color (from joined tag table, not customizable per association)
+}
+
+func (mt MonitorTag) String() string {
+	return fmt.Sprintf("MonitorTag{ID: %d, TagID: %d, MonitorID: %d, Value: %s, Name: %s, Color: %s}",
+		mt.ID, mt.TagID, mt.MonitorID, mt.Value, mt.Name, mt.Color)
+}
+
+// TagWithMonitors extends Tag with monitor associations.
+type TagWithMonitors struct {
+	Tag
+	Monitors []int64 `json:"monitors"` // List of associated monitor IDs
+}
+
+// MonitorTags represents all tags for a specific monitor.
+type MonitorTags struct {
+	MonitorID int64        `json:"monitor_id"`
+	Tags      []MonitorTag `json:"tags"`
+}

--- a/tag_test.go
+++ b/tag_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	kuma "github.com/breml/go-uptime-kuma-client"
+	"github.com/breml/go-uptime-kuma-client/monitor"
 	"github.com/breml/go-uptime-kuma-client/tag"
 )
 
@@ -84,5 +85,300 @@ func TestClient_TagCRUD(t *testing.T) {
 		_, err = client.GetTag(ctx, tagID)
 		require.Error(t, err)
 		require.ErrorIs(t, err, kuma.ErrNotFound)
+	})
+}
+
+func TestClient_MonitorTagAssociations(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// Create test tags
+	tag1ID, err := client.CreateTag(ctx, tag.Tag{Name: "Environment", Color: "#FF0000"})
+	require.NoError(t, err)
+	defer func() { _ = client.DeleteTag(ctx, tag1ID) }()
+
+	tag2ID, err := client.CreateTag(ctx, tag.Tag{Name: "Priority", Color: "#00FF00"})
+	require.NoError(t, err)
+	defer func() { _ = client.DeleteTag(ctx, tag2ID) }()
+
+	tag3ID, err := client.CreateTag(ctx, tag.Tag{Name: "Team", Color: "#0000FF"})
+	require.NoError(t, err)
+	defer func() { _ = client.DeleteTag(ctx, tag3ID) }()
+
+	// Create test monitors
+	monitorID1, err := client.CreateMonitor(ctx, monitor.HTTP{
+		Base: monitor.Base{
+			Name:           "Test Monitor 1",
+			Interval:       60,
+			RetryInterval:  60,
+			ResendInterval: 0,
+			MaxRetries:     3,
+			UpsideDown:     false,
+			IsActive:       true,
+		},
+		HTTPDetails: monitor.HTTPDetails{
+			URL:                 "https://example.com",
+			Timeout:             48,
+			Method:              "GET",
+			ExpiryNotification:  false,
+			IgnoreTLS:           false,
+			MaxRedirects:        10,
+			AcceptedStatusCodes: []string{"200-299"},
+			AuthMethod:          monitor.AuthMethodNone,
+		},
+	})
+	require.NoError(t, err)
+	defer func() { _ = client.DeleteMonitor(ctx, monitorID1) }()
+
+	monitorID2, err := client.CreateMonitor(ctx, monitor.HTTP{
+		Base: monitor.Base{
+			Name:           "Test Monitor 2",
+			Interval:       60,
+			RetryInterval:  60,
+			ResendInterval: 0,
+			MaxRetries:     3,
+			UpsideDown:     false,
+			IsActive:       true,
+		},
+		HTTPDetails: monitor.HTTPDetails{
+			URL:                 "https://example.org",
+			Timeout:             48,
+			Method:              "GET",
+			ExpiryNotification:  false,
+			IgnoreTLS:           false,
+			MaxRedirects:        10,
+			AcceptedStatusCodes: []string{"200-299"},
+			AuthMethod:          monitor.AuthMethodNone,
+		},
+	})
+	require.NoError(t, err)
+	defer func() { _ = client.DeleteMonitor(ctx, monitorID2) }()
+
+	t.Run("add_tag_to_monitor", func(t *testing.T) {
+		// Add tag with value to monitor
+		monitorTag, err := client.AddMonitorTag(ctx, tag1ID, monitorID1, "production")
+		require.NoError(t, err)
+		require.NotNil(t, monitorTag)
+		require.Equal(t, tag1ID, monitorTag.TagID)
+		require.Equal(t, monitorID1, monitorTag.MonitorID)
+		require.Equal(t, "production", monitorTag.Value)
+		require.Equal(t, "Environment", monitorTag.Name)
+		require.Equal(t, "#FF0000", monitorTag.Color)
+
+		// Verify tag appears on monitor
+		tags, err := client.GetMonitorTags(ctx, monitorID1)
+		require.NoError(t, err)
+		require.Len(t, tags, 1)
+		require.Equal(t, tag1ID, tags[0].TagID)
+		require.Equal(t, "production", tags[0].Value)
+		require.Equal(t, "Environment", tags[0].Name)
+		require.Equal(t, "#FF0000", tags[0].Color)
+	})
+
+	t.Run("add_multiple_tags_to_monitor", func(t *testing.T) {
+		// Add second tag
+		_, err := client.AddMonitorTag(ctx, tag2ID, monitorID1, "high")
+		require.NoError(t, err)
+
+		// Add third tag with empty value
+		_, err = client.AddMonitorTag(ctx, tag3ID, monitorID1, "")
+		require.NoError(t, err)
+
+		// Verify all tags
+		tags, err := client.GetMonitorTags(ctx, monitorID1)
+		require.NoError(t, err)
+		require.Len(t, tags, 3)
+
+		// Check each tag
+		tagsByID := make(map[int64]tag.MonitorTag)
+		for _, mt := range tags {
+			tagsByID[mt.TagID] = mt
+		}
+
+		require.Equal(t, "production", tagsByID[tag1ID].Value)
+		require.Equal(t, "high", tagsByID[tag2ID].Value)
+		require.Equal(t, "", tagsByID[tag3ID].Value)
+	})
+
+	t.Run("add_same_tag_with_different_values", func(t *testing.T) {
+		// Add the same tag with a different value
+		_, err := client.AddMonitorTag(ctx, tag1ID, monitorID1, "staging")
+		require.NoError(t, err)
+
+		// Verify both values exist
+		tags, err := client.GetMonitorTags(ctx, monitorID1)
+		require.NoError(t, err)
+
+		// Count environment tags
+		envTags := 0
+		for _, mt := range tags {
+			if mt.TagID == tag1ID {
+				envTags++
+			}
+		}
+		require.Equal(t, 2, envTags, "Should have 2 Environment tags with different values")
+	})
+
+	t.Run("update_monitor_tag_value", func(t *testing.T) {
+		// Update one of the tag values
+		err := client.UpdateMonitorTag(ctx, tag2ID, monitorID1, "critical")
+		require.NoError(t, err)
+
+		// Verify update
+		tags, err := client.GetMonitorTags(ctx, monitorID1)
+		require.NoError(t, err)
+
+		found := false
+		for _, mt := range tags {
+			if mt.TagID == tag2ID {
+				require.Equal(t, "critical", mt.Value)
+				found = true
+				break
+			}
+		}
+		require.True(t, found, "Updated tag not found")
+	})
+
+	t.Run("add_tag_to_multiple_monitors", func(t *testing.T) {
+		// Add tag1 to monitor2
+		_, err := client.AddMonitorTag(ctx, tag1ID, monitorID2, "development")
+		require.NoError(t, err)
+
+		// Verify tag appears on both monitors
+		monitors, err := client.GetTagMonitors(ctx, tag1ID)
+		require.NoError(t, err)
+		require.Len(t, monitors, 2)
+		require.Contains(t, monitors, monitorID1)
+		require.Contains(t, monitors, monitorID2)
+	})
+
+	t.Run("get_tag_monitors", func(t *testing.T) {
+		// Get monitors with tag2
+		monitors, err := client.GetTagMonitors(ctx, tag2ID)
+		require.NoError(t, err)
+		require.Len(t, monitors, 1)
+		require.Equal(t, monitorID1, monitors[0])
+
+		// Get monitors with tag3
+		monitors, err = client.GetTagMonitors(ctx, tag3ID)
+		require.NoError(t, err)
+		require.Len(t, monitors, 1)
+		require.Equal(t, monitorID1, monitors[0])
+	})
+
+	t.Run("delete_specific_tag_value", func(t *testing.T) {
+		// Delete one specific Environment tag value (staging)
+		err := client.DeleteMonitorTagWithValue(ctx, tag1ID, monitorID1, "staging")
+		require.NoError(t, err)
+
+		// Verify only production remains for monitor1
+		tags, err := client.GetMonitorTags(ctx, monitorID1)
+		require.NoError(t, err)
+
+		envTags := 0
+		for _, mt := range tags {
+			if mt.TagID == tag1ID && mt.MonitorID == monitorID1 {
+				envTags++
+				require.Equal(t, "production", mt.Value)
+			}
+		}
+		require.Equal(t, 1, envTags, "Should have only 1 Environment tag after deleting staging")
+	})
+
+	t.Run("delete_all_tag_associations", func(t *testing.T) {
+		// Delete all tag1 associations from monitor1
+		err := client.DeleteMonitorTag(ctx, tag1ID, monitorID1)
+		require.NoError(t, err)
+
+		// Verify tag1 is removed from monitor1
+		tags, err := client.GetMonitorTags(ctx, monitorID1)
+		require.NoError(t, err)
+
+		for _, mt := range tags {
+			require.NotEqual(t, tag1ID, mt.TagID, "tag1 should be removed from monitor1")
+		}
+
+		// Verify tag1 still exists on monitor2
+		tags, err = client.GetMonitorTags(ctx, monitorID2)
+		require.NoError(t, err)
+
+		found := false
+		for _, mt := range tags {
+			if mt.TagID == tag1ID {
+				found = true
+				break
+			}
+		}
+		require.True(t, found, "tag1 should still exist on monitor2")
+	})
+
+	t.Run("monitor_includes_tags", func(t *testing.T) {
+		// Get monitor and verify tags are included
+		mon, err := client.GetMonitor(ctx, monitorID2)
+		require.NoError(t, err)
+		require.NotNil(t, mon.Tags)
+		require.Greater(t, len(mon.Tags), 0)
+
+		// Verify tag details
+		found := false
+		for _, mt := range mon.Tags {
+			if mt.TagID == tag1ID {
+				require.Equal(t, "development", mt.Value)
+				require.Equal(t, "Environment", mt.Name)
+				require.Equal(t, "#FF0000", mt.Color)
+				found = true
+				break
+			}
+		}
+		require.True(t, found, "tag1 should be present in monitor2 tags")
+	})
+
+	t.Run("delete_tag_removes_associations", func(t *testing.T) {
+		// Create a temporary tag
+		tempTagID, err := client.CreateTag(ctx, tag.Tag{Name: "Temp", Color: "#AAAAAA"})
+		require.NoError(t, err)
+
+		// Add to monitor
+		_, err = client.AddMonitorTag(ctx, tempTagID, monitorID1, "temp")
+		require.NoError(t, err)
+
+		// Verify it's there
+		tags, err := client.GetMonitorTags(ctx, monitorID1)
+		require.NoError(t, err)
+		found := false
+		for _, mt := range tags {
+			if mt.TagID == tempTagID {
+				found = true
+				break
+			}
+		}
+		require.True(t, found, "temp tag should be on monitor")
+
+		// Delete the tag
+		err = client.DeleteTag(ctx, tempTagID)
+		require.NoError(t, err)
+
+		// Verify associations are removed (cascade delete)
+		tags, err = client.GetMonitorTags(ctx, monitorID1)
+		require.NoError(t, err)
+		for _, mt := range tags {
+			require.NotEqual(t, tempTagID, mt.TagID, "temp tag should be removed after tag deletion")
+		}
+	})
+
+	t.Run("edge_case_nonexistent_tag", func(t *testing.T) {
+		// Try to add non-existent tag
+		_, err := client.AddMonitorTag(ctx, 99999, monitorID1, "test")
+		require.Error(t, err)
+	})
+
+	t.Run("edge_case_nonexistent_monitor", func(t *testing.T) {
+		// Try to add tag to non-existent monitor
+		_, err := client.AddMonitorTag(ctx, tag1ID, 99999, "test")
+		require.Error(t, err)
 	})
 }


### PR DESCRIPTION
## Summary

This PR implements PEP 0017, which adds monitor-tag association management to the client library.

## Changes

### PEP Document
- Added PEP 0017 specification document with detailed design
- Documented two delete methods approach (delete all vs delete specific value)
- Clarified that tag colors are inherited from tag definition (read-only)
- Documented server implementation research findings

### Data Structures
- Added `MonitorTag` struct representing tag-monitor associations
- Added `TagWithMonitors` and `MonitorTags` helper types
- Extended `monitor.Base` with `Tags` field for tag associations
- Maintained nil vs empty slice semantics for backward compatibility

### Client Methods
- `AddMonitorTag(tagID, monitorID, value)` - Associate tag with monitor
- `UpdateMonitorTag(tagID, monitorID, value)` - Update tag value
- `DeleteMonitorTag(tagID, monitorID)` - Remove ALL tag associations
- `DeleteMonitorTagWithValue(tagID, monitorID, value)` - Remove specific association
- `GetMonitorTags(monitorID)` - Get all tags for a monitor
- `GetTagMonitors(tagID)` - Get all monitors with a tag

### Tests
- Comprehensive integration test suite covering:
  - Adding tags to monitors with values
  - Multiple tags on one monitor
  - Same tag with different values
  - Updating tag values
  - Tag on multiple monitors
  - Deleting specific values vs all associations
  - Cascade deletion verification
  - Edge cases (non-existent IDs)

## Test Results

- All tests passing ✅
- Linter clean ✅  
- Integration tests verified against real Uptime Kuma instance ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)