### PR TITLE
feat(notification): extend Evolution and Signal with template support

### DIFF
--- a/notification/notification_evolution.go
+++ b/notification/notification_evolution.go
@@ -21,6 +21,10 @@ type EvolutionDetails struct {
 	AuthToken string `json:"evolutionAuthToken"`
 	// Recipient is the recipient phone number for WhatsApp messages.
 	Recipient string `json:"evolutionRecipient"`
+	// UseCustomMessage enables the use of a custom message template.
+	UseCustomMessage *bool `json:"evolutionUseCustomMessage,omitempty"`
+	// CustomMessage is the custom message template used when UseCustomMessage is enabled.
+	CustomMessage *string `json:"evolutionCustomMessage,omitempty"`
 }
 
 // Type returns the notification type identifier for Evolution.

--- a/notification/notification_evolution_test.go
+++ b/notification/notification_evolution_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/breml/go-uptime-kuma-client/internal/ptr"
 	"github.com/breml/go-uptime-kuma-client/notification"
 )
 
@@ -88,6 +89,58 @@ func TestNotificationEvolution_Unmarshal(t *testing.T) {
 				},
 			},
 			wantJSON: `{"active":false,"applyExisting":false,"evolutionApiUrl":"https://custom.api.com","evolutionAuthToken":"ustoken","evolutionInstanceName":"usinstance","evolutionRecipient":"12025551234","id":3,"isDefault":false,"name":"Evolution US","type":"EvolutionApi","userId":1}`,
+		},
+		{
+			name: "with custom message template",
+			data: []byte(
+				`{"id":4,"name":"Evolution Template","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Evolution Template\",\"evolutionApiUrl\":\"https://evolapicloud.com\",\"evolutionInstanceName\":\"myinstance\",\"evolutionAuthToken\":\"token123\",\"evolutionRecipient\":\"5511999999999\",\"evolutionUseCustomMessage\":true,\"evolutionCustomMessage\":\"Alert: {{ msg }}\",\"type\":\"EvolutionApi\"}"}`,
+			),
+
+			want: notification.Evolution{
+				Base: notification.Base{
+					ID:            4,
+					Name:          "Evolution Template",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				EvolutionDetails: notification.EvolutionDetails{
+					APIURL:           "https://evolapicloud.com",
+					InstanceName:     "myinstance",
+					AuthToken:        "token123",
+					Recipient:        "5511999999999",
+					UseCustomMessage: ptr.To(true),
+					CustomMessage:    ptr.To("Alert: {{ msg }}"),
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"evolutionApiUrl":"https://evolapicloud.com","evolutionAuthToken":"token123","evolutionCustomMessage":"Alert: {{ msg }}","evolutionInstanceName":"myinstance","evolutionRecipient":"5511999999999","evolutionUseCustomMessage":true,"id":4,"isDefault":false,"name":"Evolution Template","type":"EvolutionApi","userId":1}`,
+		},
+		{
+			name: "pointer to false and empty string are serialized",
+			data: []byte(
+				`{"id":5,"name":"Evolution Explicit False","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Evolution Explicit False\",\"evolutionApiUrl\":\"https://evolapicloud.com\",\"evolutionInstanceName\":\"myinstance\",\"evolutionAuthToken\":\"token123\",\"evolutionRecipient\":\"5511999999999\",\"evolutionUseCustomMessage\":false,\"evolutionCustomMessage\":\"\",\"type\":\"EvolutionApi\"}"}`,
+			),
+
+			want: notification.Evolution{
+				Base: notification.Base{
+					ID:            5,
+					Name:          "Evolution Explicit False",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				EvolutionDetails: notification.EvolutionDetails{
+					APIURL:           "https://evolapicloud.com",
+					InstanceName:     "myinstance",
+					AuthToken:        "token123",
+					Recipient:        "5511999999999",
+					UseCustomMessage: ptr.To(false),
+					CustomMessage:    ptr.To(""),
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"evolutionApiUrl":"https://evolapicloud.com","evolutionAuthToken":"token123","evolutionCustomMessage":"","evolutionInstanceName":"myinstance","evolutionRecipient":"5511999999999","evolutionUseCustomMessage":false,"id":5,"isDefault":false,"name":"Evolution Explicit False","type":"EvolutionApi","userId":1}`,
 		},
 	}
 

--- a/notification/notification_signal.go
+++ b/notification/notification_signal.go
@@ -12,9 +12,11 @@ type Signal struct {
 
 // SignalDetails contains signal-specific notification configuration.
 type SignalDetails struct {
-	URL        string `json:"signalURL"`
-	Number     string `json:"signalNumber"`
-	Recipients string `json:"signalRecipients"`
+	URL         string  `json:"signalURL"`
+	Number      string  `json:"signalNumber"`
+	Recipients  string  `json:"signalRecipients"`
+	UseTemplate *bool   `json:"signalUseTemplate,omitempty"`
+	Template    *string `json:"signalTemplate,omitempty"`
 }
 
 // Type returns the notification type.

--- a/notification/notification_signal_test.go
+++ b/notification/notification_signal_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/breml/go-uptime-kuma-client/internal/ptr"
 	"github.com/breml/go-uptime-kuma-client/notification"
 )
 
@@ -84,6 +85,56 @@ func TestNotificationSignal_Unmarshal(t *testing.T) {
 				},
 			},
 			wantJSON: `{"active":true,"applyExisting":false,"id":3,"isDefault":false,"name":"Signal Multi","signalURL":"http://signal-api:9998","signalNumber":"+5555555555","signalRecipients":"+1111111111,+2222222222,+3333333333","type":"signal","userId":1}`,
