### PR TITLE
feat(notification): extend Teams with adaptive-card tags toggle

### DIFF
--- a/notification/notification_teams.go
+++ b/notification/notification_teams.go
@@ -13,6 +13,7 @@ type Teams struct {
 // TeamsDetails contains teams-specific notification configuration.
 type TeamsDetails struct {
 	WebhookURL string `json:"webhookUrl"`
+	EnableTags *bool  `json:"teamsEnableTags,omitempty"`
 }
 
 // Type returns the notification type.

--- a/notification/notification_teams_test.go
+++ b/notification/notification_teams_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/breml/go-uptime-kuma-client/internal/ptr"
 	"github.com/breml/go-uptime-kuma-client/notification"
 )
 
@@ -37,6 +38,50 @@ func TestNotificationTeams_Unmarshal(t *testing.T) {
 				},
 			},
 			wantJSON: `{"active":true,"applyExisting":true,"id":1,"isDefault":true,"name":"My Teams Alert","type":"teams","userId":1,"webhookUrl":"https://outlook.office.com/webhook/xxx"}`,
+		},
+		{
+			name: "with tags enabled",
+			data: []byte(
+				`{"id":2,"name":"Teams With Tags","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Teams With Tags\",\"webhookUrl\":\"https://outlook.office.com/webhook/yyy\",\"teamsEnableTags\":true,\"type\":\"teams\"}"}`,
+			),
+
+			want: notification.Teams{
+				Base: notification.Base{
+					ID:            2,
+					Name:          "Teams With Tags",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				TeamsDetails: notification.TeamsDetails{
+					WebhookURL: "https://outlook.office.com/webhook/yyy",
+					EnableTags: ptr.To(true),
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"id":2,"isDefault":false,"name":"Teams With Tags","teamsEnableTags":true,"type":"teams","userId":1,"webhookUrl":"https://outlook.office.com/webhook/yyy"}`,
+		},
+		{
+			name: "with tags explicitly disabled",
+			data: []byte(
+				`{"id":3,"name":"Teams Without Tags","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Teams Without Tags\",\"webhookUrl\":\"https://outlook.office.com/webhook/zzz\",\"teamsEnableTags\":false,\"type\":\"teams\"}"}`,
+			),
+
+			want: notification.Teams{
+				Base: notification.Base{
+					ID:            3,
+					Name:          "Teams Without Tags",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				TeamsDetails: notification.TeamsDetails{
+					WebhookURL: "https://outlook.office.com/webhook/zzz",
+					EnableTags: ptr.To(false),
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"id":3,"isDefault":false,"name":"Teams Without Tags","teamsEnableTags":false,"type":"teams","userId":1,"webhookUrl":"https://outlook.office.com/webhook/zzz"}`,
 		},
 	}
 


### PR DESCRIPTION
Adds the optional `teamsEnableTags` boolean to `TeamsDetails` so the Microsoft Teams notification provider can render monitor tags inside the adaptive card payload, matching the upstream change in louislam/uptime-kuma#6939.

## Changes

- Add `EnableTags *bool` field on `notification.TeamsDetails` with JSON tag `teamsEnableTags,omitempty`.
- Extend `notification_teams_test.go` with cases covering the toggle being enabled, explicitly disabled and absent.

Closes #264