### PR TITLE
Add Webhook Notification Type

### DIFF
--- a/notification/notification_webhook.go
+++ b/notification/notification_webhook.go
@@ -1,0 +1,109 @@
+package notification
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Webhook represents a webhook notification provider.
+// It supports multiple content types ('json', 'form-data', 'custom') and custom headers.
+type Webhook struct {
+	Base
+	WebhookDetails
+}
+
+// WebhookDetails contains the webhook-specific configuration.
+type WebhookDetails struct {
+	WebhookURL               string                   `json:"webhookURL"`
+	WebhookContentType       string                   `json:"webhookContentType"`
+	WebhookCustomBody        string                   `json:"webhookCustomBody,omitempty"`
+	WebhookAdditionalHeaders WebhookAdditionalHeaders `json:"webhookAdditionalHeaders,omitempty"`
+}
+
+// WebhookAdditionalHeaders is a map of HTTP headers that marshals to/from a JSON string.
+// The Uptime Kuma server expects the headers as a JSON-encoded string, not a nested object.
+type WebhookAdditionalHeaders map[string]string
+
+// Type returns the notification type identifier for webhooks.
+func (w Webhook) Type() string {
+	return w.WebhookDetails.Type()
+}
+
+// Type returns the notification type identifier for webhook details.
+func (d WebhookDetails) Type() string {
+	return "webhook"
+}
+
+// String returns a human-readable representation of the webhook notification.
+func (w Webhook) String() string {
+	return fmt.Sprintf("%s, %s", formatNotification(w.Base, false), formatNotification(w.WebhookDetails, true))
+}
+
+// UnmarshalJSON deserializes a webhook notification from JSON.
+func (w *Webhook) UnmarshalJSON(data []byte) error {
+	detail := WebhookDetails{}
+	base, err := unmarshalTo(data, &detail)
+	if err != nil {
+		return err
+	}
+
+	*w = Webhook{
+		Base:           base,
+		WebhookDetails: detail,
+	}
+
+	return nil
+}
+
+// MarshalJSON serializes a webhook notification to JSON.
+func (w Webhook) MarshalJSON() ([]byte, error) {
+	return marshalJSON(w.Base, w.WebhookDetails)
+}
+
+// MarshalJSON serializes the headers map to a JSON string.
+// Example: {"Authorization": "Bearer token"} becomes "{\"Authorization\":\"Bearer token\"}"
+func (h WebhookAdditionalHeaders) MarshalJSON() ([]byte, error) {
+	if h == nil {
+		return []byte("null"), nil
+	}
+
+	// First marshal the map to JSON bytes
+	mapJSON, err := json.Marshal(map[string]string(h))
+	if err != nil {
+		return nil, err
+	}
+
+	// Then marshal the JSON bytes as a string
+	return json.Marshal(string(mapJSON))
+}
+
+// UnmarshalJSON deserializes a JSON string into the headers map.
+// Example: "{\"Authorization\":\"Bearer token\"}" becomes {"Authorization": "Bearer token"}
+func (h *WebhookAdditionalHeaders) UnmarshalJSON(data []byte) error {
+	// First check if it's null or empty string
+	if string(data) == "null" || string(data) == `""` {
+		*h = nil
+		return nil
+	}
+
+	// Unmarshal the outer JSON string
+	var jsonStr string
+	if err := json.Unmarshal(data, &jsonStr); err != nil {
+		return err
+	}
+
+	// If the string is empty after unmarshaling, treat as nil
+	if jsonStr == "" {
+		*h = nil
+		return nil
+	}
+
+	// Unmarshal the inner JSON object
+	var headers map[string]string
+	if err := json.Unmarshal([]byte(jsonStr), &headers); err != nil {
+		return err
+	}
+
+	*h = WebhookAdditionalHeaders(headers)
+	return nil
+}