+		},
+		{
+			name: "with template",
+			data: []byte(
+				`{"id":4,"name":"Signal Template","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Signal Template\",\"signalURL\":\"http://localhost:9998\",\"signalNumber\":\"+1234567890\",\"signalRecipients\":\"+9876543210\",\"signalUseTemplate\":true,\"signalTemplate\":\"Alert: {{ msg }}\",\"type\":\"signal\"}"}`,
+			),
+
+			want: notification.Signal{
+				Base: notification.Base{
+					ID:            4,
+					Name:          "Signal Template",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				SignalDetails: notification.SignalDetails{
+					URL:         "http://localhost:9998",
+					Number:      "+1234567890",
+					Recipients:  "+9876543210",
+					UseTemplate: ptr.To(true),
+					Template:    ptr.To("Alert: {{ msg }}"),
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"id":4,"isDefault":false,"name":"Signal Template","signalURL":"http://localhost:9998","signalNumber":"+1234567890","signalRecipients":"+9876543210","signalUseTemplate":true,"signalTemplate":"Alert: {{ msg }}","type":"signal","userId":1}`,
+		},
+		{
+			name: "pointer to false and empty string are serialized",
+			data: []byte(
+				`{"id":5,"name":"Signal Explicit False","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Signal Explicit False\",\"signalURL\":\"http://localhost:9998\",\"signalNumber\":\"+1234567890\",\"signalRecipients\":\"+9876543210\",\"signalUseTemplate\":false,\"signalTemplate\":\"\",\"type\":\"signal\"}"}`,
+			),
+
+			want: notification.Signal{
+				Base: notification.Base{
+					ID:            5,
+					Name:          "Signal Explicit False",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				SignalDetails: notification.SignalDetails{
+					URL:         "http://localhost:9998",
+					Number:      "+1234567890",
+					Recipients:  "+9876543210",
+					UseTemplate: ptr.To(false),
+					Template:    ptr.To(""),
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"id":5,"isDefault":false,"name":"Signal Explicit False","signalURL":"http://localhost:9998","signalNumber":"+1234567890","signalRecipients":"+9876543210","signalUseTemplate":false,"signalTemplate":"","type":"signal","userId":1}`,
 		},
 	}
 


### PR DESCRIPTION
Adds the optional template fields introduced upstream:

- **Evolution** (#7207): `evolutionUseCustomMessage` / `evolutionCustomMessage`
- **Signal** (#6989): `signalUseTemplate` / `signalTemplate`

Both fields use pointer types with `omitempty` to keep round-trip compatibility with older Uptime Kuma versions that do not emit them, mirroring the existing pattern in `SlackDetails`.

Round-trip test coverage was extended in both `notification_evolution_test.go` and `notification_signal_test.go`.

Closes #265