### PR TITLE
feat(notification): expose webhook `HTTPMethod` field

### DIFF
--- a/notification/notification_webhook.go
+++ b/notification/notification_webhook.go
@@ -15,6 +15,7 @@ type Webhook struct {
 // WebhookDetails contains the webhook-specific configuration.
 type WebhookDetails struct {
 	WebhookURL               string                   `json:"webhookURL"`
+	HTTPMethod               string                   `json:"httpMethod,omitempty"`
 	WebhookContentType       string                   `json:"webhookContentType"`
 	WebhookCustomBody        string                   `json:"webhookCustomBody,omitempty"`
 	WebhookAdditionalHeaders WebhookAdditionalHeaders `json:"webhookAdditionalHeaders,omitempty"`

--- a/notification/notification_webhook_test.go
+++ b/notification/notification_webhook_test.go
@@ -111,14 +111,82 @@ func TestNotificationWebhook_Unmarshal(t *testing.T) {
 			wantJSON: `{"active":true,"applyExisting":false,"id":4,"isDefault":false,"name":"Webhook Headers","type":"webhook","userId":1,"webhookContentType":"json","webhookAdditionalHeaders":"{\"Authorization\":\"Bearer secret-token\",\"X-App-ID\":\"uptime-kuma\"}","webhookURL":"https://api.example.com/notify"}`,
 		},
 		{
-			name: "all features combined",
+			name: "explicit post http method",
 			data: []byte(
-				`{"id":5,"name":"Webhook Full","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"Webhook Full\",\"webhookURL\":\"https://alerts.example.com/v1/webhook\",\"webhookContentType\":\"custom\",\"webhookCustomBody\":\"{\\\"event\\\": \\\"{{ msg }}\\\", \\\"service\\\": \\\"{{ monitorJSON['name'] }}\\\"}\",\"webhookAdditionalHeaders\":\"{\\\"Authorization\\\":\\\"Bearer xyz123\\\",\\\"Content-Type\\\":\\\"application/json\\\",\\\"X-Custom-Header\\\":\\\"custom-value\\\"}\",\"type\":\"webhook\"}"}`,
+				`{"id":5,"name":"Webhook POST","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Webhook POST\",\"webhookURL\":\"https://example.com/webhook\",\"httpMethod\":\"post\",\"webhookContentType\":\"json\",\"type\":\"webhook\"}"}`,
 			),
 
 			want: notification.Webhook{
 				Base: notification.Base{
 					ID:            5,
+					Name:          "Webhook POST",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				WebhookDetails: notification.WebhookDetails{
+					WebhookURL:         "https://example.com/webhook",
+					HTTPMethod:         "post",
+					WebhookContentType: "json",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"id":5,"isDefault":false,"name":"Webhook POST","type":"webhook","userId":1,"httpMethod":"post","webhookContentType":"json","webhookURL":"https://example.com/webhook"}`,
+		},
+		{
+			name: "get http method",
+			data: []byte(
+				`{"id":6,"name":"Webhook GET","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Webhook GET\",\"webhookURL\":\"https://example.com/webhook\",\"httpMethod\":\"get\",\"webhookContentType\":\"json\",\"type\":\"webhook\"}"}`,
+			),
+
+			want: notification.Webhook{
+				Base: notification.Base{
+					ID:            6,
+					Name:          "Webhook GET",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				WebhookDetails: notification.WebhookDetails{
+					WebhookURL:         "https://example.com/webhook",
+					HTTPMethod:         "get",
+					WebhookContentType: "json",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"id":6,"isDefault":false,"name":"Webhook GET","type":"webhook","userId":1,"httpMethod":"get","webhookContentType":"json","webhookURL":"https://example.com/webhook"}`,
+		},
+		{
+			name: "legacy entry without http method",
+			data: []byte(
+				`{"id":7,"name":"Webhook Legacy","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Webhook Legacy\",\"webhookURL\":\"https://example.com/webhook\",\"webhookContentType\":\"json\",\"type\":\"webhook\"}"}`,
+			),
+
+			want: notification.Webhook{
+				Base: notification.Base{
+					ID:            7,
+					Name:          "Webhook Legacy",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				WebhookDetails: notification.WebhookDetails{
+					WebhookURL:         "https://example.com/webhook",
+					WebhookContentType: "json",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"id":7,"isDefault":false,"name":"Webhook Legacy","type":"webhook","userId":1,"webhookContentType":"json","webhookURL":"https://example.com/webhook"}`,
+		},
+		{
+			name: "all features combined",
+			data: []byte(
+				`{"id":8,"name":"Webhook Full","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"Webhook Full\",\"webhookURL\":\"https://alerts.example.com/v1/webhook\",\"httpMethod\":\"post\",\"webhookContentType\":\"custom\",\"webhookCustomBody\":\"{\\\"event\\\": \\\"{{ msg }}\\\", \\\"service\\\": \\\"{{ monitorJSON['name'] }}\\\"}\",\"webhookAdditionalHeaders\":\"{\\\"Authorization\\\":\\\"Bearer xyz123\\\",\\\"Content-Type\\\":\\\"application/json\\\",\\\"X-Custom-Header\\\":\\\"custom-value\\\"}\",\"type\":\"webhook\"}"}`,
+			),
+
+			want: notification.Webhook{
+				Base: notification.Base{
+					ID:            8,
 					Name:          "Webhook Full",
 					IsActive:      true,
 					UserID:        1,
@@ -127,6 +195,7 @@ func TestNotificationWebhook_Unmarshal(t *testing.T) {
 				},
 				WebhookDetails: notification.WebhookDetails{
 					WebhookURL:         "https://alerts.example.com/v1/webhook",
+					HTTPMethod:         "post",
 					WebhookContentType: "custom",
 					WebhookCustomBody:  `{"event": "{{ msg }}", "service": "{{ monitorJSON['name'] }}"}`,
 					WebhookAdditionalHeaders: notification.WebhookAdditionalHeaders{
@@ -136,7 +205,7 @@ func TestNotificationWebhook_Unmarshal(t *testing.T) {
 					},
 				},
 			},
-			wantJSON: `{"active":true,"applyExisting":true,"id":5,"isDefault":true,"name":"Webhook Full","type":"webhook","userId":1,"webhookContentType":"custom","webhookCustomBody":"{\"event\": \"{{ msg }}\", \"service\": \"{{ monitorJSON['name'] }}\"}","webhookAdditionalHeaders":"{\"Authorization\":\"Bearer xyz123\",\"Content-Type\":\"application/json\",\"X-Custom-Header\":\"custom-value\"}","webhookURL":"https://alerts.example.com/v1/webhook"}`,
+			wantJSON: `{"active":true,"applyExisting":true,"id":8,"isDefault":true,"name":"Webhook Full","type":"webhook","userId":1,"httpMethod":"post","webhookContentType":"custom","webhookCustomBody":"{\"event\": \"{{ msg }}\", \"service\": \"{{ monitorJSON['name'] }}\"}","webhookAdditionalHeaders":"{\"Authorization\":\"Bearer xyz123\",\"Content-Type\":\"application/json\",\"X-Custom-Header\":\"custom-value\"}","webhookURL":"https://alerts.example.com/v1/webhook"}`,
 		},
 	}
 

--- a/notification_test.go
+++ b/notification_test.go
@@ -213,6 +213,7 @@ func TestNotificationCRUD(t *testing.T) {
 				},
 				WebhookDetails: notification.WebhookDetails{
 					WebhookURL:         "https://example.com/webhook",
+					HTTPMethod:         "post",
 					WebhookContentType: "json",
 				},
 			},
@@ -223,6 +224,7 @@ func TestNotificationCRUD(t *testing.T) {
 				}
 
 				webhook.Name = "Test Webhook Updated"
+				webhook.HTTPMethod = "get"
 				webhook.WebhookContentType = "custom"
 				webhook.WebhookCustomBody = `{"title": "Alert - {{ monitorJSON['name'] }}", "message": "{{ msg }}"}`
 				webhook.WebhookAdditionalHeaders = notification.WebhookAdditionalHeaders{


### PR DESCRIPTION
## Summary

Adds the `HTTPMethod` field (JSON tag `httpMethod`) to `notification.WebhookDetails` so that the upstream webhook HTTP method (`post`/`get`) is preserved on round-trip.

The field uses `omitempty`, so legacy webhook entries that pre-date upstream PR louislam/uptime-kuma#6650 (where `httpMethod` was undefined) continue to deserialize and serialize unchanged.

## Verification against upstream

- `.scratch/uptime-kuma/server/notification-providers/webhook.js` reads `notification.httpMethod?.toLowerCase() || "post"`.
- `.scratch/uptime-kuma/src/components/notifications/Webhook.vue` binds `$parent.notification.httpMethod` with options `post` and `get`.

## Tests

- New unit-test cases in `notification/notification_webhook_test.go` covering explicit `post`, explicit `get`, legacy entries without `httpMethod`, and the "all features combined" round-trip.
- Integration test `TestNotificationCRUD/Webhook` in `notification_test.go` now creates with `HTTPMethod: "post"` and updates to `get`.

Closes #270