### PR TITLE
Add support for Manual monitor type

### DIFF
--- a/monitor/monitor_manual.go
+++ b/monitor/monitor_manual.go
@@ -1,0 +1,92 @@
+package monitor
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// Manual represents a manual monitor that allows manual control of the status.
+type Manual struct {
+	Base
+	ManualDetails
+}
+
+// Type returns the monitor type string.
+func (m Manual) Type() string {
+	return m.ManualDetails.Type()
+}
+
+// String returns a string representation of the manual monitor.
+func (m Manual) String() string {
+	return fmt.Sprintf("%s, %s", formatMonitor(m.Base, false), formatMonitor(m.ManualDetails, true))
+}
+
+// UnmarshalJSON unmarshals a manual monitor from JSON data.
+func (m *Manual) UnmarshalJSON(data []byte) error {
+	base := Base{}
+	err := json.Unmarshal(data, &base)
+	if err != nil {
+		return err
+	}
+
+	details := ManualDetails{}
+	err = json.Unmarshal(data, &details)
+	if err != nil {
+		return err
+	}
+
+	*m = Manual{
+		Base:          base,
+		ManualDetails: details,
+	}
+
+	return nil
+}
+
+// MarshalJSON marshals a manual monitor to JSON.
+func (m Manual) MarshalJSON() ([]byte, error) {
+	raw := map[string]any{}
+	raw["id"] = m.ID
+	raw["type"] = "manual"
+	raw["name"] = m.Name
+	raw["description"] = m.Description
+	// Don't set pathName, server generates it.
+	// raw["pathName"] = m.PathName
+	raw["parent"] = m.Parent
+	raw["interval"] = m.Interval
+	raw["retryInterval"] = m.RetryInterval
+	raw["resendInterval"] = m.ResendInterval
+	raw["maxretries"] = m.MaxRetries
+	raw["upsideDown"] = m.UpsideDown
+	raw["active"] = m.IsActive
+
+	// Update notification IDs.
+	ids := map[string]bool{}
+	for _, id := range m.NotificationIDs {
+		ids[strconv.FormatInt(id, 10)] = true
+	}
+	raw["notificationIDList"] = ids
+
+	// Always override with current Manual-specific field values.
+	raw["manual_status"] = m.ManualStatus
+
+	// Server expects these fields to be arrays and not null.
+	raw["accepted_statuscodes"] = []string{}
+
+	// Uptime Kuma v2 requires conditions field (empty array by default)
+	raw["conditions"] = []any{}
+
+	return json.Marshal(raw)
+}
+
+// ManualDetails contains manual monitor specific fields.
+type ManualDetails struct {
+	// ManualStatus is the manually set status (0=DOWN, 1=UP, 2=PENDING, null=not set).
+	ManualStatus *int `json:"manual_status"`
+}
+
+// Type returns the monitor type string.
+func (m ManualDetails) Type() string {
+	return "manual"
+}

