### PR TITLE
feat: add support for Opsgenie notifications

### DIFF
--- a/notification/notification_opsgenie.go
+++ b/notification/notification_opsgenie.go
@@ -1,0 +1,47 @@
+package notification
+
+import (
+	"fmt"
+)
+
+type Opsgenie struct {
+	Base
+	OpsgenieDetails
+}
+
+type OpsgenieDetails struct {
+	ApiKey   string `json:"opsgenieApiKey"`
+	Region   string `json:"opsgenieRegion"`
+	Priority int    `json:"opsgeniePriority"`
+}
+
+func (o Opsgenie) Type() string {
+	return o.OpsgenieDetails.Type()
+}
+
+func (n OpsgenieDetails) Type() string {
+	return "Opsgenie"
+}
+
+func (o Opsgenie) String() string {
+	return fmt.Sprintf("%s, %s", formatNotification(o.Base, false), formatNotification(o.OpsgenieDetails, true))
+}
+
+func (o *Opsgenie) UnmarshalJSON(data []byte) error {
+	detail := OpsgenieDetails{}
+	base, err := unmarshalTo(data, &detail)
+	if err != nil {
+		return err
+	}
+
+	*o = Opsgenie{
+		Base:             base,
+		OpsgenieDetails: detail,
+	}
+
+	return nil
+}
+
+func (o Opsgenie) MarshalJSON() ([]byte, error) {
+	return marshalJSON(o.Base, o.OpsgenieDetails)
+}

