### PR TITLE
feat: add Timeout field to PingDetails

### DIFF
--- a/monitor/monitor_ping.go
+++ b/monitor/monitor_ping.go
@@ -72,6 +72,7 @@ func (p Ping) MarshalJSON() ([]byte, error) {
 	// Always override with current Ping-specific field values.
 	raw["hostname"] = p.Hostname
 	raw["packetSize"] = p.PacketSize
+	raw["timeout"] = p.Timeout
 
 	// Server expects these fields to be arrays and not null.
 	raw["accepted_statuscodes"] = []string{}
@@ -91,6 +92,8 @@ func (p Ping) MarshalJSON() ([]byte, error) {
 type PingDetails struct {
 	Hostname   string `json:"hostname"`
 	PacketSize int    `json:"packetSize"`
+	// Timeout is an optional request timeout in seconds.
+	Timeout *int64 `json:"timeout"`
 }
 
 // Type returns the monitor type.

--- a/monitor/monitor_ping_test.go
+++ b/monitor/monitor_ping_test.go
@@ -12,6 +12,7 @@ import (
 
 func TestMonitorPing_Unmarshal(t *testing.T) {
 	parent1 := int64(1)
+	timeout48 := int64(48)
 
 	tests := []struct {
 		name string
@@ -21,7 +22,7 @@ func TestMonitorPing_Unmarshal(t *testing.T) {
 		wantJSON string
 	}{
 		{
-			name: "success",
+			name: "success with timeout",
 			data: []byte(
 				`{"id":3,"name":"ping-monitor","description":"Test ping monitor","pathName":"group / ping-monitor","parent":1,"childrenIDs":[],"url":null,"method":"GET","hostname":"8.8.8.8","port":null,"maxretries":2,"weight":2000,"active":true,"forceInactive":false,"type":"ping","timeout":48,"interval":60,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":64,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":"A","dns_resolve_server":"1.1.1.1","dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{"1":true,"2":true},"tags":[],"maintenance":false,"mqttTopic":"","mqttSuccessMessage":"","databaseQuery":null,"authMethod":null,"grpcUrl":null,"grpcProtobuf":null,"grpcMethod":null,"grpcServiceName":null,"grpcEnableTls":false,"radiusCalledStationId":null,"radiusCallingStationId":null,"game":null,"gamedigGivenPortOnly":true,"httpBodyEncoding":"json","jsonPath":null,"expectedValue":null,"kafkaProducerTopic":null,"kafkaProducerBrokers":[],"kafkaProducerSsl":false,"kafkaProducerAllowAutoTopicCreation":false,"kafkaProducerMessage":null,"screenshot":null,"headers":null,"body":null,"grpcBody":null,"grpcMetadata":null,"basic_auth_user":null,"basic_auth_pass":null,"oauth_client_id":null,"oauth_client_secret":null,"oauth_token_url":null,"oauth_scopes":null,"oauth_auth_method":"client_secret_basic","pushToken":null,"databaseConnectionString":null,"radiusUsername":null,"radiusPassword":null,"radiusSecret":null,"mqttUsername":"","mqttPassword":"","authWorkstation":null,"authDomain":null,"tlsCa":null,"tlsCert":null,"tlsKey":null,"kafkaProducerSaslOptions":{"mechanism":"None"},"includeSensitiveData":true}`,
 			),
@@ -44,9 +45,39 @@ func TestMonitorPing_Unmarshal(t *testing.T) {
 				PingDetails: monitor.PingDetails{
 					Hostname:   "8.8.8.8",
 					PacketSize: 64,
+					Timeout:    &timeout48,
 				},
 			},
-			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":"Test ping monitor","hostname":"8.8.8.8","id":3,"interval":60,"maxretries":2,"name":"ping-monitor","notificationIDList":{"1":true,"2":true},"packetSize":64,"parent":1,"resendInterval":0,"retryInterval":60,"type":"ping","upsideDown":false}`,
+			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":"Test ping monitor","hostname":"8.8.8.8","id":3,"interval":60,"maxretries":2,"name":"ping-monitor","notificationIDList":{"1":true,"2":true},"packetSize":64,"parent":1,"resendInterval":0,"retryInterval":60,"timeout":48,"type":"ping","upsideDown":false}`,
+		},
+		{
+			name: "success with null timeout",
+			data: []byte(
+				`{"id":4,"name":"ping-monitor-no-timeout","description":null,"pathName":"ping-monitor-no-timeout","parent":null,"childrenIDs":[],"url":null,"method":"GET","hostname":"1.1.1.1","port":null,"maxretries":3,"weight":2000,"active":true,"forceInactive":false,"type":"ping","timeout":null,"interval":60,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":"A","dns_resolve_server":"1.1.1.1","dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{},"tags":[],"maintenance":false,"mqttTopic":"","mqttSuccessMessage":"","databaseQuery":null,"authMethod":null,"grpcUrl":null,"grpcProtobuf":null,"grpcMethod":null,"grpcServiceName":null,"grpcEnableTls":false,"radiusCalledStationId":null,"radiusCallingStationId":null,"game":null,"gamedigGivenPortOnly":true,"httpBodyEncoding":"json","jsonPath":null,"expectedValue":null,"kafkaProducerTopic":null,"kafkaProducerBrokers":[],"kafkaProducerSsl":false,"kafkaProducerAllowAutoTopicCreation":false,"kafkaProducerMessage":null,"screenshot":null,"headers":null,"body":null,"grpcBody":null,"grpcMetadata":null,"basic_auth_user":null,"basic_auth_pass":null,"oauth_client_id":null,"oauth_client_secret":null,"oauth_token_url":null,"oauth_scopes":null,"oauth_auth_method":"client_secret_basic","pushToken":null,"databaseConnectionString":null,"radiusUsername":null,"radiusPassword":null,"radiusSecret":null,"mqttUsername":"","mqttPassword":"","authWorkstation":null,"authDomain":null,"tlsCa":null,"tlsCert":null,"tlsKey":null,"kafkaProducerSaslOptions":{"mechanism":"None"},"includeSensitiveData":true}`,
+			),
+
+			want: monitor.Ping{
+				Base: monitor.Base{
+					ID:              4,
+					Name:            "ping-monitor-no-timeout",
+					Description:     nil,
+					PathName:        "ping-monitor-no-timeout",
+					Parent:          nil,
+					Interval:        60,
+					RetryInterval:   60,
+					ResendInterval:  0,
+					MaxRetries:      3,
+					UpsideDown:      false,
+					NotificationIDs: nil,
+					IsActive:        true,
+				},
+				PingDetails: monitor.PingDetails{
+					Hostname:   "1.1.1.1",
+					PacketSize: 56,
+					Timeout:    nil,
+				},
+			},
+			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":null,"hostname":"1.1.1.1","id":4,"interval":60,"maxretries":3,"name":"ping-monitor-no-timeout","notificationIDList":{},"packetSize":56,"parent":null,"resendInterval":0,"retryInterval":60,"timeout":null,"type":"ping","upsideDown":false}`,
 		},
 	}
 

--- a/monitor_test.go
+++ b/monitor_test.go
@@ -147,6 +147,7 @@ func TestMonitorCRUD(t *testing.T) {
 				PingDetails: monitor.PingDetails{
 					Hostname:   "8.8.8.8",
 					PacketSize: 56,
+					Timeout:    ptr.To(int64(48)),
 				},
 			},
 			updateFunc: func(m monitor.Monitor) {


### PR DESCRIPTION
Add optional `Timeout *int64` field to `PingDetails` struct and serialize it in `Ping.MarshalJSON`. The Uptime Kuma server sends and accepts a `timeout` value for ping monitors, but the client was not exposing it.

This is needed by the Terraform provider to support the `timeout` attribute on `uptimekuma_monitor_ping` resources (breml/terraform-provider-uptimekuma#301).