### PR TITLE
feat(notification): add SMTP `IgnoreSTARTTLS` field

### DIFF
--- a/notification/notification_smtp.go
+++ b/notification/notification_smtp.go
@@ -15,6 +15,7 @@ type SMTPDetails struct {
 	Host                 string `json:"smtpHost"`
 	Port                 int    `json:"smtpPort"`
 	Secure               bool   `json:"smtpSecure"`
+	IgnoreSTARTTLS       bool   `json:"smtpIgnoreSTARTTLS"`
 	IgnoreTLSError       bool   `json:"smtpIgnoreTLSError"`
 	DkimDomain           string `json:"smtpDkimDomain"`
 	DkimKeySelector      string `json:"smtpDkimKeySelector"`

--- a/notification/notification_smtp_test.go
+++ b/notification/notification_smtp_test.go
@@ -44,7 +44,7 @@ func TestNotificationSMTP_Unmarshal(t *testing.T) {
 					HTMLBody:       true,
 				},
 			},
-			wantJSON: `{"active":true,"applyExisting":true,"customBody":"Status: {{ msg }}","customSubject":"Alert: {{ monitorJSON['name'] }}","htmlBody":true,"id":1,"isDefault":true,"name":"My SMTP Alert","smtpCC":"","smtpBCC":"","smtpDkimDomain":"","smtpDkimHashAlgo":"","smtpDkimKeySelector":"","smtpDkimPrivateKey":"","smtpDkimheaderFieldNames":"","smtpDkimskipFields":"","smtpFrom":"noreply@example.com","smtpHost":"smtp.gmail.com","smtpIgnoreTLSError":false,"smtpPassword":"","smtpPort":587,"smtpSecure":false,"smtpTo":"alerts@example.com","smtpUsername":"","type":"smtp","userId":1}`,
+			wantJSON: `{"active":true,"applyExisting":true,"customBody":"Status: {{ msg }}","customSubject":"Alert: {{ monitorJSON['name'] }}","htmlBody":true,"id":1,"isDefault":true,"name":"My SMTP Alert","smtpCC":"","smtpBCC":"","smtpDkimDomain":"","smtpDkimHashAlgo":"","smtpDkimKeySelector":"","smtpDkimPrivateKey":"","smtpDkimheaderFieldNames":"","smtpDkimskipFields":"","smtpFrom":"noreply@example.com","smtpHost":"smtp.gmail.com","smtpIgnoreSTARTTLS":false,"smtpIgnoreTLSError":false,"smtpPassword":"","smtpPort":587,"smtpSecure":false,"smtpTo":"alerts@example.com","smtpUsername":"","type":"smtp","userId":1}`,
 		},
 		{
 			name: "with authentication and DKIM",
@@ -79,7 +79,35 @@ func TestNotificationSMTP_Unmarshal(t *testing.T) {
 					HTMLBody:        false,
 				},
 			},
