### PR TITLE
Allows conditions to be set for DNS Monitors

### DIFF
--- a/monitor/monitor_base.go
+++ b/monitor/monitor_base.go
@@ -21,6 +21,14 @@ type Monitor interface {
 	GetNotificationIDs() []int64
 }
 
+type Conditions struct {
+	Type     string `json:"type"`
+	AndOr    string `json:"andOr"`
+	Variable string `json:"variable"`
+	Operator string `json:"operator"`
+	Value    string `json:"value"`
+}
+
 // Base contains the common fields for all monitor types.
 type Base struct {
 	ID              int64            `json:"id"`
@@ -37,6 +45,7 @@ type Base struct {
 	NotificationIDs []int64          `json:"-"`
 	Tags            []tag.MonitorTag `json:"tags"`
 	IsActive        bool             `json:"active"`
+	Conditions      []Conditions     `json:"conditions"`
 
 	internalType string
 	raw          []byte

--- a/monitor/monitor_base.go
+++ b/monitor/monitor_base.go
@@ -21,7 +21,7 @@ type Monitor interface {
 	GetNotificationIDs() []int64
 }
 
-type Conditions struct {
+type Condition struct {
 	Type     string `json:"type"`
 	AndOr    string `json:"andOr"`
 	Variable string `json:"variable"`
@@ -45,7 +45,7 @@ type Base struct {
 	NotificationIDs []int64          `json:"-"`
 	Tags            []tag.MonitorTag `json:"tags"`
 	IsActive        bool             `json:"active"`
-	Conditions      []Conditions     `json:"conditions"`
+	Conditions      []Condition     `json:"conditions"`
 
 	internalType string
 	raw          []byte

--- a/monitor/monitor_base.go
+++ b/monitor/monitor_base.go
@@ -21,14 +21,6 @@ type Monitor interface {
 	GetNotificationIDs() []int64
 }
 
-type Condition struct {
-	Type     string `json:"type"`
-	AndOr    string `json:"andOr"`
-	Variable string `json:"variable"`
-	Operator string `json:"operator"`
-	Value    string `json:"value"`
-}
-
 // Base contains the common fields for all monitor types.
 type Base struct {
 	ID              int64            `json:"id"`
@@ -45,7 +37,6 @@ type Base struct {
 	NotificationIDs []int64          `json:"-"`
 	Tags            []tag.MonitorTag `json:"tags"`
 	IsActive        bool             `json:"active"`
-	Conditions      []Condition     `json:"conditions"`
 
 	internalType string
 	raw          []byte

--- a/monitor/monitor_dns.go
+++ b/monitor/monitor_dns.go
@@ -78,8 +78,7 @@ func (d DNS) MarshalJSON() ([]byte, error) {
 	// Server expects these fields to be arrays and not null.
 	raw["accepted_statuscodes"] = []string{}
 
-	// Uptime Kuma v2 requires conditions field (empty array by default)
-	raw["conditions"] = []any{}
+	raw["conditions"] = d.Conditions
 
 	data, err := json.Marshal(raw)
 	if err != nil {

--- a/monitor/monitor_dns.go
+++ b/monitor/monitor_dns.go
@@ -78,7 +78,11 @@ func (d DNS) MarshalJSON() ([]byte, error) {
 	// Server expects these fields to be arrays and not null.
 	raw["accepted_statuscodes"] = []string{}
 
-	raw["conditions"] = d.Conditions
+	if d.Conditions == nil {
+		raw["conditions"] = []any{}
+	} else {
+		raw["conditions"] = d.Conditions
+	}
 
 	data, err := json.Marshal(raw)
 	if err != nil {

--- a/monitor/monitor_dns.go
+++ b/monitor/monitor_dns.go
@@ -92,6 +92,7 @@ func (d DNS) MarshalJSON() ([]byte, error) {
 	return data, nil
 }
 
+// Condition carries the information that allow setting a condition on the monitor.
 type Condition struct {
 	Type     string `json:"type"`
 	AndOr    string `json:"andOr"`

--- a/monitor/monitor_dns.go
+++ b/monitor/monitor_dns.go
@@ -88,12 +88,21 @@ func (d DNS) MarshalJSON() ([]byte, error) {
 	return data, nil
 }
 
+type Condition struct {
+	Type     string `json:"type"`
+	AndOr    string `json:"andOr"`
+	Variable string `json:"variable"`
+	Operator string `json:"operator"`
+	Value    string `json:"value"`
+}
+
 // DNSDetails contains DNS-specific monitor configuration.
 type DNSDetails struct {
 	Hostname       string         `json:"hostname"`
 	ResolverServer string         `json:"dns_resolve_server"`
 	ResolveType    DNSResolveType `json:"dns_resolve_type"`
 	Port           int            `json:"port"`
+	Conditions     []Condition    `json:"conditions"`
 }
 
 // Type returns the monitor type.


### PR DESCRIPTION
This allows monitoring the response value of a CNAME or TXT record.

```golang
				&monitor.DNS{
					Base: monitor.Base{
						Name:          monitorName,
						Interval:      300,
						RetryInterval: 10,
						IsActive:      true,
					},
					DNSDetails: monitor.DNSDetails{
						ResolveType:    monitor.DNSResolveTypeCNAME,
						ResolverServer: "9.9.9.9,149.112.112.112",
						Hostname:       domainName,
						Conditions: []monitor.Condition{{
							Type:     "expression",
							AndOr:    "and",
							Variable: "record",
							Operator: "equals",
							Value:    record.CNAME.Target,
						}},
					}
```