### PR TITLE
Add remote_browser field to RealBrowser monitor

### DIFF
--- a/monitor/monitor_real_browser.go
+++ b/monitor/monitor_real_browser.go
@@ -70,6 +70,7 @@ func (r RealBrowser) MarshalJSON() ([]byte, error) {
 	raw["maxredirects"] = r.MaxRedirects
 	raw["accepted_statuscodes"] = r.AcceptedStatusCodes
 	raw["proxyId"] = r.ProxyID
+	raw["remote_browser"] = r.RemoteBrowser
 
 	// Uptime Kuma v2 requires conditions field (empty array by default)
 	raw["conditions"] = []any{}
@@ -83,6 +84,7 @@ type RealBrowserDetails struct {
 	IgnoreTLS           bool     `json:"ignoreTls"`
 	MaxRedirects        int      `json:"maxredirects"`
 	AcceptedStatusCodes []string `json:"accepted_statuscodes"`
+	RemoteBrowser       *int64   `json:"remote_browser,omitempty"`
 }
 
 func (r RealBrowserDetails) Type() string {

--- a/monitor/monitor_real_browser_test.go
+++ b/monitor/monitor_real_browser_test.go
@@ -47,7 +47,7 @@ func TestMonitorRealBrowser_Unmarshal(t *testing.T) {
 					AcceptedStatusCodes: []string{"200-299"},
 				},
 			},
-			wantJSON: `{"accepted_statuscodes":["200-299"],"active":true,"conditions":[],"description":null,"id":2,"ignoreTls":false,"interval":60,"maxredirects":10,"maxretries":2,"name":"example.com","notificationIDList":{"1":true},"parent":1,"proxyId":null,"resendInterval":0,"retryInterval":60,"timeout":48,"type":"real-browser","upsideDown":false,"url":"https://www.example.com"}`,
+			wantJSON: `{"accepted_statuscodes":["200-299"],"active":true,"conditions":[],"description":null,"id":2,"ignoreTls":false,"interval":60,"maxredirects":10,"maxretries":2,"name":"example.com","notificationIDList":{"1":true},"parent":1,"proxyId":null,"remote_browser":null,"resendInterval":0,"retryInterval":60,"timeout":48,"type":"real-browser","upsideDown":false,"url":"https://www.example.com"}`,
 		},
 	}
 


### PR DESCRIPTION
Add support for remote_browser field in the RealBrowser monitor type. This field allows specifying a remote browser instance to use for monitoring instead of a local browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)