### PR TITLE
feat: add support for Signal notifications

### DIFF
--- a/notification/notification_signal.go
+++ b/notification/notification_signal.go
@@ -1,0 +1,47 @@
+package notification
+
+import (
+	"fmt"
+)
+
+type Signal struct {
+	Base
+	SignalDetails
+}
+
+type SignalDetails struct {
+	URL        string `json:"signalURL"`
+	Number     string `json:"signalNumber"`
+	Recipients string `json:"signalRecipients"`
+}
+
+func (s Signal) Type() string {
+	return s.SignalDetails.Type()
+}
+
+func (n SignalDetails) Type() string {
+	return "signal"
+}
+
+func (s Signal) String() string {
+	return fmt.Sprintf("%s, %s", formatNotification(s.Base, false), formatNotification(s.SignalDetails, true))
+}
+
+func (s *Signal) UnmarshalJSON(data []byte) error {
+	detail := SignalDetails{}
+	base, err := unmarshalTo(data, &detail)
+	if err != nil {
+		return err
+	}
+
+	*s = Signal{
+		Base:          base,
+		SignalDetails: detail,
+	}
+
+	return nil
+}
+
+func (s Signal) MarshalJSON() ([]byte, error) {
+	return marshalJSON(s.Base, s.SignalDetails)
+}

