### PR TITLE
feat(#42): Add support for Apprise notifications

### DIFF
--- a/notification/notification_apprise.go
+++ b/notification/notification_apprise.go
@@ -1,0 +1,54 @@
+package notification
+
+import (
+	"fmt"
+)
+
+// Apprise represents an Apprise notification provider.
+// Apprise is a versatile notification library that supports many notification services.
+type Apprise struct {
+	Base
+	AppriseDetails
+}
+
+// AppriseDetails contains the Apprise-specific configuration.
+type AppriseDetails struct {
+	AppriseURL string `json:"appriseURL"`
+	Title      string `json:"title"`
+}
+
+// Type returns the notification type identifier for Apprise.
+func (a Apprise) Type() string {
+	return a.AppriseDetails.Type()
+}
+
+// Type returns the notification type identifier for Apprise details.
+func (d AppriseDetails) Type() string {
+	return "apprise"
+}
+
+// String returns a human-readable representation of the Apprise notification.
+func (a Apprise) String() string {
+	return fmt.Sprintf("%s, %s", formatNotification(a.Base, false), formatNotification(a.AppriseDetails, true))
+}
+
+// UnmarshalJSON deserializes an Apprise notification from JSON.
+func (a *Apprise) UnmarshalJSON(data []byte) error {
+	detail := AppriseDetails{}
+	base, err := unmarshalTo(data, &detail)
+	if err != nil {
+		return err
+	}
+
+	*a = Apprise{
+		Base:           base,
+		AppriseDetails: detail,
+	}
+
+	return nil
+}
+
+// MarshalJSON serializes an Apprise notification to JSON.
+func (a Apprise) MarshalJSON() ([]byte, error) {
+	return marshalJSON(a.Base, a.AppriseDetails)
+}

--- a/notification/notification_apprise_test.go
+++ b/notification/notification_apprise_test.go
@@ -1,0 +1,77 @@
+package notification_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/breml/go-uptime-kuma-client/notification"
+)
+
+func TestNotificationApprise_Unmarshal(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+
+		want     notification.Apprise
+		wantJSON string
+	}{
+		{
+			name: "success",
+			data: []byte(`{"id":1,"name":"My Apprise Alert","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"My Apprise Alert\",\"appriseURL\":\"json://localhost:8080\",\"title\":\"Uptime Kuma Alert\",\"type\":\"apprise\"}"}`),
+
+			want: notification.Apprise{
+				Base: notification.Base{
+					ID:            1,
+					Name:          "My Apprise Alert",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     true,
+					ApplyExisting: true,
+				},
+				AppriseDetails: notification.AppriseDetails{
+					AppriseURL: "json://localhost:8080",
+					Title:      "Uptime Kuma Alert",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":true,"appriseURL":"json://localhost:8080","id":1,"isDefault":true,"name":"My Apprise Alert","title":"Uptime Kuma Alert","type":"apprise","userId":1}`,
+		},
+		{
+			name: "minimal",
+			data: []byte(`{"id":2,"name":"Simple Apprise","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Simple Apprise\",\"appriseURL\":\"json://localhost:8080\",\"type\":\"apprise\"}"}`),
+
+			want: notification.Apprise{
+				Base: notification.Base{
+					ID:            2,
+					Name:          "Simple Apprise",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				AppriseDetails: notification.AppriseDetails{
+					AppriseURL: "json://localhost:8080",
+					Title:      "",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"appriseURL":"json://localhost:8080","id":2,"isDefault":false,"name":"Simple Apprise","title":"","type":"apprise","userId":1}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			apprise := notification.Apprise{}
+
+			err := json.Unmarshal(tc.data, &apprise)
+			require.NoError(t, err)
+
+			require.EqualExportedValues(t, tc.want, apprise)
+
+			data, err := json.Marshal(apprise)
+			require.NoError(t, err)
+
+			require.JSONEq(t, tc.wantJSON, string(data))
+		})
+	}
+}


### PR DESCRIPTION
## Description

Add support for Apprise notification provider to match Uptime Kuma server functionality.

## Implementation

- Created \`notification/notification_apprise.go\` with Apprise struct and AppriseDetails
- Implemented required methods: Type(), String(), UnmarshalJSON(), MarshalJSON()
- Added comprehensive unit tests in \`notification/notification_apprise_test.go\`
- Added CRUD integration test in \`notification_test.go\`

## Configuration Fields

Maps the following fields from Uptime Kuma:
- \`appriseURL\`: Apprise URL(s) - can be one or multiple URLs
- \`title\`: Notification title (optional)

## Testing

- All unit tests pass
- All integration tests pass
- Code formatted with gofumpt
- Passes golangci-lint

## Closes

Closes #42