### PR TITLE
Add support for API key authentication

### DIFF
--- a/client.go
+++ b/client.go
@@ -94,6 +94,9 @@ type Client struct {
 	socketioLogger               socketio.Logger
 	autosetup                    bool
 
+	username string
+	password string
+
 	mu      *sync.Mutex
 	updates signals.Signal[string]
 	state   state
@@ -115,6 +118,23 @@ func WithLogLevel(level int) Option {
 		if level >= utils.DEBUG && level <= utils.NONE {
 			c.socketioLogger = &utils.DefaultLogger{Level: level}
 		}
+	}
+}
+
+// WithCredentials sets the username and password used to authenticate with the Uptime Kuma server.
+func WithCredentials(username string, password string) Option {
+	return func(c *Client) {
+		c.username = username
+		c.password = password
+	}
+}
+
+// WithAPIKey sets the API key used to authenticate with the Uptime Kuma server.
+// This is the recommended authentication method when 2FA is enabled.
+func WithAPIKey(key string) Option {
+	return func(c *Client) {
+		c.username = ""
+		c.password = key
 	}
 }
 
@@ -290,7 +310,7 @@ func setupDatabase(ctx context.Context, baseURL string) error {
 // New creates a new Client connected to an Uptime Kuma server.
 //
 //nolint:revive // Complexity is necessary for complete client initialization and event setup
-func New(ctx context.Context, baseURL string, username string, password string, opts ...Option) (*Client, error) {
+func New(ctx context.Context, baseURL string, opts ...Option) (*Client, error) {
 	c := &Client{
 		socketioLogger: &utils.DefaultLogger{Level: utils.NONE},
 
@@ -511,11 +531,11 @@ func New(ctx context.Context, baseURL string, username string, password string, 
 		return nil, fmt.Errorf("connect to server: %w", err)
 	}
 
-	if username != "" && password != "" {
+	if c.password != "" {
 		_, err = c.syncEmit(
 			ctxWithConnectTimeout,
 			"login",
-			map[string]any{"username": username, "password": password, "token": ""},
+			map[string]any{"username": c.username, "password": c.password, "token": ""},
 		)
 		if err != nil {
 			// Ensure we had the time to receive a potential setup event.
@@ -548,7 +568,7 @@ func New(ctx context.Context, baseURL string, username string, password string, 
 				return nil, errors.New("server does require setup, but autosetup is disabled")
 			}
 
-			_, err := c.syncEmit(ctxWithConnectTimeout, "setup", username, password)
+			_, err := c.syncEmit(ctxWithConnectTimeout, "setup", c.username, c.password)
 			if err != nil {
 				return nil, fmt.Errorf("setup: %w", err)
 			}
@@ -556,7 +576,7 @@ func New(ctx context.Context, baseURL string, username string, password string, 
 			_, err = c.syncEmit(
 				ctxWithConnectTimeout,
 				"login",
-				map[string]any{"username": username, "password": password, "token": ""},
+				map[string]any{"username": c.username, "password": c.password, "token": ""},
 			)
 			if err != nil {
 				return nil, fmt.Errorf("login: %w", err)

--- a/doc.go
+++ b/doc.go
@@ -20,7 +20,7 @@
 // # Basic Usage
 //
 //	ctx := context.Background()
-//	client, err := kuma.New(ctx, "http://localhost:3001", "username", "password")
+//	client, err := kuma.New(ctx, "http://localhost:3001", kuma.WithCredentials("username", "password"))
 //	if err != nil {
 //	    log.Fatal(err)
 //	}

--- a/example_test.go
+++ b/example_test.go
@@ -15,7 +15,7 @@ func Example() {
 	// Using pre-initialized client from main_test.go connecting to Uptime
 	// Kuma running in Docker container.
 	//
-	// client, err := kuma.New(ctx, "http://localhost:3001", "admin", "password")
+	// client, err := kuma.New(ctx, "http://localhost:3001", kuma.WithCredentials("admin", "password"))
 	// if err != nil {
 	// 	log.Fatal(err)
 	// }

--- a/main_test.go
+++ b/main_test.go
@@ -91,7 +91,7 @@ func testMainSetup(m *testing.M) (int, error) {
 		client, err = kuma.New(
 			ctx,
 			fmt.Sprintf("http://localhost:%s", resource.GetPort("3001/tcp")),
-			"admin", "admin1",
+			kuma.WithCredentials("admin", "admin1"),
 			kuma.WithAutosetup(),
 			kuma.WithLogLevel(kuma.LogLevel(os.Getenv("SOCKETIO_LOG_LEVEL"))),
 			kuma.WithConnectTimeout(10*time.Second),


### PR DESCRIPTION
The authentication parameters have been moved to the options pattern in New(). This makes it possible to support API key authentication cleanly without adding additional creators.