### PR TITLE
feat(notification): extend Ntfy with v2.x fields

### DIFF
--- a/notification/notification_ntfy.go
+++ b/notification/notification_ntfy.go
@@ -12,19 +12,19 @@ type Ntfy struct {
 
 // NtfyDetails contains ntfy-specific notification configuration.
 type NtfyDetails struct {
-	AccessToken          string `json:"ntfyaccesstoken"`
-	AuthenticationMethod string `json:"ntfyAuthenticationMethod"`
-	Call                 string `json:"ntfyCall,omitempty"`
-	CustomMessage        string `json:"ntfyCustomMessage,omitempty"`
-	CustomTitle          string `json:"ntfyCustomTitle,omitempty"`
-	Icon                 string `json:"ntfyIcon"`
-	Password             string `json:"ntfypassword"`
-	Priority             int64  `json:"ntfyPriority"`
-	PriorityDown         int64  `json:"ntfyPriorityDown,omitempty"`
-	ServerURL            string `json:"ntfyserverurl"`
-	Topic                string `json:"ntfytopic"`
-	UseTemplate          bool   `json:"ntfyUseTemplate,omitempty"`
-	Username             string `json:"ntfyusername"`
+	AccessToken          string  `json:"ntfyaccesstoken"`
+	AuthenticationMethod string  `json:"ntfyAuthenticationMethod"`
+	Call                 *string `json:"ntfyCall,omitempty"`
+	CustomMessage        *string `json:"ntfyCustomMessage,omitempty"`
+	CustomTitle          *string `json:"ntfyCustomTitle,omitempty"`
+	Icon                 string  `json:"ntfyIcon"`
+	Password             string  `json:"ntfypassword"`
+	Priority             int64   `json:"ntfyPriority"`
+	PriorityDown         int64   `json:"ntfyPriorityDown,omitempty"`
+	ServerURL            string  `json:"ntfyserverurl"`
+	Topic                string  `json:"ntfytopic"`
+	UseTemplate          *bool   `json:"ntfyUseTemplate,omitempty"`
+	Username             string  `json:"ntfyusername"`
 }
 
 // Type returns the notification type.

--- a/notification/notification_ntfy.go
+++ b/notification/notification_ntfy.go
@@ -14,11 +14,16 @@ type Ntfy struct {
 type NtfyDetails struct {
 	AccessToken          string `json:"ntfyaccesstoken"`
 	AuthenticationMethod string `json:"ntfyAuthenticationMethod"`
+	Call                 string `json:"ntfyCall,omitempty"`
+	CustomMessage        string `json:"ntfyCustomMessage,omitempty"`
+	CustomTitle          string `json:"ntfyCustomTitle,omitempty"`
 	Icon                 string `json:"ntfyIcon"`
 	Password             string `json:"ntfypassword"`
 	Priority             int64  `json:"ntfyPriority"`
+	PriorityDown         int64  `json:"ntfyPriorityDown,omitempty"`
 	ServerURL            string `json:"ntfyserverurl"`
 	Topic                string `json:"ntfytopic"`
+	UseTemplate          bool   `json:"ntfyUseTemplate,omitempty"`
 	Username             string `json:"ntfyusername"`
 }
 

--- a/notification/notification_ntfy_test.go
+++ b/notification/notification_ntfy_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/breml/go-uptime-kuma-client/internal/ptr"
 	"github.com/breml/go-uptime-kuma-client/notification"
 )
 
@@ -61,13 +62,13 @@ func TestNotificationNtfy_Unmarshal(t *testing.T) {
 				},
 				NtfyDetails: notification.NtfyDetails{
 					AuthenticationMethod: "usernamePassword",
-					Call:                 "+12223334444",
-					CustomMessage:        "custom message",
-					CustomTitle:          "custom title",
+					Call:                 ptr.To("+12223334444"),
+					CustomMessage:        ptr.To("custom message"),
+					CustomTitle:          ptr.To("custom title"),
 					Icon:                 "http://symbol.url",
 					Priority:             3,
 					PriorityDown:         5,
-					UseTemplate:          true,
+					UseTemplate:          ptr.To(true),
 					Password:             "password",
 					ServerURL:            "https://ntfy.sh",
 					Topic:                "topic",
@@ -75,6 +76,34 @@ func TestNotificationNtfy_Unmarshal(t *testing.T) {
 				},
 			},
 			wantJSON: `{"active":true,"applyExisting":true,"id":2,"isDefault":true,"name":"My Ntfy Alert","ntfyAuthenticationMethod":"usernamePassword","ntfyCall":"+12223334444","ntfyCustomMessage":"custom message","ntfyCustomTitle":"custom title","ntfyIcon":"http://symbol.url","ntfyPriority":3,"ntfyPriorityDown":5,"ntfyUseTemplate":true,"ntfyaccesstoken":"","ntfypassword":"password","ntfyserverurl":"https://ntfy.sh","ntfytopic":"topic","ntfyusername":"user","type":"ntfy","userId":1}`,
+		},
+		{
+			name: "explicit empty template fields and disabled toggle",
+			data: []byte(
+				`{"id":3,"name":"My Ntfy Alert","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"My Ntfy Alert\",\"ntfyAuthenticationMethod\":\"none\",\"ntfyCall\":\"\",\"ntfyCustomMessage\":\"\",\"ntfyCustomTitle\":\"\",\"ntfyIcon\":\"\",\"ntfyPriority\":5,\"ntfyUseTemplate\":false,\"ntfypassword\":\"\",\"ntfyserverurl\":\"https://ntfy.sh\",\"ntfytopic\":\"topic\",\"ntfyusername\":\"\",\"type\":\"ntfy\"}"}`,
+			),
+
+			want: notification.Ntfy{
+				Base: notification.Base{
+					ID:            3,
+					Name:          "My Ntfy Alert",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     true,
+					ApplyExisting: true,
+				},
+				NtfyDetails: notification.NtfyDetails{
+					AuthenticationMethod: "none",
+					Call:                 ptr.To(""),
+					CustomMessage:        ptr.To(""),
+					CustomTitle:          ptr.To(""),
+					Priority:             5,
+					ServerURL:            "https://ntfy.sh",
+					Topic:                "topic",
+					UseTemplate:          ptr.To(false),
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":true,"id":3,"isDefault":true,"name":"My Ntfy Alert","ntfyAuthenticationMethod":"none","ntfyCall":"","ntfyCustomMessage":"","ntfyCustomTitle":"","ntfyIcon":"","ntfyPriority":5,"ntfyUseTemplate":false,"ntfyaccesstoken":"","ntfypassword":"","ntfyserverurl":"https://ntfy.sh","ntfytopic":"topic","ntfyusername":"","type":"ntfy","userId":1}`,
 		},
 	}
 

--- a/notification/notification_ntfy_test.go
+++ b/notification/notification_ntfy_test.go
@@ -44,6 +44,38 @@ func TestNotificationNtfy_Unmarshal(t *testing.T) {
 			},
 			wantJSON: `{"active":true,"applyExisting":true,"id":1,"isDefault":true,"name":"My Ntfy Alert","ntfyAuthenticationMethod":"usernamePassword","ntfyIcon":"http://symbol.url","ntfyPriority":5,"ntfyaccesstoken":"","ntfypassword":"password","ntfyserverurl":"https://ntfy.sh","ntfytopic":"topic","ntfyusername":"user","type":"ntfy","userId":1}`,
 		},
