### PR TITLE
feat(notification): extend WeCom with mentioned mobile list

### DIFF
--- a/notification/notification_wecom.go
+++ b/notification/notification_wecom.go
@@ -13,7 +13,8 @@ type WeCom struct {
 
 // WeComDetails contains the WeCom-specific configuration.
 type WeComDetails struct {
-	BotKey string `json:"weComBotKey"`
+	BotKey              string `json:"weComBotKey"`
+	MentionedMobileList string `json:"weComMentionedMobileList,omitempty"`
 }
 
 // Type returns the notification type identifier for WeCom.

--- a/notification/notification_wecom_test.go
+++ b/notification/notification_wecom_test.go
@@ -20,7 +20,7 @@ func TestNotificationWeCom_Unmarshal(t *testing.T) {
 		{
 			name: "success",
 			data: []byte(
-				`{"id":1,"name":"My WeCom Alert","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"My WeCom Alert\",\"weComBotKey\":\"abc123def456\",\"type\":\"WeCom\"}"}`,
+				`{"id":1,"name":"My WeCom Alert","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"My WeCom Alert\",\"weComBotKey\":\"abc123def456\",\"weComMentionedMobileList\":\"13800001111,13900002222,@all\",\"type\":\"WeCom\"}"}`,
 			),
 
 			want: notification.WeCom{
@@ -33,10 +33,11 @@ func TestNotificationWeCom_Unmarshal(t *testing.T) {
 					ApplyExisting: true,
 				},
 				WeComDetails: notification.WeComDetails{
-					BotKey: "abc123def456",
+					BotKey:              "abc123def456",
+					MentionedMobileList: "13800001111,13900002222,@all",
 				},
 			},
-			wantJSON: `{"active":true,"applyExisting":true,"id":1,"isDefault":true,"name":"My WeCom Alert","type":"WeCom","userId":1,"weComBotKey":"abc123def456"}`,
+			wantJSON: `{"active":true,"applyExisting":true,"id":1,"isDefault":true,"name":"My WeCom Alert","type":"WeCom","userId":1,"weComBotKey":"abc123def456","weComMentionedMobileList":"13800001111,13900002222,@all"}`,
 		},
 		{
 			name: "minimal",

--- a/notification_test.go
+++ b/notification_test.go
@@ -1100,7 +1100,8 @@ func TestNotificationCRUD(t *testing.T) {
 					Name:          "Test WeCom Created",
 				},
 				WeComDetails: notification.WeComDetails{
-					BotKey: "xxxx",
+					BotKey:              "xxxx",
+					MentionedMobileList: "13800001111,13900002222",
 				},
 			},
 			updateFunc: func(n notification.Notification) {
@@ -1111,6 +1112,7 @@ func TestNotificationCRUD(t *testing.T) {
 
 				wecom.Name = "Test WeCom Updated"
 				wecom.BotKey = "yyyy"
+				wecom.MentionedMobileList = "13911112222,@all"
 			},
 			verifyCreatedFunc: func(t *testing.T, actual notification.Notification, expected notification.Notification, id int64) {
 				t.Helper()


### PR DESCRIPTION
Adds the `weComMentionedMobileList` field added in upstream
[louislam/uptime-kuma#6758](https://github.com/louislam/uptime-kuma/pull/6758)
to the WeCom notification provider.

The field stores a comma-separated list of mobile numbers (and/or `@all`)
that should be `@mentioned` in the WeCom group chat message.

## Changes

- `notification/notification_wecom.go`: add `MentionedMobileList` field
  (JSON key `weComMentionedMobileList`, `omitempty`) to `WeComDetails`.
- `notification/notification_wecom_test.go`: extend round-trip test with
  the new field.
- `notification_test.go`: extend the WeCom CRUD integration test to set
  the field on create and modify it on update.

Closes #262