--- a/notification/notification_opsgenie_test.go
+++ b/notification/notification_opsgenie_test.go
@@ -1,0 +1,98 @@
+package notification_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/breml/go-uptime-kuma-client/notification"
+)
+
+func TestNotificationOpsgenie_Unmarshal(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+
+		want     notification.Opsgenie
+		wantJSON string
+	}{
+		{
+			name: "success",
+			data: []byte(`{"id":1,"name":"My Opsgenie Alert","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"My Opsgenie Alert\",\"opsgenieApiKey\":\"test-api-key-123\",\"opsgenieRegion\":\"us\",\"opsgeniePriority\":3,\"type\":\"Opsgenie\"}"}`),
+
+			want: notification.Opsgenie{
+				Base: notification.Base{
+					ID:            1,
+					Name:          "My Opsgenie Alert",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     true,
+					ApplyExisting: true,
+				},
+				OpsgenieDetails: notification.OpsgenieDetails{
+					ApiKey:   "test-api-key-123",
+					Region:   "us",
+					Priority: 3,
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":true,"id":1,"isDefault":true,"name":"My Opsgenie Alert","opsgenieApiKey":"test-api-key-123","opsgenieRegion":"us","opsgeniePriority":3,"type":"Opsgenie","userId":1}`,
+		},
+		{
+			name: "minimal",
+			data: []byte(`{"id":2,"name":"Simple Opsgenie","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Simple Opsgenie\",\"opsgenieApiKey\":\"abc-123\",\"type\":\"Opsgenie\"}"}`),
+
+			want: notification.Opsgenie{
+				Base: notification.Base{
+					ID:            2,
+					Name:          "Simple Opsgenie",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				OpsgenieDetails: notification.OpsgenieDetails{
+					ApiKey: "abc-123",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"id":2,"isDefault":false,"name":"Simple Opsgenie","opsgenieApiKey":"abc-123","opsgenieRegion":"","opsgeniePriority":0,"type":"Opsgenie","userId":1}`,
+		},
+		{
+			name: "with eu region",
+			data: []byte(`{"id":3,"name":"EU Opsgenie","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"EU Opsgenie\",\"opsgenieApiKey\":\"eu-api-key\",\"opsgenieRegion\":\"eu\",\"opsgeniePriority\":5,\"type\":\"Opsgenie\"}"}`),
+
+			want: notification.Opsgenie{
+				Base: notification.Base{
+					ID:            3,
+					Name:          "EU Opsgenie",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				OpsgenieDetails: notification.OpsgenieDetails{
+					ApiKey:   "eu-api-key",
+					Region:   "eu",
+					Priority: 5,
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"id":3,"isDefault":false,"name":"EU Opsgenie","opsgenieApiKey":"eu-api-key","opsgenieRegion":"eu","opsgeniePriority":5,"type":"Opsgenie","userId":1}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			opsgenie := notification.Opsgenie{}
+
+			err := json.Unmarshal(tc.data, &opsgenie)
+			require.NoError(t, err)
+
+			require.EqualExportedValues(t, tc.want, opsgenie)
+
+			data, err := json.Marshal(opsgenie)
+			require.NoError(t, err)
+
+			require.JSONEq(t, tc.wantJSON, string(data))
+		})
+	}
+}

--- a/notification_test.go
+++ b/notification_test.go
@@ -785,3 +785,98 @@ func TestPagerDutyNotificationCRUD(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+func TestOpsgenieNotificationCRUD(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	var err error
+
+	createNotification := notification.Opsgenie{
+		Base: notification.Base{
+			ApplyExisting: true,
+			IsDefault:     false,
+			IsActive:      true,
+			Name:          "Test Opsgenie Created",
+		},
+		OpsgenieDetails: notification.OpsgenieDetails{
+			ApiKey:   "test-api-key-123",
+			Region:   "us",
+			Priority: 3,
+		},
+	}
+
+	t.Run("initial_state", func(t *testing.T) {
+		notifications := client.GetNotifications(ctx)
+		t.Logf("Initial notifications count: %d", len(notifications))
+	})
+
+	var id int64
+	t.Run("create", func(t *testing.T) {
+		initialNotifications := client.GetNotifications(ctx)
+		initialCount := len(initialNotifications)
+
+		id, err = client.CreateNotification(ctx, createNotification)
+		require.NoError(t, err)
+		require.Greater(t, id, int64(0))
+
+		notifications := client.GetNotifications(ctx)
+		require.Len(t, notifications, initialCount+1)
+
+		createdNotification, err := client.GetNotification(ctx, id)
+		require.NoError(t, err)
+		require.Equal(t, "Opsgenie", createdNotification.Type())
+		require.Equal(t, id, createdNotification.GetID())
+
+		specificNotification := notification.Opsgenie{}
+		err = createdNotification.As(&specificNotification)
+		require.NoError(t, err)
+
+		expectedOpsgenie := createNotification
+		expectedOpsgenie.ID = id
+		expectedOpsgenie.UserID = specificNotification.UserID
+		require.EqualExportedValues(t, expectedOpsgenie, specificNotification)
+	})
+
+	t.Run("update", func(t *testing.T) {
+		currentNotification, err := client.GetNotification(ctx, id)
+		require.NoError(t, err)
+
+		current := notification.Opsgenie{}
+		err = currentNotification.As(&current)
+		require.NoError(t, err)
+
+		current.Name = "Test Opsgenie Updated"
+		current.Region = "eu"
+		current.Priority = 5
+
+		err = client.UpdateNotification(ctx, current)
+		require.NoError(t, err)
+
+		retrievedNotification, err := client.GetNotification(ctx, id)
+		require.NoError(t, err)
+
+		retrieved := notification.Opsgenie{}
+		err = retrievedNotification.As(&retrieved)
+		require.NoError(t, err)
+		require.EqualExportedValues(t, current, retrieved)
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		preDeleteNotifications := client.GetNotifications(ctx)
+		preDeleteCount := len(preDeleteNotifications)
+
+		err := client.DeleteNotification(ctx, id)
+		require.NoError(t, err)
+
+		notifications := client.GetNotifications(ctx)
+		require.Len(t, notifications, preDeleteCount-1)
+
+		_, err = client.GetNotification(ctx, id)
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
Add support for Opsgenie notification provider to match Uptime Kuma server functionality.

## Changes
- Create notification_opsgenie.go with Opsgenie notification type
- Implement Opsgenie struct with fields:
  - ApiKey: Opsgenie API key
  - Region: Region setting (us or eu, defaults to us)
  - Priority: Alert priority (1-5, default: 3)
- Add comprehensive unit tests in notification_opsgenie_test.go
- Add CRUD integration tests to notification_test.go

## Testing
- Unit tests pass
- Integration/CRUD tests pass
- Code passes task lint
- Code passes task test-e2e

Closes #34