### PR TITLE
feat(notification): extend Slack with v2.x fields

### DIFF
--- a/notification/notification_slack.go
+++ b/notification/notification_slack.go
@@ -12,12 +12,15 @@ type Slack struct {
 
 // SlackDetails contains slack-specific notification configuration.
 type SlackDetails struct {
-	WebhookURL    string `json:"slackwebhookURL"`
-	Username      string `json:"slackusername"`
-	IconEmoji     string `json:"slackiconemo"`
-	Channel       string `json:"slackchannel"`
-	RichMessage   bool   `json:"slackrichmessage"`
-	ChannelNotify bool   `json:"slackchannelnotify"`
+	WebhookURL       string  `json:"slackwebhookURL"`
+	Username         string  `json:"slackusername"`
+	IconEmoji        string  `json:"slackiconemo"`
+	Channel          string  `json:"slackchannel"`
+	RichMessage      bool    `json:"slackrichmessage"`
+	ChannelNotify    bool    `json:"slackchannelnotify"`
+	IncludeGroupName *bool   `json:"slackIncludeGroupName,omitempty"`
+	UseTemplate      *bool   `json:"slackUseTemplate,omitempty"`
+	Template         *string `json:"slackTemplate,omitempty"`
 }
 
 // Type returns the notification type.

--- a/notification/notification_slack_test.go
+++ b/notification/notification_slack_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/breml/go-uptime-kuma-client/internal/ptr"
 	"github.com/breml/go-uptime-kuma-client/notification"
 )
 
@@ -42,6 +43,81 @@ func TestNotificationSlack_Unmarshal(t *testing.T) {
 				},
 			},
 			wantJSON: `{"active":true,"applyExisting":true,"id":1,"isDefault":true,"name":"My Slack Alert","slackchannel":"#alerts","slackchannelnotify":false,"slackiconemo":":ghost:","slackrichmessage":true,"slackusername":"uptime-kuma","slackwebhookURL":"https://hooks.slack.com/services/xxx/yyy/zzz","type":"slack","userId":1}`,
+		},
+		{
+			name: "with include group name",
+			data: []byte(
+				`{"id":2,"name":"Slack Group Path","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Slack Group Path\",\"slackwebhookURL\":\"https://hooks.slack.com/services/aaa/bbb/ccc\",\"slackrichmessage\":true,\"slackchannelnotify\":false,\"slackIncludeGroupName\":true,\"type\":\"slack\"}"}`,
+			),
+
+			want: notification.Slack{
+				Base: notification.Base{
+					ID:            2,
+					Name:          "Slack Group Path",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				SlackDetails: notification.SlackDetails{
+					WebhookURL:       "https://hooks.slack.com/services/aaa/bbb/ccc",
+					RichMessage:      true,
+					ChannelNotify:    false,
+					IncludeGroupName: ptr.To(true),
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"id":2,"isDefault":false,"name":"Slack Group Path","slackIncludeGroupName":true,"slackchannel":"","slackchannelnotify":false,"slackiconemo":"","slackrichmessage":true,"slackusername":"","slackwebhookURL":"https://hooks.slack.com/services/aaa/bbb/ccc","type":"slack","userId":1}`,
+		},
+		{
+			name: "with template",
+			data: []byte(
+				`{"id":3,"name":"Slack Template","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Slack Template\",\"slackwebhookURL\":\"https://hooks.slack.com/services/ddd/eee/fff\",\"slackrichmessage\":false,\"slackchannelnotify\":false,\"slackUseTemplate\":true,\"slackTemplate\":\"Alert: {{ msg }}\",\"type\":\"slack\"}"}`,
+			),
+
+			want: notification.Slack{
+				Base: notification.Base{
+					ID:            3,
+					Name:          "Slack Template",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				SlackDetails: notification.SlackDetails{
+					WebhookURL:    "https://hooks.slack.com/services/ddd/eee/fff",
+					RichMessage:   false,
+					ChannelNotify: false,
+					UseTemplate:   ptr.To(true),
+					Template:      ptr.To("Alert: {{ msg }}"),
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"id":3,"isDefault":false,"name":"Slack Template","slackTemplate":"Alert: {{ msg }}","slackUseTemplate":true,"slackchannel":"","slackchannelnotify":false,"slackiconemo":"","slackrichmessage":false,"slackusername":"","slackwebhookURL":"https://hooks.slack.com/services/ddd/eee/fff","type":"slack","userId":1}`,
+		},
+		{
+			name: "pointer to false and empty string are serialized",
+			data: []byte(
+				`{"id":4,"name":"Slack Explicit False","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Slack Explicit False\",\"slackwebhookURL\":\"https://hooks.slack.com/services/ggg/hhh/iii\",\"slackrichmessage\":false,\"slackchannelnotify\":false,\"slackIncludeGroupName\":false,\"slackUseTemplate\":false,\"slackTemplate\":\"\",\"type\":\"slack\"}"}`,
+			),
+
+			want: notification.Slack{
+				Base: notification.Base{
+					ID:            4,
+					Name:          "Slack Explicit False",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				SlackDetails: notification.SlackDetails{
+					WebhookURL:       "https://hooks.slack.com/services/ggg/hhh/iii",
+					RichMessage:      false,
+					ChannelNotify:    false,
+					IncludeGroupName: ptr.To(false),
+					UseTemplate:      ptr.To(false),
+					Template:         ptr.To(""),
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"id":4,"isDefault":false,"name":"Slack Explicit False","slackIncludeGroupName":false,"slackTemplate":"","slackUseTemplate":false,"slackchannel":"","slackchannelnotify":false,"slackiconemo":"","slackrichmessage":false,"slackusername":"","slackwebhookURL":"https://hooks.slack.com/services/ggg/hhh/iii","type":"slack","userId":1}`,
 		},
 	}
 


### PR DESCRIPTION
Add support for the Slack notification fields introduced in upstream Uptime Kuma v2.x:

- `slackIncludeGroupName` (`*bool`, omitempty): include monitor group path in messages (upstream PR [#6835](https://github.com/louislam/uptime-kuma/pull/6835))
- `slackUseTemplate` (`*bool`, omitempty) / `slackTemplate` (`*string`, omitempty): render messages from a template (upstream PR [#6690](https://github.com/louislam/uptime-kuma/pull/6690))

Following the existing pattern (see Discord), pointer types with `omitempty` are used so that absent fields stay absent on the wire while explicit `false`/empty-string values still round-trip.

Tests for unmarshal/marshal round-trip have been added covering all three new fields, including the explicit `false` / empty string case.

Closes #260