### PR TITLE
feat(notification): extend Matrix with customizable templates

### DIFF
--- a/notification/notification_matrix.go
+++ b/notification/notification_matrix.go
@@ -15,6 +15,8 @@ type MatrixDetails struct {
 	HomeserverURL  string `json:"homeserverUrl"`
 	InternalRoomID string `json:"internalRoomId"`
 	AccessToken    string `json:"accessToken"`
+	UseTemplate    bool   `json:"matrixUseTemplate"`
+	Template       string `json:"matrixTemplate"`
 }
 
 // Type returns the notification type.

--- a/notification/notification_matrix_test.go
+++ b/notification/notification_matrix_test.go
@@ -20,7 +20,7 @@ func TestNotificationMatrix_Unmarshal(t *testing.T) {
 		{
 			name: "success",
 			data: []byte(
-				`{"id":1,"name":"My Matrix Alert","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"My Matrix Alert\",\"homeserverUrl\":\"https://matrix.example.com\",\"internalRoomId\":\"!roomid:example.com\",\"accessToken\":\"syt_token_example\",\"type\":\"matrix\"}"}`,
+				`{"id":1,"name":"My Matrix Alert","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"My Matrix Alert\",\"homeserverUrl\":\"https://matrix.example.com\",\"internalRoomId\":\"!roomid:example.com\",\"accessToken\":\"syt_token_example\",\"matrixUseTemplate\":true,\"matrixTemplate\":\"Monitor: {{ monitorJSON.name }}\\nStatus: {{ status }}\",\"type\":\"matrix\"}"}`,
 			),
 
 			want: notification.Matrix{
@@ -36,14 +36,16 @@ func TestNotificationMatrix_Unmarshal(t *testing.T) {
 					HomeserverURL:  "https://matrix.example.com",
 					InternalRoomID: "!roomid:example.com",
 					AccessToken:    "syt_token_example",
+					UseTemplate:    true,
+					Template:       "Monitor: {{ monitorJSON.name }}\nStatus: {{ status }}",
 				},
 			},
-			wantJSON: `{"active":true,"applyExisting":true,"id":1,"isDefault":true,"name":"My Matrix Alert","homeserverUrl":"https://matrix.example.com","internalRoomId":"!roomid:example.com","accessToken":"syt_token_example","type":"matrix","userId":1}`,
+			wantJSON: `{"active":true,"applyExisting":true,"id":1,"isDefault":true,"name":"My Matrix Alert","homeserverUrl":"https://matrix.example.com","internalRoomId":"!roomid:example.com","accessToken":"syt_token_example","matrixUseTemplate":true,"matrixTemplate":"Monitor: {{ monitorJSON.name }}\nStatus: {{ status }}","type":"matrix","userId":1}`,
 		},
 		{
 			name: "minimal",
 			data: []byte(
-				`{"id":2,"name":"Simple Matrix","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Simple Matrix\",\"homeserverUrl\":\"https://matrix.org\",\"internalRoomId\":\"!room:matrix.org\",\"accessToken\":\"token\",\"type\":\"matrix\"}"}`,
+				`{"id":2,"name":"Simple Matrix","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Simple Matrix\",\"homeserverUrl\":\"https://matrix.org\",\"internalRoomId\":\"!room:matrix.org\",\"accessToken\":\"token\",\"matrixUseTemplate\":false,\"matrixTemplate\":\"\",\"type\":\"matrix\"}"}`,
 			),
 
 			want: notification.Matrix{
@@ -59,9 +61,11 @@ func TestNotificationMatrix_Unmarshal(t *testing.T) {
 					HomeserverURL:  "https://matrix.org",
 					InternalRoomID: "!room:matrix.org",
 					AccessToken:    "token",
+					UseTemplate:    false,
+					Template:       "",
 				},
 			},
-			wantJSON: `{"active":true,"applyExisting":false,"id":2,"isDefault":false,"name":"Simple Matrix","homeserverUrl":"https://matrix.org","internalRoomId":"!room:matrix.org","accessToken":"token","type":"matrix","userId":1}`,
+			wantJSON: `{"active":true,"applyExisting":false,"id":2,"isDefault":false,"name":"Simple Matrix","homeserverUrl":"https://matrix.org","internalRoomId":"!room:matrix.org","accessToken":"token","matrixUseTemplate":false,"matrixTemplate":"","type":"matrix","userId":1}`,
 		},
 	}
 

--- a/notification_test.go
+++ b/notification_test.go
@@ -993,6 +993,8 @@ func TestNotificationCRUD(t *testing.T) {
 					HomeserverURL:  "https://matrix.example.com",
 					InternalRoomID: "!roomid:example.com",
 					AccessToken:    "test_access_token",
+					UseTemplate:    false,
+					Template:       "",
 				},
 			},
 			updateFunc: func(n notification.Notification) {
@@ -1003,6 +1005,8 @@ func TestNotificationCRUD(t *testing.T) {
 
 				matrix.Name = "Test Matrix Updated"
 				matrix.InternalRoomID = "!newroomid:example.com"
+				matrix.UseTemplate = true
+				matrix.Template = "Monitor: {{ monitorJSON.name }}\nStatus: {{ status }}"
 			},
 			verifyCreatedFunc: func(t *testing.T, actual notification.Notification, expected notification.Notification, id int64) {
 				t.Helper()


### PR DESCRIPTION
Adds the `matrixUseTemplate` and `matrixTemplate` fields added in
upstream [louislam/uptime-kuma#6899](https://github.com/louislam/uptime-kuma/pull/6899)
to the Matrix notification provider.

When `matrixUseTemplate` is set, the upstream provider renders
`matrixTemplate` (with access to the monitor and heartbeat objects)
and uses the result as the message body sent to the Matrix room.

## Changes

- `notification/notification_matrix.go`: add `UseTemplate` (JSON key
  `matrixUseTemplate`) and `Template` (JSON key `matrixTemplate`)
  fields to `MatrixDetails`.
- `notification/notification_matrix_test.go`: extend round-trip test
  coverage with the new fields.
- `notification_test.go`: extend the Matrix CRUD integration test to
  exercise the new fields on create and update.

Closes #263