### PR TITLE
feat(notification): extend AliyunSMS with optional parameters toggle

### DIFF
--- a/notification/notification_aliyunsms.go
+++ b/notification/notification_aliyunsms.go
@@ -12,11 +12,12 @@ type AliyunSMS struct {
 
 // AliyunSMSDetails contains the configuration fields for Aliyun SMS notifications.
 type AliyunSMSDetails struct {
-	AccessKeyID     string `json:"accessKeyId"`
-	SecretAccessKey string `json:"secretAccessKey"`
-	PhoneNumber     string `json:"phonenumber"`
-	SignName        string `json:"signName"`
-	TemplateCode    string `json:"templateCode"`
+	AccessKeyID        string `json:"accessKeyId"`
+	SecretAccessKey    string `json:"secretAccessKey"`
+	PhoneNumber        string `json:"phonenumber"`
+	SignName           string `json:"signName"`
+	TemplateCode       string `json:"templateCode"`
+	OptionalParameters *bool  `json:"optionalParameters,omitempty"`
 }
 
 // Type returns the notification type identifier.

--- a/notification/notification_aliyunsms_test.go
+++ b/notification/notification_aliyunsms_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/breml/go-uptime-kuma-client/internal/ptr"
 	"github.com/breml/go-uptime-kuma-client/notification"
 )
 
@@ -66,6 +67,58 @@ func TestNotificationAliyunSMS_Unmarshal(t *testing.T) {
 				},
 			},
 			wantJSON: `{"accessKeyId":"AKIA123","active":true,"applyExisting":false,"id":2,"isDefault":false,"name":"Simple Aliyun SMS","phonenumber":"8613800000002","secretAccessKey":"secret123","signName":"Alert","templateCode":"SMS_0000000001","type":"AliyunSMS","userId":1}`,
+		},
+		{
+			name: "with optional parameters enabled",
+			data: []byte(
+				`{"id":3,"name":"Aliyun SMS Optional","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Aliyun SMS Optional\",\"accessKeyId\":\"AKIA456\",\"secretAccessKey\":\"secret456\",\"phonenumber\":\"8613800000003\",\"signName\":\"Alert\",\"templateCode\":\"SMS_0000000002\",\"optionalParameters\":true,\"type\":\"AliyunSMS\"}"}`,
+			),
+
+			want: notification.AliyunSMS{
+				Base: notification.Base{
+					ID:            3,
+					Name:          "Aliyun SMS Optional",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				AliyunSMSDetails: notification.AliyunSMSDetails{
+					AccessKeyID:        "AKIA456",
+					SecretAccessKey:    "secret456",
+					PhoneNumber:        "8613800000003",
+					SignName:           "Alert",
+					TemplateCode:       "SMS_0000000002",
+					OptionalParameters: ptr.To(true),
+				},
+			},
+			wantJSON: `{"accessKeyId":"AKIA456","active":true,"applyExisting":false,"id":3,"isDefault":false,"name":"Aliyun SMS Optional","optionalParameters":true,"phonenumber":"8613800000003","secretAccessKey":"secret456","signName":"Alert","templateCode":"SMS_0000000002","type":"AliyunSMS","userId":1}`,
+		},
+		{
+			name: "with optional parameters disabled",
+			data: []byte(
+				`{"id":4,"name":"Aliyun SMS NoOptional","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Aliyun SMS NoOptional\",\"accessKeyId\":\"AKIA789\",\"secretAccessKey\":\"secret789\",\"phonenumber\":\"8613800000004\",\"signName\":\"Alert\",\"templateCode\":\"SMS_0000000003\",\"optionalParameters\":false,\"type\":\"AliyunSMS\"}"}`,
+			),
+
+			want: notification.AliyunSMS{
+				Base: notification.Base{
+					ID:            4,
+					Name:          "Aliyun SMS NoOptional",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				AliyunSMSDetails: notification.AliyunSMSDetails{
+					AccessKeyID:        "AKIA789",
+					SecretAccessKey:    "secret789",
+					PhoneNumber:        "8613800000004",
+					SignName:           "Alert",
+					TemplateCode:       "SMS_0000000003",
+					OptionalParameters: ptr.To(false),
+				},
+			},
+			wantJSON: `{"accessKeyId":"AKIA789","active":true,"applyExisting":false,"id":4,"isDefault":false,"name":"Aliyun SMS NoOptional","optionalParameters":false,"phonenumber":"8613800000004","secretAccessKey":"secret789","signName":"Alert","templateCode":"SMS_0000000003","type":"AliyunSMS","userId":1}`,
 		},
 	}
 


### PR DESCRIPTION
Add the `optionalParameters` field to `notification.AliyunSMSDetails` to mirror the upstream Aliyun SMS provider, which made the `msg` template variable optional and added IP/domain sanitization to comply with Chinese carrier restrictions on SMS template variables.

The field is modeled as `*bool` with `omitempty` so existing notifications without this field round-trip unchanged.

Closes #266