### PR TITLE
feat(#45): Add support for DingDing notifications

### DIFF
--- a/notification/notification_dingding.go
+++ b/notification/notification_dingding.go
@@ -1,0 +1,55 @@
+package notification
+
+import (
+	"fmt"
+)
+
+// DingDing represents a DingDing (钉钉) notification provider.
+// DingDing is a Chinese enterprise messaging platform that supports webhooks for notifications.
+type DingDing struct {
+	Base
+	DingDingDetails
+}
+
+// DingDingDetails contains the DingDing-specific configuration.
+type DingDingDetails struct {
+	WebHookURL string `json:"webHookUrl"`
+	SecretKey  string `json:"secretKey"`
+	Mentioning string `json:"mentioning"`
+}
+
+// Type returns the notification type identifier for DingDing.
+func (d DingDing) Type() string {
+	return d.DingDingDetails.Type()
+}
+
+// Type returns the notification type identifier for DingDing details.
+func (d DingDingDetails) Type() string {
+	return "DingDing"
+}
+
+// String returns a human-readable representation of the DingDing notification.
+func (d DingDing) String() string {
+	return fmt.Sprintf("%s, %s", formatNotification(d.Base, false), formatNotification(d.DingDingDetails, true))
+}
+
+// UnmarshalJSON deserializes a DingDing notification from JSON.
+func (d *DingDing) UnmarshalJSON(data []byte) error {
+	detail := DingDingDetails{}
+	base, err := unmarshalTo(data, &detail)
+	if err != nil {
+		return err
+	}
+
+	*d = DingDing{
+		Base:            base,
+		DingDingDetails: detail,
+	}
+
+	return nil
+}
+
+// MarshalJSON serializes a DingDing notification to JSON.
+func (d DingDing) MarshalJSON() ([]byte, error) {
+	return marshalJSON(d.Base, d.DingDingDetails)
+}

--- a/notification/notification_dingding_test.go
+++ b/notification/notification_dingding_test.go
@@ -1,0 +1,79 @@
+package notification_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/breml/go-uptime-kuma-client/notification"
+)
+
+func TestNotificationDingDing_Unmarshal(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+
+		want     notification.DingDing
+		wantJSON string
+	}{
+		{
+			name: "success",
+			data: []byte(`{"id":1,"name":"My DingDing Alert","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"My DingDing Alert\",\"webHookUrl\":\"https://oapi.dingtalk.com/robot/send?access_token=xxx\",\"secretKey\":\"secret123\",\"mentioning\":\"everyone\",\"type\":\"DingDing\"}"}`),
+
+			want: notification.DingDing{
+				Base: notification.Base{
+					ID:            1,
+					Name:          "My DingDing Alert",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     true,
+					ApplyExisting: true,
+				},
+				DingDingDetails: notification.DingDingDetails{
+					WebHookURL: "https://oapi.dingtalk.com/robot/send?access_token=xxx",
+					SecretKey:  "secret123",
+					Mentioning: "everyone",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":true,"id":1,"isDefault":true,"mentioning":"everyone","name":"My DingDing Alert","secretKey":"secret123","type":"DingDing","userId":1,"webHookUrl":"https://oapi.dingtalk.com/robot/send?access_token=xxx"}`,
+		},
+		{
+			name: "minimal",
+			data: []byte(`{"id":2,"name":"Simple DingDing","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Simple DingDing\",\"webHookUrl\":\"https://oapi.dingtalk.com/robot/send?access_token=yyy\",\"secretKey\":\"\",\"mentioning\":\"\",\"type\":\"DingDing\"}"}`),
+
+			want: notification.DingDing{
+				Base: notification.Base{
+					ID:            2,
+					Name:          "Simple DingDing",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				DingDingDetails: notification.DingDingDetails{
+					WebHookURL: "https://oapi.dingtalk.com/robot/send?access_token=yyy",
+					SecretKey:  "",
+					Mentioning: "",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"id":2,"isDefault":false,"mentioning":"","name":"Simple DingDing","secretKey":"","type":"DingDing","userId":1,"webHookUrl":"https://oapi.dingtalk.com/robot/send?access_token=yyy"}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dingding := notification.DingDing{}
+
+			err := json.Unmarshal(tc.data, &dingding)
+			require.NoError(t, err)
+
+			require.EqualExportedValues(t, tc.want, dingding)
+
+			data, err := json.Marshal(dingding)
+			require.NoError(t, err)
+
+			require.JSONEq(t, tc.wantJSON, string(data))
+		})
+	}
+}

--- a/notification_test.go
+++ b/notification_test.go
@@ -1936,6 +1936,100 @@ func TestRocketChatNotificationCRUD(t *testing.T) {
 	})
 }
 