--- a/monitor/monitor_manual_test.go
+++ b/monitor/monitor_manual_test.go
@@ -1,0 +1,142 @@
+package monitor_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/breml/go-uptime-kuma-client/monitor"
+)
+
+func TestMonitorManual_Unmarshal(t *testing.T) {
+	parent1 := int64(1)
+	statusUp := 1
+	statusDown := 0
+	statusPending := 2
+
+	tests := []struct {
+		name string
+		data []byte
+
+		want     monitor.Manual
+		wantJSON string
+	}{
+		{
+			name: "success with UP status",
+			data: []byte(`{"id":3,"name":"manual-monitor-up","description":null,"pathName":"group / manual-monitor-up","parent":1,"childrenIDs":[],"url":null,"method":"GET","hostname":null,"port":null,"maxretries":0,"weight":2000,"active":true,"forceInactive":false,"type":"manual","timeout":null,"interval":60,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":"A","dns_resolve_server":"1.1.1.1","dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{"1":true,"2":true},"tags":[],"maintenance":false,"mqttTopic":"","mqttSuccessMessage":"","databaseQuery":null,"authMethod":null,"grpcUrl":null,"grpcProtobuf":null,"grpcMethod":null,"grpcServiceName":null,"grpcEnableTls":false,"radiusCalledStationId":null,"radiusCallingStationId":null,"game":null,"gamedigGivenPortOnly":true,"httpBodyEncoding":"json","jsonPath":null,"expectedValue":null,"kafkaProducerTopic":null,"kafkaProducerBrokers":[],"kafkaProducerSsl":false,"kafkaProducerAllowAutoTopicCreation":false,"kafkaProducerMessage":null,"screenshot":null,"headers":null,"body":null,"grpcBody":null,"grpcMetadata":null,"basic_auth_user":null,"basic_auth_pass":null,"oauth_client_id":null,"oauth_client_secret":null,"oauth_token_url":null,"oauth_scopes":null,"oauth_auth_method":"client_secret_basic","manual_status":1,"databaseConnectionString":null,"radiusUsername":null,"radiusPassword":null,"radiusSecret":null,"mqttUsername":"","mqttPassword":"","authWorkstation":null,"authDomain":null,"tlsCa":null,"tlsCert":null,"tlsKey":null,"kafkaProducerSaslOptions":{"mechanism":"None"},"includeSensitiveData":true}`),
+
+			want: monitor.Manual{
+				Base: monitor.Base{
+					ID:              3,
+					Name:            "manual-monitor-up",
+					Description:     nil,
+					PathName:        "group / manual-monitor-up",
+					Parent:          &parent1,
+					Interval:        60,
+					RetryInterval:   60,
+					ResendInterval:  0,
+					MaxRetries:      0,
+					UpsideDown:      false,
+					NotificationIDs: []int64{1, 2},
+					IsActive:        true,
+				},
+				ManualDetails: monitor.ManualDetails{
+					ManualStatus: &statusUp,
+				},
+			},
+			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":null,"id":3,"interval":60,"manual_status":1,"maxretries":0,"name":"manual-monitor-up","notificationIDList":{"1":true,"2":true},"parent":1,"resendInterval":0,"retryInterval":60,"type":"manual","upsideDown":false}`,
+		},
+		{
+			name: "success with DOWN status",
+			data: []byte(`{"id":4,"name":"manual-monitor-down","description":null,"pathName":"manual-monitor-down","parent":null,"childrenIDs":[],"url":null,"method":"GET","hostname":null,"port":null,"maxretries":0,"weight":2000,"active":true,"forceInactive":false,"type":"manual","timeout":null,"interval":60,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":"A","dns_resolve_server":"1.1.1.1","dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{},"tags":[],"maintenance":false,"mqttTopic":"","mqttSuccessMessage":"","databaseQuery":null,"authMethod":null,"grpcUrl":null,"grpcProtobuf":null,"grpcMethod":null,"grpcServiceName":null,"grpcEnableTls":false,"radiusCalledStationId":null,"radiusCallingStationId":null,"game":null,"gamedigGivenPortOnly":true,"httpBodyEncoding":"json","jsonPath":null,"expectedValue":null,"kafkaProducerTopic":null,"kafkaProducerBrokers":[],"kafkaProducerSsl":false,"kafkaProducerAllowAutoTopicCreation":false,"kafkaProducerMessage":null,"screenshot":null,"headers":null,"body":null,"grpcBody":null,"grpcMetadata":null,"basic_auth_user":null,"basic_auth_pass":null,"oauth_client_id":null,"oauth_client_secret":null,"oauth_token_url":null,"oauth_scopes":null,"oauth_auth_method":"client_secret_basic","manual_status":0,"databaseConnectionString":null,"radiusUsername":null,"radiusPassword":null,"radiusSecret":null,"mqttUsername":"","mqttPassword":"","authWorkstation":null,"authDomain":null,"tlsCa":null,"tlsCert":null,"tlsKey":null,"kafkaProducerSaslOptions":{"mechanism":"None"},"includeSensitiveData":true}`),
+
+			want: monitor.Manual{
+				Base: monitor.Base{
+					ID:              4,
+					Name:            "manual-monitor-down",
+					Description:     nil,
+					PathName:        "manual-monitor-down",
+					Parent:          nil,
+					Interval:        60,
+					RetryInterval:   60,
+					ResendInterval:  0,
+					MaxRetries:      0,
+					UpsideDown:      false,
+					NotificationIDs: nil,
+					IsActive:        true,
+				},
+				ManualDetails: monitor.ManualDetails{
+					ManualStatus: &statusDown,
+				},
+			},
+			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":null,"id":4,"interval":60,"manual_status":0,"maxretries":0,"name":"manual-monitor-down","notificationIDList":{},"parent":null,"resendInterval":0,"retryInterval":60,"type":"manual","upsideDown":false}`,
+		},
+		{
+			name: "success with PENDING status",
+			data: []byte(`{"id":5,"name":"manual-monitor-pending","description":null,"pathName":"manual-monitor-pending","parent":null,"childrenIDs":[],"url":null,"method":"GET","hostname":null,"port":null,"maxretries":0,"weight":2000,"active":true,"forceInactive":false,"type":"manual","timeout":null,"interval":60,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":"A","dns_resolve_server":"1.1.1.1","dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{},"tags":[],"maintenance":false,"mqttTopic":"","mqttSuccessMessage":"","databaseQuery":null,"authMethod":null,"grpcUrl":null,"grpcProtobuf":null,"grpcMethod":null,"grpcServiceName":null,"grpcEnableTls":false,"radiusCalledStationId":null,"radiusCallingStationId":null,"game":null,"gamedigGivenPortOnly":true,"httpBodyEncoding":"json","jsonPath":null,"expectedValue":null,"kafkaProducerTopic":null,"kafkaProducerBrokers":[],"kafkaProducerSsl":false,"kafkaProducerAllowAutoTopicCreation":false,"kafkaProducerMessage":null,"screenshot":null,"headers":null,"body":null,"grpcBody":null,"grpcMetadata":null,"basic_auth_user":null,"basic_auth_pass":null,"oauth_client_id":null,"oauth_client_secret":null,"oauth_token_url":null,"oauth_scopes":null,"oauth_auth_method":"client_secret_basic","manual_status":2,"databaseConnectionString":null,"radiusUsername":null,"radiusPassword":null,"radiusSecret":null,"mqttUsername":"","mqttPassword":"","authWorkstation":null,"authDomain":null,"tlsCa":null,"tlsCert":null,"tlsKey":null,"kafkaProducerSaslOptions":{"mechanism":"None"},"includeSensitiveData":true}`),
+
+			want: monitor.Manual{
+				Base: monitor.Base{
+					ID:              5,
+					Name:            "manual-monitor-pending",
+					Description:     nil,
+					PathName:        "manual-monitor-pending",
+					Parent:          nil,
+					Interval:        60,
+					RetryInterval:   60,
+					ResendInterval:  0,
+					MaxRetries:      0,
+					UpsideDown:      false,
+					NotificationIDs: nil,
+					IsActive:        true,
+				},
+				ManualDetails: monitor.ManualDetails{
+					ManualStatus: &statusPending,
+				},
+			},
+			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":null,"id":5,"interval":60,"manual_status":2,"maxretries":0,"name":"manual-monitor-pending","notificationIDList":{},"parent":null,"resendInterval":0,"retryInterval":60,"type":"manual","upsideDown":false}`,
+		},
+		{
+			name: "success with null status",
+			data: []byte(`{"id":6,"name":"manual-monitor-null","description":null,"pathName":"manual-monitor-null","parent":null,"childrenIDs":[],"url":null,"method":"GET","hostname":null,"port":null,"maxretries":0,"weight":2000,"active":true,"forceInactive":false,"type":"manual","timeout":null,"interval":60,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":"A","dns_resolve_server":"1.1.1.1","dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{},"tags":[],"maintenance":false,"mqttTopic":"","mqttSuccessMessage":"","databaseQuery":null,"authMethod":null,"grpcUrl":null,"grpcProtobuf":null,"grpcMethod":null,"grpcServiceName":null,"grpcEnableTls":false,"radiusCalledStationId":null,"radiusCallingStationId":null,"game":null,"gamedigGivenPortOnly":true,"httpBodyEncoding":"json","jsonPath":null,"expectedValue":null,"kafkaProducerTopic":null,"kafkaProducerBrokers":[],"kafkaProducerSsl":false,"kafkaProducerAllowAutoTopicCreation":false,"kafkaProducerMessage":null,"screenshot":null,"headers":null,"body":null,"grpcBody":null,"grpcMetadata":null,"basic_auth_user":null,"basic_auth_pass":null,"oauth_client_id":null,"oauth_client_secret":null,"oauth_token_url":null,"oauth_scopes":null,"oauth_auth_method":"client_secret_basic","manual_status":null,"databaseConnectionString":null,"radiusUsername":null,"radiusPassword":null,"radiusSecret":null,"mqttUsername":"","mqttPassword":"","authWorkstation":null,"authDomain":null,"tlsCa":null,"tlsCert":null,"tlsKey":null,"kafkaProducerSaslOptions":{"mechanism":"None"},"includeSensitiveData":true}`),
+
+			want: monitor.Manual{
+				Base: monitor.Base{
+					ID:              6,
+					Name:            "manual-monitor-null",
+					Description:     nil,
+					PathName:        "manual-monitor-null",
+					Parent:          nil,
+					Interval:        60,
+					RetryInterval:   60,
+					ResendInterval:  0,
+					MaxRetries:      0,
+					UpsideDown:      false,
+					NotificationIDs: nil,
+					IsActive:        true,
+				},
+				ManualDetails: monitor.ManualDetails{
+					ManualStatus: nil,
+				},
+			},
+			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":null,"id":6,"interval":60,"manual_status":null,"maxretries":0,"name":"manual-monitor-null","notificationIDList":{},"parent":null,"resendInterval":0,"retryInterval":60,"type":"manual","upsideDown":false}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			manualMonitor := monitor.Manual{}
+
+			err := json.Unmarshal(tc.data, &manualMonitor)
+			require.NoError(t, err)
+
+			require.EqualExportedValues(t, tc.want, manualMonitor)
+
+			data, err := json.Marshal(manualMonitor)
+			require.NoError(t, err)
+
+			require.JSONEq(t, tc.wantJSON, string(data))
+		})
+	}
+}

