### PR TITLE
fix: honour WithConnectTimeout while waiting for ready events

### DIFF
--- a/client.go
+++ b/client.go
@@ -522,10 +522,9 @@ func New(ctx context.Context, baseURL string, username string, password string, 
 
 	// The socket.io client is now connected. On any subsequent error path
 	// the caller receives no *Client handle and therefore cannot call
-	// Disconnect themselves. Trigger a non-blocking close in a separate
-	// goroutine so New() returns promptly; the goroutine will finish once
-	// the caller's ctx is cancelled.  Cleared to false on the success path
-	// so the caller takes ownership.
+	// Disconnect themselves. Trigger a best-effort async close so that
+	// goroutines and connections are eventually cleaned up.
+	// Cleared to false on the success path so the caller takes ownership.
 	closeOnErr := true
 	defer func() {
 		if closeOnErr {
@@ -600,6 +599,16 @@ func New(ctx context.Context, baseURL string, username string, password string, 
 			// "missing events" message on an ordinary cancellation.
 			if ctx.Err() != nil {
 				return nil, fmt.Errorf("wait for ready: %w", ctx.Err())
+			}
+
+			// If all ready events arrived at the exact same instant as the
+			// timeout, prefer the success path over the error path.
+			select {
+			case <-ready:
+				closeOnErr = false
+				return c, nil
+
+			default:
 			}
 
 			updateSeenMu.Lock()

--- a/client.go
+++ b/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -564,6 +565,22 @@ func New(ctx context.Context, baseURL string, username string, password string, 
 
 		case <-ctx.Done():
 			return nil, fmt.Errorf("wait for ready: %w", ctx.Err())
+
+		case <-ctxWithConnectTimeout.Done():
+			updateSeenMu.Lock()
+			missing := make([]string, 0, len(updateSeen))
+			for event := range updateSeen {
+				missing = append(missing, event)
+			}
+			updateSeenMu.Unlock()
+
+			sort.Strings(missing)
+
+			return nil, fmt.Errorf(
+				"wait for ready: %w (missing events: %s)",
+				ctxWithConnectTimeout.Err(),
+				strings.Join(missing, ", "),
+			)
 		}
 	}
 }

--- a/client.go
+++ b/client.go
@@ -304,10 +304,18 @@ func New(ctx context.Context, baseURL string, username string, password string, 
 	}
 
 	ctxWithConnectTimeout := ctx
+
+	// connectTimeoutDone is non-nil only when WithConnectTimeout is
+	// configured. Using nil keeps the ready-wait select deterministic when
+	// ctxWithConnectTimeout and ctx are the same context (no timeout set).
+	var connectTimeoutDone <-chan struct{}
+
 	if c.socketioClientConnectTimeout != 0 {
 		var cancel func()
 		ctxWithConnectTimeout, cancel = context.WithTimeout(ctx, c.socketioClientConnectTimeout)
 		defer cancel()
+
+		connectTimeoutDone = ctxWithConnectTimeout.Done()
 	}
 
 	// Handle database setup for Uptime Kuma v2 if autosetup is enabled
@@ -566,7 +574,7 @@ func New(ctx context.Context, baseURL string, username string, password string, 
 		case <-ctx.Done():
 			return nil, fmt.Errorf("wait for ready: %w", ctx.Err())
 
-		case <-ctxWithConnectTimeout.Done():
+		case <-connectTimeoutDone:
 			updateSeenMu.Lock()
 			missing := make([]string, 0, len(updateSeen))
 			for event := range updateSeen {

--- a/client.go
+++ b/client.go
@@ -529,7 +529,12 @@ func New(ctx context.Context, baseURL string, username string, password string, 
 	closeOnErr := true
 	defer func() {
 		if closeOnErr {
-			go func() { _ = c.Disconnect() }()
+			go func() {
+				disconnectErr := c.Disconnect()
+				if disconnectErr != nil {
+					c.socketioLogger.Errorf("disconnect after New() error: %s", disconnectErr)
+				}
+			}()
 		}
 	}()
 
@@ -589,6 +594,14 @@ func New(ctx context.Context, baseURL string, username string, password string, 
 			return nil, fmt.Errorf("wait for ready: %w", ctx.Err())
 
 		case <-connectTimeoutDone:
+			// ctxWithConnectTimeout is derived from ctx, so its Done channel
+			// closes whenever the parent ctx is cancelled too. Prefer the
+			// parent's error in that case to avoid a misleading
+			// "missing events" message on an ordinary cancellation.
+			if ctx.Err() != nil {
+				return nil, fmt.Errorf("wait for ready: %w", ctx.Err())
+			}
+
 			updateSeenMu.Lock()
 			missing := make([]string, 0, len(updateSeen))
 			for event := range updateSeen {

--- a/client.go
+++ b/client.go
@@ -520,6 +520,19 @@ func New(ctx context.Context, baseURL string, username string, password string, 
 		return nil, fmt.Errorf("connect to server: %w", err)
 	}
 
+	// The socket.io client is now connected. On any subsequent error path
+	// the caller receives no *Client handle and therefore cannot call
+	// Disconnect themselves. Trigger a non-blocking close in a separate
+	// goroutine so New() returns promptly; the goroutine will finish once
+	// the caller's ctx is cancelled.  Cleared to false on the success path
+	// so the caller takes ownership.
+	closeOnErr := true
+	defer func() {
+		if closeOnErr {
+			go func() { _ = c.Disconnect() }()
+		}
+	}()
+
 	if username != "" && password != "" {
 		_, err = c.syncEmit(
 			ctxWithConnectTimeout,
@@ -548,6 +561,7 @@ func New(ctx context.Context, baseURL string, username string, password string, 
 	for {
 		select {
 		case <-ready:
+			closeOnErr = false
 			return c, nil
 
 		case <-setupRequired:

--- a/client_timeout_test.go
+++ b/client_timeout_test.go
@@ -1,0 +1,136 @@
+package kuma_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	kuma "github.com/breml/go-uptime-kuma-client"
+)
+
+// fakeSocketIOServer implements a minimal socket.io server over HTTP long-polling.
+// It handles the initial engine.io handshake, socket.io CONNECT, and login phases,
+// but then deliberately blocks on subsequent GET requests without ever emitting
+// ready events (e.g. apiKeyList). This simulates the Uptime Kuma 2.3.x behavior
+// that triggers issue #271.
+type fakeSocketIOServer struct {
+	messages chan []byte
+}
+
+func (s *fakeSocketIOServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	sid := r.URL.Query().Get("sid")
+
+	switch {
+	case r.Method == http.MethodGet && sid == "":
+		// Initial engine.io handshake: respond with PacketOpen ("0") + JSON.
+		type engineIOHandshake struct {
+			Sid          string   `json:"sid"`
+			Upgrades     []string `json:"upgrades"`
+			PingInterval int      `json:"pingInterval"`
+			PingTimeout  int      `json:"pingTimeout"`
+			MaxPayload   int      `json:"maxPayload"`
+		}
+		data, _ := json.Marshal(engineIOHandshake{
+			Sid:          "test-sid",
+			Upgrades:     []string{}, // no WebSocket upgrade keeps the client on polling
+			PingInterval: 50,
+			PingTimeout:  5000,
+			MaxPayload:   1000000,
+		})
+		_, _ = w.Write(append([]byte("0"), data...))
+
+	case r.Method == http.MethodPost && sid != "":
+		body, _ := io.ReadAll(r.Body)
+		s.handleClientMessage(body)
+		w.WriteHeader(http.StatusOK)
+
+	case r.Method == http.MethodGet && sid != "":
+		// Long-poll: deliver the next queued message or block until the
+		// client disconnects (simulating a server that never emits ready events).
+		select {
+		case msg := <-s.messages:
+			_, _ = w.Write(msg)
+
+		case <-r.Context().Done():
+		}
+
+	default:
+	}
+}
+
+// handleClientMessage processes socket.io messages received from the client via POST.
+// The body format is: engine.io type byte ("4" for Message) + socket.io packet.
+func (s *fakeSocketIOServer) handleClientMessage(body []byte) {
+	if len(body) < 2 {
+		return
+	}
+
+	socketIOData := body[1:] // strip engine.io "4" (Message) prefix
+
+	switch socketIOData[0] {
+	case '0': // socket.io CONNECT
+		// Enqueue CONNECT ACK: engine.io "4" (Message) + socket.io "0" (Connect).
+		s.messages <- []byte("40")
+
+	case '2': // socket.io EVENT — the login request
+		// Extract the ack ID: digits immediately after the "2" type byte.
+		i := 1
+		for i < len(socketIOData) && socketIOData[i] >= '0' && socketIOData[i] <= '9' {
+			i++
+		}
+
+		ackID := string(socketIOData[1:i])
+		// Enqueue login ACK: engine.io "4" + socket.io "3" (Ack) + ack ID + JSON payload.
+		ack := fmt.Sprintf(`43%s[{"ok":true,"msg":"Logged in successfully."}]`, ackID)
+		s.messages <- []byte(ack)
+
+	default:
+	}
+}
+
+func TestNewConnectTimeoutDuringReadyWait(t *testing.T) {
+	// Regression test for issue #271: kuma.New() hangs indefinitely waiting for
+	// ready events when WithConnectTimeout is set (Uptime Kuma 2.3.x).
+	//
+	// The fake server completes the handshake and login phases successfully, but
+	// never sends the required ready events (e.g. apiKeyList). kuma.New() must
+	// return a context.DeadlineExceeded error within the configured timeout.
+	server := httptest.NewServer(&fakeSocketIOServer{
+		messages: make(chan []byte, 10),
+	})
+
+	// Use an explicit cancellable context so that background goroutines
+	// started by kuma.New() can be stopped before server.Close() waits
+	// for all active connections to drain.
+	ctx, cancel := context.WithCancel(t.Context())
+
+	const timeout = 500 * time.Millisecond
+	start := time.Now()
+
+	_, err := kuma.New(
+		ctx,
+		server.URL,
+		"admin", "admin1",
+		kuma.WithConnectTimeout(timeout),
+	)
+
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.DeadlineExceeded, "error should wrap context.DeadlineExceeded, got: %v", err)
+	require.Less(t, elapsed, 2*timeout, "New() should return within 2x timeout, took %s", elapsed)
+
+	// Cancel the context to abort in-flight requests from background
+	// goroutines, then force-close any remaining connections so that
+	// server.Close() does not block waiting for active connections to drain.
+	cancel()
+	server.CloseClientConnections()
+	server.Close()
+}

--- a/client_timeout_test.go
+++ b/client_timeout_test.go
@@ -102,16 +102,24 @@ func TestNewConnectTimeoutDuringReadyWait(t *testing.T) {
 	// The fake server completes the handshake and login phases successfully, but
 	// never sends the required ready events (e.g. apiKeyList). kuma.New() must
 	// return a context.DeadlineExceeded error within the configured timeout.
+	const timeout = 500 * time.Millisecond
+
 	server := httptest.NewServer(&fakeSocketIOServer{
 		messages: make(chan []byte, 10),
 	})
 
-	// Use an explicit cancellable context so that background goroutines
-	// started by kuma.New() can be stopped before server.Close() waits
-	// for all active connections to drain.
-	ctx, cancel := context.WithCancel(t.Context())
+	// Bound the test itself so it fails fast if the regression reappears and
+	// kuma.New() blocks indefinitely rather than honouring the timeout.
+	ctx, cancel := context.WithTimeout(t.Context(), 5*timeout)
 
-	const timeout = 500 * time.Millisecond
+	// Always cancel the context and close the server, even when a require.*
+	// assertion short-circuits the test via FailNow.
+	t.Cleanup(func() {
+		cancel()
+		server.CloseClientConnections()
+		server.Close()
+	})
+
 	start := time.Now()
 
 	_, err := kuma.New(
@@ -126,11 +134,4 @@ func TestNewConnectTimeoutDuringReadyWait(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorIs(t, err, context.DeadlineExceeded, "error should wrap context.DeadlineExceeded, got: %v", err)
 	require.Less(t, elapsed, 2*timeout, "New() should return within 2x timeout, took %s", elapsed)
-
-	// Cancel the context to abort in-flight requests from background
-	// goroutines, then force-close any remaining connections so that
-	// server.Close() does not block waiting for active connections to drain.
-	cancel()
-	server.CloseClientConnections()
-	server.Close()
 }

--- a/client_timeout_test.go
+++ b/client_timeout_test.go
@@ -37,17 +37,27 @@ func (s *fakeSocketIOServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			PingTimeout  int      `json:"pingTimeout"`
 			MaxPayload   int      `json:"maxPayload"`
 		}
-		data, _ := json.Marshal(engineIOHandshake{
+		data, err := json.Marshal(engineIOHandshake{
 			Sid:          "test-sid",
 			Upgrades:     []string{}, // no WebSocket upgrade keeps the client on polling
 			PingInterval: 50,
 			PingTimeout:  5000,
 			MaxPayload:   1000000,
 		})
+		if err != nil {
+			http.Error(w, "marshal handshake", http.StatusInternalServerError)
+			return
+		}
+
 		_, _ = w.Write(append([]byte("0"), data...))
 
 	case r.Method == http.MethodPost && sid != "":
-		body, _ := io.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "read body", http.StatusInternalServerError)
+			return
+		}
+
 		s.handleClientMessage(body)
 		w.WriteHeader(http.StatusOK)
 

--- a/client_timeout_test.go
+++ b/client_timeout_test.go
@@ -143,5 +143,7 @@ func TestNewConnectTimeoutDuringReadyWait(t *testing.T) {
 
 	require.Error(t, err)
 	require.ErrorIs(t, err, context.DeadlineExceeded, "error should wrap context.DeadlineExceeded, got: %v", err)
+	require.ErrorContains(t, err, "missing events:", "error should list the still-missing ready events")
+	require.ErrorContains(t, err, "apiKeyList", "apiKeyList should appear in the missing events list")
 	require.Less(t, elapsed, 2*timeout, "New() should return within 2x timeout, took %s", elapsed)
 }


### PR DESCRIPTION
## Summary

- Add `case <-ctxWithConnectTimeout.Done():` to the ready-wait loop in `New()` so `WithConnectTimeout` is honoured even when the parent context never expires (e.g. `context.Background()`)
- Include the still-missing event names in the timeout error to aid diagnosis
- Add a regression test using a minimal fake socket.io polling server that completes login but never emits ready events, verifying `New()` returns `context.DeadlineExceeded` within the configured timeout

Closes #271