--- a/notification/notification_signal_test.go
+++ b/notification/notification_signal_test.go
@@ -1,0 +1,99 @@
+package notification_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/breml/go-uptime-kuma-client/notification"
+)
+
+func TestNotificationSignal_Unmarshal(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+
+		want     notification.Signal
+		wantJSON string
+	}{
+		{
+			name: "success",
+			data: []byte(`{"id":1,"name":"My Signal Alert","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"My Signal Alert\",\"signalURL\":\"http://localhost:9998\",\"signalNumber\":\"+1234567890\",\"signalRecipients\":\"+9876543210,+1112223333\",\"type\":\"signal\"}"}`),
+
+			want: notification.Signal{
+				Base: notification.Base{
+					ID:            1,
+					Name:          "My Signal Alert",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     true,
+					ApplyExisting: true,
+				},
+				SignalDetails: notification.SignalDetails{
+					URL:        "http://localhost:9998",
+					Number:     "+1234567890",
+					Recipients: "+9876543210,+1112223333",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":true,"id":1,"isDefault":true,"name":"My Signal Alert","signalURL":"http://localhost:9998","signalNumber":"+1234567890","signalRecipients":"+9876543210,+1112223333","type":"signal","userId":1}`,
+		},
+		{
+			name: "minimal",
+			data: []byte(`{"id":2,"name":"Simple Signal","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Simple Signal\",\"signalNumber\":\"+1234567890\",\"signalRecipients\":\"+9999999999\",\"type\":\"signal\"}"}`),
+
+			want: notification.Signal{
+				Base: notification.Base{
+					ID:            2,
+					Name:          "Simple Signal",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				SignalDetails: notification.SignalDetails{
+					Number:     "+1234567890",
+					Recipients: "+9999999999",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"id":2,"isDefault":false,"name":"Simple Signal","signalURL":"","signalNumber":"+1234567890","signalRecipients":"+9999999999","type":"signal","userId":1}`,
+		},
+		{
+			name: "multiple recipients",
+			data: []byte(`{"id":3,"name":"Signal Multi","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Signal Multi\",\"signalURL\":\"http://signal-api:9998\",\"signalNumber\":\"+5555555555\",\"signalRecipients\":\"+1111111111,+2222222222,+3333333333\",\"type\":\"signal\"}"}`),
+
+			want: notification.Signal{
+				Base: notification.Base{
+					ID:            3,
+					Name:          "Signal Multi",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				SignalDetails: notification.SignalDetails{
+					URL:        "http://signal-api:9998",
+					Number:     "+5555555555",
+					Recipients: "+1111111111,+2222222222,+3333333333",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"id":3,"isDefault":false,"name":"Signal Multi","signalURL":"http://signal-api:9998","signalNumber":"+5555555555","signalRecipients":"+1111111111,+2222222222,+3333333333","type":"signal","userId":1}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			signal := notification.Signal{}
+
+			err := json.Unmarshal(tc.data, &signal)
+			require.NoError(t, err)
+
+			require.EqualExportedValues(t, tc.want, signal)
+
+			data, err := json.Marshal(signal)
+			require.NoError(t, err)
+
+			require.JSONEq(t, tc.wantJSON, string(data))
+		})
+	}
+}

--- a/notification_test.go
+++ b/notification_test.go
@@ -786,6 +786,101 @@ func TestPagerDutyNotificationCRUD(t *testing.T) {
 	})
 }
 
+func TestSignalNotificationCRUD(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	var err error
+
+	createNotification := notification.Signal{
+		Base: notification.Base{
+			ApplyExisting: true,
+			IsDefault:     false,
+			IsActive:      true,
+			Name:          "Test Signal Created",
+		},
+		SignalDetails: notification.SignalDetails{
+			URL:        "http://localhost:9998",
+			Number:     "+1234567890",
+			Recipients: "+9876543210,+1112223333",
+		},
+	}
+
+	t.Run("initial_state", func(t *testing.T) {
+		notifications := client.GetNotifications(ctx)
+		t.Logf("Initial notifications count: %d", len(notifications))
+	})
+
+	var id int64
+	t.Run("create", func(t *testing.T) {
+		initialNotifications := client.GetNotifications(ctx)
+		initialCount := len(initialNotifications)
+
+		id, err = client.CreateNotification(ctx, createNotification)
+		require.NoError(t, err)
+		require.Greater(t, id, int64(0))
+
+		notifications := client.GetNotifications(ctx)
+		require.Len(t, notifications, initialCount+1)
+
+		createdNotification, err := client.GetNotification(ctx, id)
+		require.NoError(t, err)
+		require.Equal(t, "signal", createdNotification.Type())
+		require.Equal(t, id, createdNotification.GetID())
+
+		specificNotification := notification.Signal{}
+		err = createdNotification.As(&specificNotification)
+		require.NoError(t, err)
+
+		expectedSignal := createNotification
+		expectedSignal.ID = id
+		expectedSignal.UserID = specificNotification.UserID
+		require.EqualExportedValues(t, expectedSignal, specificNotification)
+	})
+
+	t.Run("update", func(t *testing.T) {
+		currentNotification, err := client.GetNotification(ctx, id)
+		require.NoError(t, err)
+
+		current := notification.Signal{}
+		err = currentNotification.As(&current)
+		require.NoError(t, err)
+
+		current.Name = "Test Signal Updated"
+		current.URL = "http://signal-api:9998"
+		current.Recipients = "+1111111111,+2222222222"
+
+		err = client.UpdateNotification(ctx, current)
+		require.NoError(t, err)
+
+		retrievedNotification, err := client.GetNotification(ctx, id)
+		require.NoError(t, err)
+
+		retrieved := notification.Signal{}
+		err = retrievedNotification.As(&retrieved)
+		require.NoError(t, err)
+		require.EqualExportedValues(t, current, retrieved)
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		preDeleteNotifications := client.GetNotifications(ctx)
+		preDeleteCount := len(preDeleteNotifications)
+
+		err := client.DeleteNotification(ctx, id)
+		require.NoError(t, err)
+
+		notifications := client.GetNotifications(ctx)
+		require.Len(t, notifications, preDeleteCount-1)
+
+		_, err = client.GetNotification(ctx, id)
+		require.Error(t, err)
+	})
+}
+
 func TestOpsgenieNotificationCRUD(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")


### PR DESCRIPTION
Add support for Signal notification provider to match Uptime Kuma server functionality.

## Changes
- Create notification_signal.go with Signal notification type
- Implement Signal struct with fields:
  - URL: Signal API URL
  - Number: Signal number
  - Recipients: Comma-separated list of recipients
- Add comprehensive unit tests in notification_signal_test.go covering:
  - Full configuration with all fields
  - Minimal configuration
  - Multiple recipients
- Add CRUD integration tests to notification_test.go

## Testing
- Unit tests pass
- Integration/CRUD tests pass
- Code passes task lint
- Code passes task test-e2e

Closes #41