--- a/monitor_test.go
+++ b/monitor_test.go
@@ -795,6 +795,55 @@ func TestMonitorCRUD(t *testing.T) {
 			},
 			testPauseResume: true,
 		},
+		{
+			name: "Manual",
+			create: monitor.Manual{
+				Base: monitor.Base{
+					Name:           "Test Manual Monitor",
+					Interval:       60,
+					RetryInterval:  60,
+					ResendInterval: 0,
+					MaxRetries:     0,
+					UpsideDown:     false,
+					IsActive:       true,
+				},
+				ManualDetails: monitor.ManualDetails{
+					ManualStatus: ptr.To(1),
+				},
+			},
+			updateFunc: func(m monitor.Monitor) {
+				manual := m.(*monitor.Manual)
+				manual.Name = "Updated Manual Monitor"
+				manual.ManualStatus = ptr.To(0)
+			},
+			verifyCreatedFunc: func(t *testing.T, actual monitor.Monitor, id int64) {
+				t.Helper()
+				var manual monitor.Manual
+				err := actual.As(&manual)
+				require.NoError(t, err)
+				require.Equal(t, id, manual.ID)
+				require.Equal(t, "Test Manual Monitor", manual.Name)
+				// The manual_status field is not returned from the server.
+				// require.Equal(t, *manual.ManualStatus, 1)
+			},
+			createTypedFunc: func(t *testing.T, base monitor.Monitor) monitor.Monitor {
+				t.Helper()
+				var manual monitor.Manual
+				err := base.As(&manual)
+				require.NoError(t, err)
+				return &manual
+			},
+			verifyUpdatedFunc: func(t *testing.T, actual monitor.Monitor) {
+				t.Helper()
+				var manual monitor.Manual
+				err := actual.As(&manual)
+				require.NoError(t, err)
+				require.Equal(t, "Updated Manual Monitor", manual.Name)
+				// The manual_status field is not returned from the server.
+				// require.Equal(t, *manual.ManualStatus, 0)
+			},
+			testPauseResume: false,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Implement support for the Manual monitor type, a passive monitor that allows manual control of status.

The Manual monitor type includes:
- ManualStatus field that can be set to 0 (DOWN), 1 (UP), 2 (PENDING), or null (not set)
- No actual checks, just reflects the manually set status
- Unit tests for unmarshaling various monitor states
- CRUD integration tests for create, retrieve, update, and delete operations

Closes #132