### PR TITLE
chore(deps): replace go.socket.io with breml fork dev branch

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -119,6 +119,10 @@ linters:
 
   # All settings can be found here https://github.com/golangci/golangci-lint/blob/HEAD/.golangci.reference.yml
   settings:
+    gomoddirectives:
+      replace-allow-list:
+        - github.com/maldikhan/go.socket.io
+
     depguard:
       # Rules to apply.
       #

--- a/go.mod
+++ b/go.mod
@@ -382,3 +382,5 @@ tool (
 )
 
 exclude github.com/docker/cli v28.2.2+incompatible
+
+replace github.com/maldikhan/go.socket.io => github.com/breml/go.socket.io v0.0.0-20260414211716-a97e0deab31e

--- a/go.sum
+++ b/go.sum
@@ -165,6 +165,8 @@ github.com/breml/errchkjson v0.4.1 h1:keFSS8D7A2T0haP9kzZTi7o26r7kE3vymjZNeNDRDw
 github.com/breml/errchkjson v0.4.1/go.mod h1:a23OvR6Qvcl7DG/Z4o0el6BRAjKnaReoPQFciAl9U3s=
 github.com/breml/githooks v0.0.0-20260328191633-541253a9d3bd h1:Y8xr806ar32BjMXH26TtNKI4gFvTf5oAgZqygoaaeF4=
 github.com/breml/githooks v0.0.0-20260328191633-541253a9d3bd/go.mod h1:wSedAMuNx+ige9zqCTwIJufpRAenWlIgM6zNZ9Npae4=
+github.com/breml/go.socket.io v0.0.0-20260414211716-a97e0deab31e h1:oFgdFwoYQiAciZEXid4MQ4FIGSJ2+WtNPjPIKL/F0HI=
+github.com/breml/go.socket.io v0.0.0-20260414211716-a97e0deab31e/go.mod h1:H1EoWDJvqfV2WryM8F9og6ZkH7NsZDlHr0BRkKb58tY=
 github.com/breml/newline-after-block v0.0.0-20251225141726-84337171eef7 h1:ilIWXePccxYq7HvA/max1ZqS0kTkIB/sKzBPDneECts=
 github.com/breml/newline-after-block v0.0.0-20251225141726-84337171eef7/go.mod h1:zM/p1tEc+HETWeCNzspi+2C5H0D8I7dDClAtmt/fWBA=
 github.com/briandowns/spinner v1.23.2 h1:Zc6ecUnI+YzLmJniCfDNaMbW0Wid1d5+qcTq4L2FW8w=
@@ -505,8 +507,6 @@ github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQ
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/macabu/inamedparam v0.2.0 h1:VyPYpOc10nkhI2qeNUdh3Zket4fcZjEWe35poddBCpE=
 github.com/macabu/inamedparam v0.2.0/go.mod h1:+Pee9/YfGe5LJ62pYXqB89lJ+0k5bsR8Wgz/C0Zlq3U=
-github.com/maldikhan/go.socket.io v0.1.1 h1:4yNNZRwbdcpw6NyXSXyLiQOMzNEXJyKsUZKaMihkRi0=
-github.com/maldikhan/go.socket.io v0.1.1/go.mod h1:H1EoWDJvqfV2WryM8F9og6ZkH7NsZDlHr0BRkKb58tY=
 github.com/maniartech/signals v1.3.1 h1:pT3dK6x5Un+B6L3ZLAKygEe+L49TClPreyT08vOoHXY=
 github.com/maniartech/signals v1.3.1/go.mod h1:AbE8Yy9ZjKCWNU/VhQ+0Ea9KOaTWHp6aOfdLBe5m1iM=
 github.com/manuelarte/embeddedstructfieldcheck v0.4.0 h1:3mAIyaGRtjK6EO9E73JlXLtiy7ha80b2ZVGyacxgfww=


### PR DESCRIPTION
Replace `github.com/maldikhan/go.socket.io` with `github.com/breml/go.socket.io` dev branch (bddd338) using a `replace` directive in `go.mod`.

The dev branch contains fixes for race conditions:

- **engine.io client**: Eliminates data races in polling transport (`stopped` field via `sync/atomic.Bool`) and context sharing (pass `ctx` as parameter instead of reading struct field)
- **engine.io client**: Adds `transportMu` to serialize access to transport field during upgrades, preventing use of stale/stopped transports
- **socket.io client**: Adds `mu` to namespace to protect concurrent access to handler maps during registration and dispatch

See: https://github.com/breml/go.socket.io/tree/dev