+func TestDingDingNotificationCRUD(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	var err error
+
+	createNotification := notification.DingDing{
+		Base: notification.Base{
+			ApplyExisting: true,
+			IsDefault:     false,
+			IsActive:      true,
+			Name:          "Test DingDing Created",
+		},
+		DingDingDetails: notification.DingDingDetails{
+			WebHookURL: "https://oapi.dingtalk.com/robot/send?access_token=xxx",
+			SecretKey:  "secret123",
+			Mentioning: "everyone",
+		},
+	}
+
+	t.Run("initial_state", func(t *testing.T) {
+		notifications := client.GetNotifications(ctx)
+		t.Logf("Initial notifications count: %d", len(notifications))
+	})
+
+	var id int64
+	t.Run("create", func(t *testing.T) {
+		initialNotifications := client.GetNotifications(ctx)
+		initialCount := len(initialNotifications)
+
+		id, err = client.CreateNotification(ctx, createNotification)
+		require.NoError(t, err)
+		require.Greater(t, id, int64(0))
+
+		notifications := client.GetNotifications(ctx)
+		require.Len(t, notifications, initialCount+1)
+
+		createdNotification, err := client.GetNotification(ctx, id)
+		require.NoError(t, err)
+		require.Equal(t, "DingDing", createdNotification.Type())
+		require.Equal(t, id, createdNotification.GetID())
+
+		specificNotification := notification.DingDing{}
+		err = createdNotification.As(&specificNotification)
+		require.NoError(t, err)
+
+		expectedDingDing := createNotification
+		expectedDingDing.ID = id
+		expectedDingDing.UserID = specificNotification.UserID
+		require.EqualExportedValues(t, expectedDingDing, specificNotification)
+	})
+
+	t.Run("update", func(t *testing.T) {
+		currentNotification, err := client.GetNotification(ctx, id)
+		require.NoError(t, err)
+
+		current := notification.DingDing{}
+		err = currentNotification.As(&current)
+		require.NoError(t, err)
+
+		current.Name = "Test DingDing Updated"
+		current.Mentioning = ""
+
+		err = client.UpdateNotification(ctx, current)
+		require.NoError(t, err)
+
+		retrievedNotification, err := client.GetNotification(ctx, id)
+		require.NoError(t, err)
+
+		retrieved := notification.DingDing{}
+		err = retrievedNotification.As(&retrieved)
+		require.NoError(t, err)
+		require.EqualExportedValues(t, current, retrieved)
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		preDeleteNotifications := client.GetNotifications(ctx)
+		preDeleteCount := len(preDeleteNotifications)
+
+		err := client.DeleteNotification(ctx, id)
+		require.NoError(t, err)
+
+		notifications := client.GetNotifications(ctx)
+		require.Len(t, notifications, preDeleteCount-1)
+
+		_, err = client.GetNotification(ctx, id)
+		require.Error(t, err)
+	})
+}
+
 func TestAppriseNotificationCRUD(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")


### PR DESCRIPTION
## Description

Add support for DingDing (钉钉) notification provider to match Uptime Kuma server functionality.

## Implementation

- Created \`notification/notification_dingding.go\` with DingDing struct and DingDingDetails
- Implemented required methods: Type(), String(), UnmarshalJSON(), MarshalJSON()
- Added comprehensive unit tests in \`notification/notification_dingding_test.go\`
- Added CRUD integration test in \`notification_test.go\`

## Configuration Fields

Maps the following fields from Uptime Kuma:
- \`webHookUrl\`: DingDing webhook URL
- \`secretKey\`: Secret key for signing requests
- \`mentioning\`: Mention settings ("everyone" or empty)

## Testing

- All unit tests pass
- All integration tests pass
- Code formatted with gofumpt
- Passes golangci-lint

## Closes

Closes #45