### PR TITLE
feat(#43): Add support for Google Chat notifications

### DIFF
--- a/notification/notification_googlechat.go
+++ b/notification/notification_googlechat.go
@@ -1,0 +1,55 @@
+package notification
+
+import (
+	"fmt"
+)
+
+// GoogleChat represents a Google Chat notification provider.
+// Google Chat is a messaging platform that supports webhooks for notifications.
+type GoogleChat struct {
+	Base
+	GoogleChatDetails
+}
+
+// GoogleChatDetails contains the Google Chat-specific configuration.
+type GoogleChatDetails struct {
+	WebhookURL  string `json:"googleChatWebhookURL"`
+	UseTemplate bool   `json:"googleChatUseTemplate"`
+	Template    string `json:"googleChatTemplate"`
+}
+
+// Type returns the notification type identifier for Google Chat.
+func (g GoogleChat) Type() string {
+	return g.GoogleChatDetails.Type()
+}
+
+// Type returns the notification type identifier for Google Chat details.
+func (d GoogleChatDetails) Type() string {
+	return "GoogleChat"
+}
+
+// String returns a human-readable representation of the Google Chat notification.
+func (g GoogleChat) String() string {
+	return fmt.Sprintf("%s, %s", formatNotification(g.Base, false), formatNotification(g.GoogleChatDetails, true))
+}
+
+// UnmarshalJSON deserializes a Google Chat notification from JSON.
+func (g *GoogleChat) UnmarshalJSON(data []byte) error {
+	detail := GoogleChatDetails{}
+	base, err := unmarshalTo(data, &detail)
+	if err != nil {
+		return err
+	}
+
+	*g = GoogleChat{
+		Base:              base,
+		GoogleChatDetails: detail,
+	}
+
+	return nil
+}
+
+// MarshalJSON serializes a Google Chat notification to JSON.
+func (g GoogleChat) MarshalJSON() ([]byte, error) {
+	return marshalJSON(g.Base, g.GoogleChatDetails)
+}

--- a/notification/notification_googlechat_test.go
+++ b/notification/notification_googlechat_test.go
@@ -1,0 +1,79 @@
+package notification_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/breml/go-uptime-kuma-client/notification"
+)
+
+func TestNotificationGoogleChat_Unmarshal(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+
+		want     notification.GoogleChat
+		wantJSON string
+	}{
+		{
+			name: "success",
+			data: []byte(`{"id":1,"name":"My Google Chat Alert","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"My Google Chat Alert\",\"googleChatWebhookURL\":\"https://chat.googleapis.com/v1/spaces/AAAAAA/messages?key=test\",\"googleChatUseTemplate\":true,\"googleChatTemplate\":\"Test Template\",\"type\":\"GoogleChat\"}"}`),
+
+			want: notification.GoogleChat{
+				Base: notification.Base{
+					ID:            1,
+					Name:          "My Google Chat Alert",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     true,
+					ApplyExisting: true,
+				},
+				GoogleChatDetails: notification.GoogleChatDetails{
+					WebhookURL:  "https://chat.googleapis.com/v1/spaces/AAAAAA/messages?key=test",
+					UseTemplate: true,
+					Template:    "Test Template",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":true,"googleChatTemplate":"Test Template","googleChatUseTemplate":true,"googleChatWebhookURL":"https://chat.googleapis.com/v1/spaces/AAAAAA/messages?key=test","id":1,"isDefault":true,"name":"My Google Chat Alert","type":"GoogleChat","userId":1}`,
+		},
+		{
+			name: "minimal",
+			data: []byte(`{"id":2,"name":"Simple Google Chat","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Simple Google Chat\",\"googleChatWebhookURL\":\"https://chat.googleapis.com/v1/spaces/AAAAAA/messages?key=test\",\"googleChatUseTemplate\":false,\"googleChatTemplate\":\"\",\"type\":\"GoogleChat\"}"}`),
+
+			want: notification.GoogleChat{
+				Base: notification.Base{
+					ID:            2,
+					Name:          "Simple Google Chat",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				GoogleChatDetails: notification.GoogleChatDetails{
+					WebhookURL:  "https://chat.googleapis.com/v1/spaces/AAAAAA/messages?key=test",
+					UseTemplate: false,
+					Template:    "",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"googleChatTemplate":"","googleChatUseTemplate":false,"googleChatWebhookURL":"https://chat.googleapis.com/v1/spaces/AAAAAA/messages?key=test","id":2,"isDefault":false,"name":"Simple Google Chat","type":"GoogleChat","userId":1}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			googlechat := notification.GoogleChat{}
+
+			err := json.Unmarshal(tc.data, &googlechat)
+			require.NoError(t, err)
+
+			require.EqualExportedValues(t, tc.want, googlechat)
+
+			data, err := json.Marshal(googlechat)
+			require.NoError(t, err)
+
+			require.JSONEq(t, tc.wantJSON, string(data))
+		})
+	}
+}

--- a/notification_test.go
+++ b/notification_test.go
@@ -2028,3 +2028,98 @@ func TestAppriseNotificationCRUD(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+func TestGoogleChatNotificationCRUD(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	var err error
+
+	createNotification := notification.GoogleChat{
+		Base: notification.Base{
+			ApplyExisting: true,
+			IsDefault:     false,
+			IsActive:      true,
+			Name:          "Test Google Chat Created",
+		},
+		GoogleChatDetails: notification.GoogleChatDetails{
+			WebhookURL:  "https://chat.googleapis.com/v1/spaces/AAAAAA/messages?key=test",
+			UseTemplate: false,
+			Template:    "",
+		},
+	}
+
+	t.Run("initial_state", func(t *testing.T) {
+		notifications := client.GetNotifications(ctx)
+		t.Logf("Initial notifications count: %d", len(notifications))
+	})
+
+	var id int64
+	t.Run("create", func(t *testing.T) {
+		initialNotifications := client.GetNotifications(ctx)
+		initialCount := len(initialNotifications)
+
+		id, err = client.CreateNotification(ctx, createNotification)
+		require.NoError(t, err)
+		require.Greater(t, id, int64(0))
+
+		notifications := client.GetNotifications(ctx)
+		require.Len(t, notifications, initialCount+1)
+
+		createdNotification, err := client.GetNotification(ctx, id)
+		require.NoError(t, err)
+		require.Equal(t, "GoogleChat", createdNotification.Type())
+		require.Equal(t, id, createdNotification.GetID())
+
+		specificNotification := notification.GoogleChat{}
+		err = createdNotification.As(&specificNotification)
+		require.NoError(t, err)
+
+		expectedGoogleChat := createNotification
+		expectedGoogleChat.ID = id
+		expectedGoogleChat.UserID = specificNotification.UserID
+		require.EqualExportedValues(t, expectedGoogleChat, specificNotification)
+	})
+
+	t.Run("update", func(t *testing.T) {
+		currentNotification, err := client.GetNotification(ctx, id)
+		require.NoError(t, err)
+
+		current := notification.GoogleChat{}
+		err = currentNotification.As(&current)
+		require.NoError(t, err)
+
+		current.Name = "Test Google Chat Updated"
+		current.UseTemplate = true
+		current.Template = "Updated Template"
+
+		err = client.UpdateNotification(ctx, current)
+		require.NoError(t, err)
+
+		retrievedNotification, err := client.GetNotification(ctx, id)
+		require.NoError(t, err)
+
+		retrieved := notification.GoogleChat{}
+		err = retrievedNotification.As(&retrieved)
+		require.NoError(t, err)
+		require.EqualExportedValues(t, current, retrieved)
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		preDeleteNotifications := client.GetNotifications(ctx)
+		preDeleteCount := len(preDeleteNotifications)
+
+		err := client.DeleteNotification(ctx, id)
+		require.NoError(t, err)
+
+		notifications := client.GetNotifications(ctx)
+		require.Len(t, notifications, preDeleteCount-1)
+
+		_, err = client.GetNotification(ctx, id)
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
## Description

Add support for Google Chat notification provider to match Uptime Kuma server functionality.

## Implementation

- Created \`notification/notification_googlechat.go\` with GoogleChat struct and GoogleChatDetails
- Implemented required methods: Type(), String(), UnmarshalJSON(), MarshalJSON()
- Added comprehensive unit tests in \`notification/notification_googlechat_test.go\`
- Added CRUD integration test in \`notification_test.go\`

## Configuration Fields

Maps the following fields from Uptime Kuma:
- \`googleChatWebhookURL\`: Google Chat webhook URL
- \`googleChatUseTemplate\`: Whether to use custom template
- \`googleChatTemplate\`: Custom message template (optional)

## Testing

- All unit tests pass
- All integration tests pass
- Code formatted with gofumpt
- Passes golangci-lint

## Closes

Closes #43