-			wantJSON: `{"active":true,"applyExisting":false,"customBody":"","customSubject":"","htmlBody":false,"id":2,"isDefault":false,"name":"SMTP with Auth","smtpBCC":"bcc@example.com","smtpCC":"cc@example.com","smtpDkimDomain":"example.com","smtpDkimHashAlgo":"sha256","smtpDkimKeySelector":"default","smtpDkimPrivateKey":"-----BEGIN RSA PRIVATE KEY-----\n...","smtpDkimheaderFieldNames":"","smtpDkimskipFields":"","smtpFrom":"sender@example.com","smtpHost":"smtp.example.com","smtpIgnoreTLSError":true,"smtpPassword":"secret","smtpPort":587,"smtpSecure":true,"smtpTo":"recipient@example.com","smtpUsername":"user@example.com","type":"smtp","userId":1}`,
+			wantJSON: `{"active":true,"applyExisting":false,"customBody":"","customSubject":"","htmlBody":false,"id":2,"isDefault":false,"name":"SMTP with Auth","smtpBCC":"bcc@example.com","smtpCC":"cc@example.com","smtpDkimDomain":"example.com","smtpDkimHashAlgo":"sha256","smtpDkimKeySelector":"default","smtpDkimPrivateKey":"-----BEGIN RSA PRIVATE KEY-----\n...","smtpDkimheaderFieldNames":"","smtpDkimskipFields":"","smtpFrom":"sender@example.com","smtpHost":"smtp.example.com","smtpIgnoreSTARTTLS":false,"smtpIgnoreTLSError":true,"smtpPassword":"secret","smtpPort":587,"smtpSecure":true,"smtpTo":"recipient@example.com","smtpUsername":"user@example.com","type":"smtp","userId":1}`,
+		},
+		{
+			name: "with STARTTLS disabled",
+			data: []byte(
+				`{"id":3,"name":"SMTP No STARTTLS","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"SMTP No STARTTLS\",\"smtpHost\":\"legacy.example.com\",\"smtpPort\":25,\"smtpSecure\":false,\"smtpIgnoreSTARTTLS\":true,\"smtpIgnoreTLSError\":false,\"smtpFrom\":\"sender@example.com\",\"smtpTo\":\"recipient@example.com\",\"htmlBody\":false,\"type\":\"smtp\"}"}`,
+			),
+
+			want: notification.SMTP{
+				Base: notification.Base{
+					ID:            3,
+					Name:          "SMTP No STARTTLS",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				SMTPDetails: notification.SMTPDetails{
+					Host:           "legacy.example.com",
+					Port:           25,
+					Secure:         false,
+					IgnoreSTARTTLS: true,
+					IgnoreTLSError: false,
+					From:           "sender@example.com",
+					To:             "recipient@example.com",
+					HTMLBody:       false,
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"customBody":"","customSubject":"","htmlBody":false,"id":3,"isDefault":false,"name":"SMTP No STARTTLS","smtpBCC":"","smtpCC":"","smtpDkimDomain":"","smtpDkimHashAlgo":"","smtpDkimKeySelector":"","smtpDkimPrivateKey":"","smtpDkimheaderFieldNames":"","smtpDkimskipFields":"","smtpFrom":"sender@example.com","smtpHost":"legacy.example.com","smtpIgnoreSTARTTLS":true,"smtpIgnoreTLSError":false,"smtpPassword":"","smtpPort":25,"smtpSecure":false,"smtpTo":"recipient@example.com","smtpUsername":"","type":"smtp","userId":1}`,
 		},
 	}
 

--- a/notification_test.go
+++ b/notification_test.go
@@ -295,7 +295,8 @@ func TestNotificationCRUD(t *testing.T) {
 				smtp.Password = "secretpassword"
 				smtp.CC = "cc@example.com"
 				smtp.BCC = "bcc@example.com"
-				smtp.Secure = true
+				smtp.Secure = false
+				smtp.IgnoreSTARTTLS = true
 			},
 			verifyCreatedFunc: func(t *testing.T, actual notification.Notification, expected notification.Notification, id int64) {
 				t.Helper()


### PR DESCRIPTION
## Summary

Expose the upstream `smtpIgnoreSTARTTLS` option (added in [louislam/uptime-kuma#6770](https://github.com/louislam/uptime-kuma/pull/6770)) on the SMTP **notification provider**, so users can configure SMTP servers that do not support STARTTLS.

## Note on scope

Issue #257 originally targeted the SMTP **monitor**, but the referenced upstream PR actually changed the SMTP **notification provider** (`server/notification-providers/smtp.js`). The SMTP monitor in `server/monitor-types/smtp.js` already supports disabling STARTTLS via `smtpSecurity: "nostarttls"`, which is already implemented in `monitor/monitor_smtp.go` and covered by tests.

This PR therefore implements the missing `smtpIgnoreSTARTTLS` field on the notification side, matching the upstream change.

## Changes

- Added `IgnoreSTARTTLS bool` (`json:"smtpIgnoreSTARTTLS"`) to `notification.SMTPDetails`.
- Extended round-trip tests in `notification/notification_smtp_test.go` (new "with STARTTLS disabled" case + updated existing `wantJSON` for the new field).
- Updated `TestNotificationCRUD/SMTP` in `notification_test.go` to exercise `IgnoreSTARTTLS = true` against a live Uptime Kuma instance.

Closes #257