### PR TITLE
feat: add support for PagerDuty notifications

### DIFF
--- a/notification/notification_base.go
+++ b/notification/notification_base.go
@@ -91,7 +91,6 @@ func (b Base) MarshalJSON() ([]byte, error) {
 	}
 
 	genericDetails := GenericDetails{}
-	fmt.Println(b.configStr)
 	err := json.Unmarshal([]byte(b.configStr), &genericDetails)
 	if err != nil {
 		return nil, fmt.Errorf("invalid internal state for configStr, failed to unmarshal: %w", err)

--- a/notification/notification_pagerduty.go
+++ b/notification/notification_pagerduty.go
@@ -1,0 +1,48 @@
+package notification
+
+import (
+	"fmt"
+)
+
+type PagerDuty struct {
+	Base
+	PagerDutyDetails
+}
+
+type PagerDutyDetails struct {
+	IntegrationURL string `json:"pagerdutyIntegrationUrl"`
+	IntegrationKey string `json:"pagerdutyIntegrationKey"`
+	Priority       string `json:"pagerdutyPriority"`
+	AutoResolve    string `json:"pagerdutyAutoResolve"`
+}
+
+func (p PagerDuty) Type() string {
+	return p.PagerDutyDetails.Type()
+}
+
+func (n PagerDutyDetails) Type() string {
+	return "PagerDuty"
+}
+
+func (p PagerDuty) String() string {
+	return fmt.Sprintf("%s, %s", formatNotification(p.Base, false), formatNotification(p.PagerDutyDetails, true))
+}
+
+func (p *PagerDuty) UnmarshalJSON(data []byte) error {
+	detail := PagerDutyDetails{}
+	base, err := unmarshalTo(data, &detail)
+	if err != nil {
+		return err
+	}
+
+	*p = PagerDuty{
+		Base:               base,
+		PagerDutyDetails: detail,
+	}
+
+	return nil
+}
+
+func (p PagerDuty) MarshalJSON() ([]byte, error) {
+	return marshalJSON(p.Base, p.PagerDutyDetails)
+}

--- a/notification/notification_pagerduty_test.go
+++ b/notification/notification_pagerduty_test.go
@@ -1,0 +1,78 @@
+package notification_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/breml/go-uptime-kuma-client/notification"
+)
+
+func TestNotificationPagerDuty_Unmarshal(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+
+		want     notification.PagerDuty
+		wantJSON string
+	}{
+		{
+			name: "success",
+			data: []byte(`{"id":1,"name":"My PagerDuty Alert","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"My PagerDuty Alert\",\"pagerdutyIntegrationUrl\":\"https://events.pagerduty.com/v2/enqueue\",\"pagerdutyIntegrationKey\":\"test-integration-key-123\",\"pagerdutyPriority\":\"warning\",\"pagerdutyAutoResolve\":\"resolve\",\"type\":\"PagerDuty\"}"}`),
+
+			want: notification.PagerDuty{
+				Base: notification.Base{
+					ID:            1,
+					Name:          "My PagerDuty Alert",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     true,
+					ApplyExisting: true,
+				},
+				PagerDutyDetails: notification.PagerDutyDetails{
+					IntegrationURL: "https://events.pagerduty.com/v2/enqueue",
+					IntegrationKey: "test-integration-key-123",
+					Priority:       "warning",
+					AutoResolve:    "resolve",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":true,"id":1,"isDefault":true,"name":"My PagerDuty Alert","pagerdutyIntegrationUrl":"https://events.pagerduty.com/v2/enqueue","pagerdutyIntegrationKey":"test-integration-key-123","pagerdutyPriority":"warning","pagerdutyAutoResolve":"resolve","type":"PagerDuty","userId":1}`,
+		},
+		{
+			name: "minimal",
+			data: []byte(`{"id":2,"name":"Simple PagerDuty","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Simple PagerDuty\",\"pagerdutyIntegrationKey\":\"abc-123\",\"type\":\"PagerDuty\"}"}`),
+
+			want: notification.PagerDuty{
+				Base: notification.Base{
+					ID:            2,
+					Name:          "Simple PagerDuty",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				PagerDutyDetails: notification.PagerDutyDetails{
+					IntegrationKey: "abc-123",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"id":2,"isDefault":false,"name":"Simple PagerDuty","pagerdutyIntegrationUrl":"","pagerdutyIntegrationKey":"abc-123","pagerdutyPriority":"","pagerdutyAutoResolve":"","type":"PagerDuty","userId":1}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pagerduty := notification.PagerDuty{}
+
+			err := json.Unmarshal(tc.data, &pagerduty)
+			require.NoError(t, err)
+
+			require.EqualExportedValues(t, tc.want, pagerduty)
+
+			data, err := json.Marshal(pagerduty)
+			require.NoError(t, err)
+
+			require.JSONEq(t, tc.wantJSON, string(data))
+		})
+	}
+}


### PR DESCRIPTION
Add support for PagerDuty notification provider to match Uptime Kuma server functionality.

## Changes
- Create notification_pagerduty.go with PagerDuty notification type
- Implement PagerDuty struct with fields:
  - IntegrationURL: PagerDuty integration URL
  - IntegrationKey: PagerDuty integration key
  - Priority: Alert priority (e.g., warning, critical)
  - AutoResolve: Auto-resolve setting (e.g., resolve, null)
- Add comprehensive unit tests in notification_pagerduty_test.go
- Add CRUD integration tests to notification_test.go
- Remove debug print statement from notification_base.go

## Testing
- Unit tests pass
- Integration/CRUD tests pass
- Code passes task lint
- Code passes task test-e2e

Closes #33