+		{
+			name: "with template, call and priority down",
+			data: []byte(
+				`{"id":2,"name":"My Ntfy Alert","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"My Ntfy Alert\",\"ntfyAuthenticationMethod\":\"usernamePassword\",\"ntfyCall\":\"+12223334444\",\"ntfyCustomMessage\":\"custom message\",\"ntfyCustomTitle\":\"custom title\",\"ntfyIcon\":\"http://symbol.url\",\"ntfyPriority\":3,\"ntfyPriorityDown\":5,\"ntfyUseTemplate\":true,\"ntfypassword\":\"password\",\"ntfyserverurl\":\"https://ntfy.sh\",\"ntfytopic\":\"topic\",\"ntfyusername\":\"user\",\"type\":\"ntfy\"}"}`,
+			),
+
+			want: notification.Ntfy{
+				Base: notification.Base{
+					ID:            2,
+					Name:          "My Ntfy Alert",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     true,
+					ApplyExisting: true,
+				},
+				NtfyDetails: notification.NtfyDetails{
+					AuthenticationMethod: "usernamePassword",
+					Call:                 "+12223334444",
+					CustomMessage:        "custom message",
+					CustomTitle:          "custom title",
+					Icon:                 "http://symbol.url",
+					Priority:             3,
+					PriorityDown:         5,
+					UseTemplate:          true,
+					Password:             "password",
+					ServerURL:            "https://ntfy.sh",
+					Topic:                "topic",
+					Username:             "user",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":true,"id":2,"isDefault":true,"name":"My Ntfy Alert","ntfyAuthenticationMethod":"usernamePassword","ntfyCall":"+12223334444","ntfyCustomMessage":"custom message","ntfyCustomTitle":"custom title","ntfyIcon":"http://symbol.url","ntfyPriority":3,"ntfyPriorityDown":5,"ntfyUseTemplate":true,"ntfyaccesstoken":"","ntfypassword":"password","ntfyserverurl":"https://ntfy.sh","ntfytopic":"topic","ntfyusername":"user","type":"ntfy","userId":1}`,
+		},
 	}
 
 	for _, tc := range tests {

--- a/notification_test.go
+++ b/notification_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/breml/go-uptime-kuma-client/internal/ptr"
 	"github.com/breml/go-uptime-kuma-client/notification"
 )
 
@@ -57,10 +58,10 @@ func TestNotificationCRUD(t *testing.T) {
 				ntfy.Password = "testpass"
 				ntfy.Priority = 3
 				ntfy.PriorityDown = 5
-				ntfy.Call = "+12223334444"
-				ntfy.UseTemplate = true
-				ntfy.CustomTitle = "{{ name }} is {{ status }}"
-				ntfy.CustomMessage = "{{ msg }}"
+				ntfy.Call = ptr.To("+12223334444")
+				ntfy.UseTemplate = ptr.To(true)
+				ntfy.CustomTitle = ptr.To("{{ name }} is {{ status }}")
+				ntfy.CustomMessage = ptr.To("{{ msg }}")
 			},
 			verifyCreatedFunc: func(t *testing.T, actual notification.Notification, expected notification.Notification, id int64) {
 				t.Helper()

--- a/notification_test.go
+++ b/notification_test.go
@@ -56,6 +56,11 @@ func TestNotificationCRUD(t *testing.T) {
 				ntfy.Username = "testuser"
 				ntfy.Password = "testpass"
 				ntfy.Priority = 3
+				ntfy.PriorityDown = 5
+				ntfy.Call = "+12223334444"
+				ntfy.UseTemplate = true
+				ntfy.CustomTitle = "{{ name }} is {{ status }}"
+				ntfy.CustomMessage = "{{ msg }}"
 			},
 			verifyCreatedFunc: func(t *testing.T, actual notification.Notification, expected notification.Notification, id int64) {
 				t.Helper()


### PR DESCRIPTION
Add support for the Ntfy notification fields introduced in upstream Uptime Kuma v2.x:

- `ntfyCall`: phone-call priority phone-number field ([#6640](https://github.com/louislam/uptime-kuma/pull/6640))
- `ntfyPriorityDown`: separate priority for DOWN heartbeats
- `ntfyUseTemplate` / `ntfyCustomTitle` / `ntfyCustomMessage`: render messages from custom templates ([#6804](https://github.com/louislam/uptime-kuma/pull/6804))

The remaining items from the issue (#6762 monitor metadata in messages, #6766 tag-values in tags array) are server-side rendering changes in `ntfy.js` that do not introduce new notification settings fields, so no client-side changes are required for them.

All new fields use `omitempty` JSON tags. The unit tests in `notification/notification_ntfy_test.go` cover marshal/unmarshal of the new fields, and the integration test in `notification_test.go` exercises them through the full CRUD flow.

Closes #261