--- a/notification/notification_webhook_test.go
+++ b/notification/notification_webhook_test.go
@@ -1,0 +1,240 @@
+package notification_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/breml/go-uptime-kuma-client/notification"
+)
+
+func TestNotificationWebhook_Unmarshal(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+
+		want     notification.Webhook
+		wantJSON string
+	}{
+		{
+			name: "json content type",
+			data: []byte(`{"id":1,"name":"Webhook JSON","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":true,\"isDefault\":false,\"name\":\"Webhook JSON\",\"webhookURL\":\"https://example.com/webhook\",\"webhookContentType\":\"json\",\"type\":\"webhook\"}"}`),
+
+			want: notification.Webhook{
+				Base: notification.Base{
+					ID:            1,
+					Name:          "Webhook JSON",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: true,
+				},
+				WebhookDetails: notification.WebhookDetails{
+					WebhookURL:         "https://example.com/webhook",
+					WebhookContentType: "json",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":true,"id":1,"isDefault":false,"name":"Webhook JSON","type":"webhook","userId":1,"webhookContentType":"json","webhookURL":"https://example.com/webhook"}`,
+		},
+		{
+			name: "form-data content type",
+			data: []byte(`{"id":2,"name":"Webhook Form","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Webhook Form\",\"webhookURL\":\"https://example.com/form-handler\",\"webhookContentType\":\"form-data\",\"type\":\"webhook\"}"}`),
+
+			want: notification.Webhook{
+				Base: notification.Base{
+					ID:            2,
+					Name:          "Webhook Form",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				WebhookDetails: notification.WebhookDetails{
+					WebhookURL:         "https://example.com/form-handler",
+					WebhookContentType: "form-data",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"id":2,"isDefault":false,"name":"Webhook Form","type":"webhook","userId":1,"webhookContentType":"form-data","webhookURL":"https://example.com/form-handler"}`,
+		},
+		{
+			name: "custom content type with body",
+			data: []byte(`{"id":3,"name":"Webhook Custom","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Webhook Custom\",\"webhookURL\":\"https://api.example.com/alerts\",\"webhookContentType\":\"custom\",\"webhookCustomBody\":\"{\\\"title\\\": \\\"Alert - {{ monitorJSON['name'] }}\\\", \\\"message\\\": \\\"{{ msg }}\\\"}\",\"type\":\"webhook\"}"}`),
+
+			want: notification.Webhook{
+				Base: notification.Base{
+					ID:            3,
+					Name:          "Webhook Custom",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				WebhookDetails: notification.WebhookDetails{
+					WebhookURL:         "https://api.example.com/alerts",
+					WebhookContentType: "custom",
+					WebhookCustomBody:  `{"title": "Alert - {{ monitorJSON['name'] }}", "message": "{{ msg }}"}`,
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"id":3,"isDefault":false,"name":"Webhook Custom","type":"webhook","userId":1,"webhookContentType":"custom","webhookCustomBody":"{\"title\": \"Alert - {{ monitorJSON['name'] }}\", \"message\": \"{{ msg }}\"}","webhookURL":"https://api.example.com/alerts"}`,
+		},
+		{
+			name: "with additional headers",
+			data: []byte(`{"id":4,"name":"Webhook Headers","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Webhook Headers\",\"webhookURL\":\"https://api.example.com/notify\",\"webhookContentType\":\"json\",\"webhookAdditionalHeaders\":\"{\\\"Authorization\\\":\\\"Bearer secret-token\\\",\\\"X-App-ID\\\":\\\"uptime-kuma\\\"}\",\"type\":\"webhook\"}"}`),
+
+			want: notification.Webhook{
+				Base: notification.Base{
+					ID:            4,
+					Name:          "Webhook Headers",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				WebhookDetails: notification.WebhookDetails{
+					WebhookURL:         "https://api.example.com/notify",
+					WebhookContentType: "json",
+					WebhookAdditionalHeaders: notification.WebhookAdditionalHeaders{
+						"Authorization": "Bearer secret-token",
+						"X-App-ID":      "uptime-kuma",
+					},
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"id":4,"isDefault":false,"name":"Webhook Headers","type":"webhook","userId":1,"webhookContentType":"json","webhookAdditionalHeaders":"{\"Authorization\":\"Bearer secret-token\",\"X-App-ID\":\"uptime-kuma\"}","webhookURL":"https://api.example.com/notify"}`,
+		},
+		{
+			name: "all features combined",
+			data: []byte(`{"id":5,"name":"Webhook Full","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"Webhook Full\",\"webhookURL\":\"https://alerts.example.com/v1/webhook\",\"webhookContentType\":\"custom\",\"webhookCustomBody\":\"{\\\"event\\\": \\\"{{ msg }}\\\", \\\"service\\\": \\\"{{ monitorJSON['name'] }}\\\"}\",\"webhookAdditionalHeaders\":\"{\\\"Authorization\\\":\\\"Bearer xyz123\\\",\\\"Content-Type\\\":\\\"application/json\\\",\\\"X-Custom-Header\\\":\\\"custom-value\\\"}\",\"type\":\"webhook\"}"}`),
+
+			want: notification.Webhook{
+				Base: notification.Base{
+					ID:            5,
+					Name:          "Webhook Full",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     true,
+					ApplyExisting: true,
+				},
+				WebhookDetails: notification.WebhookDetails{
+					WebhookURL:         "https://alerts.example.com/v1/webhook",
+					WebhookContentType: "custom",
+					WebhookCustomBody:  `{"event": "{{ msg }}", "service": "{{ monitorJSON['name'] }}"}`,
+					WebhookAdditionalHeaders: notification.WebhookAdditionalHeaders{
+						"Authorization":   "Bearer xyz123",
+						"Content-Type":    "application/json",
+						"X-Custom-Header": "custom-value",
+					},
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":true,"id":5,"isDefault":true,"name":"Webhook Full","type":"webhook","userId":1,"webhookContentType":"custom","webhookCustomBody":"{\"event\": \"{{ msg }}\", \"service\": \"{{ monitorJSON['name'] }}\"}","webhookAdditionalHeaders":"{\"Authorization\":\"Bearer xyz123\",\"Content-Type\":\"application/json\",\"X-Custom-Header\":\"custom-value\"}","webhookURL":"https://alerts.example.com/v1/webhook"}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			webhook := notification.Webhook{}
+
+			err := json.Unmarshal(tc.data, &webhook)
+			require.NoError(t, err)
+
+			require.EqualExportedValues(t, tc.want, webhook)
+
+			data, err := json.Marshal(webhook)
+			require.NoError(t, err)
+
+			require.JSONEq(t, tc.wantJSON, string(data))
+		})
+	}
+}
+
+func TestNotificationWebhook_Type(t *testing.T) {
+	webhook := notification.Webhook{}
+	require.Equal(t, "webhook", webhook.Type())
+
+	details := notification.WebhookDetails{}
+	require.Equal(t, "webhook", details.Type())
+}
+
+func TestNotificationWebhook_String(t *testing.T) {
+	webhook := notification.Webhook{
+		Base: notification.Base{
+			ID:            1,
+			Name:          "Test Webhook",
+			IsActive:      true,
+			UserID:        1,
+			IsDefault:     false,
+			ApplyExisting: true,
+		},
+		WebhookDetails: notification.WebhookDetails{
+			WebhookURL:         "https://example.com/webhook",
+			WebhookContentType: "json",
+		},
+	}
+
+	str := webhook.String()
+	require.Contains(t, str, "Test Webhook")
+	require.Contains(t, str, "webhook")
+	require.Contains(t, str, "https://example.com/webhook")
+	require.Contains(t, str, "json")
+}
+
+func TestWebhookAdditionalHeaders_MarshalUnmarshal(t *testing.T) {
+	tests := []struct {
+		name     string
+		headers  notification.WebhookAdditionalHeaders
+		wantJSON string
+	}{
+		{
+			name: "single header",
+			headers: notification.WebhookAdditionalHeaders{
+				"Authorization": "Bearer token",
+			},
+			wantJSON: `"{\"Authorization\":\"Bearer token\"}"`,
+		},
+		{
+			name: "multiple headers",
+			headers: notification.WebhookAdditionalHeaders{
+				"Authorization": "Bearer token",
+				"X-Custom":      "value",
+			},
+			wantJSON: `"{\"Authorization\":\"Bearer token\",\"X-Custom\":\"value\"}"`,
+		},
+		{
+			name:     "empty map",
+			headers:  notification.WebhookAdditionalHeaders{},
+			wantJSON: `"{}"`,
+		},
+		{
+			name:     "nil map",
+			headers:  nil,
+			wantJSON: `null`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Test marshaling
+			data, err := json.Marshal(tc.headers)
+			require.NoError(t, err)
+			require.JSONEq(t, tc.wantJSON, string(data))
+
+			// Test unmarshaling
+			var headers notification.WebhookAdditionalHeaders
+			err = json.Unmarshal(data, &headers)
+			require.NoError(t, err)
+
+			if tc.headers == nil {
+				require.Nil(t, headers)
+			} else {
+				require.Equal(t, tc.headers, headers)
+			}
+		})
+	}
+}
+
+func TestWebhookAdditionalHeaders_UnmarshalEmptyString(t *testing.T) {
+	var headers notification.WebhookAdditionalHeaders
+	err := json.Unmarshal([]byte(`""`), &headers)
+	require.NoError(t, err)
+	require.Nil(t, headers)
+}


### PR DESCRIPTION
## Summary

Implements issue #9 by adding comprehensive webhook notification support to the `notification` package.

This PR adds support for the webhook notification type, one of the most versatile notification types in Uptime Kuma, enabling integration with custom systems, internal tools, and services that don't have dedicated notification providers.

## Key Features

- **Multiple Content Types**: Full support for all three content types:
  - `json`: Standard JSON payload with `application/json` content type
  - `form-data`: Multipart form data with `multipart/form-data` content type
  - `custom`: User-defined custom body using template syntax
- **Template Support**: Custom body templates with Uptime Kuma template variables like `{{ msg }}` and `{{ monitorJSON['name'] }}`
- **Custom Headers**: Additional HTTP headers support with automatic JSON string marshaling for seamless API integration
- **Type-Safe API**: `WebhookAdditionalHeaders` type provides user-friendly `map[string]string` interface while automatically handling JSON string marshaling/unmarshaling as required by the Uptime Kuma server

## Implementation Details

### New Types

- `notification.Webhook`: Main struct embedding `Base` and `WebhookDetails`
- `notification.WebhookDetails`: Webhook-specific configuration fields
- `notification.WebhookAdditionalHeaders`: Custom type with automatic JSON string marshaling

### Field Details

- `WebhookURL` (required): The HTTP(S) endpoint URL to POST notification data to
- `WebhookContentType` (required): The request body format (`json`, `form-data`, or `custom`)
- `WebhookCustomBody` (optional): Template string for custom request body
- `WebhookAdditionalHeaders` (optional): Map of additional HTTP headers

## Testing

- **Unit Tests**: Comprehensive unit tests covering all webhook functionality including:
  - JSON marshaling/unmarshaling for all content types
  - Type() and String() methods
  - WebhookAdditionalHeaders marshaling edge cases
- **Integration Tests**: Full CRUD operations tested against real Uptime Kuma instance:
  - Create webhook notifications with different content types
  - Update webhook notifications
  - Delete webhook notifications
  - Variant tests for form-data and custom headers

## Example Usage

```go
// Create a webhook notification with JSON content type
webhook := notification.Webhook{
    Base: notification.Base{
        Name:     "My Webhook",
        IsActive: true,
    },
    WebhookDetails: notification.WebhookDetails{
        WebhookURL:         "https://example.com/webhook",
        WebhookContentType: "json",
    },
}

id, err := client.CreateNotification(ctx, webhook)

// Create a webhook with custom body and headers
webhookCustom := notification.Webhook{
    Base: notification.Base{
        Name:     "Custom Webhook",
        IsActive: true,
    },
    WebhookDetails: notification.WebhookDetails{
        WebhookURL:         "https://api.example.com/alerts",
        WebhookContentType: "custom",
        WebhookCustomBody:  `{"title": "Alert - {{ monitorJSON['name'] }}", "message": "{{ msg }}"}`,
        WebhookAdditionalHeaders: notification.WebhookAdditionalHeaders{
            "Authorization": "Bearer secret-token",
            "X-App-ID":      "uptime-kuma",
        },
    },
}

id, err := client.CreateNotification(ctx, webhookCustom)
```

## Files Changed

- `notification/notification_webhook.go`: Core implementation
- `notification/notification_webhook_test.go`: Unit tests
- `notification_test.go`: Integration tests

## Test Results

All tests pass:
- Unit tests: ✅ All webhook tests passing
- Integration tests: ✅ CRUD operations verified
- Linter: ✅ No issues

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)