### PR TITLE
feat(notification): add SerwerSMS group messaging support

### DIFF
--- a/notification/notification_serwersms.go
+++ b/notification/notification_serwersms.go
@@ -17,10 +17,15 @@ type SerwerSMSDetails struct {
 	Username string `json:"serwersmsUsername"`
 	// Password is the SerwerSMS account password.
 	Password string `json:"serwersmsPassword"`
-	// PhoneNumber is the recipient phone number.
+	// PhoneNumber is the recipient phone number. Used when RecipientType is "number".
 	PhoneNumber string `json:"serwersmsPhoneNumber"`
 	// SenderName is the sender name or identifier.
 	SenderName string `json:"serwersmsSenderName"`
+	// RecipientType selects how the message recipient is addressed.
+	// Allowed values are "number" (default) and "group".
+	RecipientType string `json:"serwersmsRecipientType,omitempty"`
+	// GroupID is the SerwerSMS recipient group identifier. Used when RecipientType is "group".
+	GroupID string `json:"serwersmsGroupId,omitempty"`
 }
 
 // Type returns the notification type identifier for SerwerSMS.

--- a/notification/notification_serwersms_test.go
+++ b/notification/notification_serwersms_test.go
@@ -89,6 +89,57 @@ func TestNotificationSerwerSMS_Unmarshal(t *testing.T) {
 			},
 			wantJSON: `{"active":false,"applyExisting":false,"id":3,"isDefault":false,"name":"SerwerSMS International","serwersmsPassword":"intlpass","serwersmsPhoneNumber":"358501234567","serwersmsSenderName":"GlobalAlert","serwersmsUsername":"intluser","type":"serwersms","userId":1}`,
 		},
+		{
+			name: "with recipient type number",
+			data: []byte(
+				`{"id":4,"name":"SerwerSMS Number","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"SerwerSMS Number\",\"serwersmsUsername\":\"numuser\",\"serwersmsPassword\":\"numpass\",\"serwersmsPhoneNumber\":\"48111222333\",\"serwersmsSenderName\":\"NumAlert\",\"serwersmsRecipientType\":\"number\",\"type\":\"serwersms\"}"}`,
+			),
+
+			want: notification.SerwerSMS{
+				Base: notification.Base{
+					ID:            4,
+					Name:          "SerwerSMS Number",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				SerwerSMSDetails: notification.SerwerSMSDetails{
+					Username:      "numuser",
+					Password:      "numpass",
+					PhoneNumber:   "48111222333",
+					SenderName:    "NumAlert",
+					RecipientType: "number",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"id":4,"isDefault":false,"name":"SerwerSMS Number","serwersmsPassword":"numpass","serwersmsPhoneNumber":"48111222333","serwersmsRecipientType":"number","serwersmsSenderName":"NumAlert","serwersmsUsername":"numuser","type":"serwersms","userId":1}`,
+		},
+		{
+			name: "with recipient type group",
+			data: []byte(
+				`{"id":5,"name":"SerwerSMS Group","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"SerwerSMS Group\",\"serwersmsUsername\":\"grpuser\",\"serwersmsPassword\":\"grppass\",\"serwersmsPhoneNumber\":\"\",\"serwersmsSenderName\":\"GroupAlert\",\"serwersmsRecipientType\":\"group\",\"serwersmsGroupId\":\"42\",\"type\":\"serwersms\"}"}`,
+			),
+
+			want: notification.SerwerSMS{
+				Base: notification.Base{
+					ID:            5,
+					Name:          "SerwerSMS Group",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				SerwerSMSDetails: notification.SerwerSMSDetails{
+					Username:      "grpuser",
+					Password:      "grppass",
+					PhoneNumber:   "",
+					SenderName:    "GroupAlert",
+					RecipientType: "group",
+					GroupID:       "42",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"id":5,"isDefault":false,"name":"SerwerSMS Group","serwersmsGroupId":"42","serwersmsPassword":"grppass","serwersmsPhoneNumber":"","serwersmsRecipientType":"group","serwersmsSenderName":"GroupAlert","serwersmsUsername":"grpuser","type":"serwersms","userId":1}`,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Extend the SerwerSMS notification provider with the new `serwersmsRecipientType` and `serwersmsGroupId` fields introduced by upstream PR [louislam/uptime-kuma#6610](https://github.com/louislam/uptime-kuma/pull/6610).

The recipient can now be addressed either by phone number (default) or by SerwerSMS group ID.

## Changes
- Added `RecipientType` field (JSON: `serwersmsRecipientType`, `omitempty`) to `SerwerSMSDetails`.
- Added `GroupID` field (JSON: `serwersmsGroupId`, `omitempty`) to `SerwerSMSDetails`.
- Extended `notification_serwersms_test.go` with test cases for both `number` and `group` recipient modes.

Closes #267