### PR TITLE
feat(monitor): expose TCP/Port monitor TLS / cert-expiry fields

### DIFF
--- a/monitor/monitor_tcp_port.go
+++ b/monitor/monitor_tcp_port.go
@@ -72,6 +72,9 @@ func (t TCPPort) MarshalJSON() ([]byte, error) {
 	// Always override with current TCP Port-specific field values.
 	raw["hostname"] = t.Hostname
 	raw["port"] = t.Port
+	raw["smtpSecurity"] = t.SMTPSecurity
+	raw["expiryNotification"] = t.ExpiryNotification
+	raw["expectedTlsAlert"] = t.ExpectedTLSAlert
 
 	// Server expects these fields to be arrays and not null.
 	raw["accepted_statuscodes"] = []string{}
@@ -91,6 +94,18 @@ func (t TCPPort) MarshalJSON() ([]byte, error) {
 type TCPPortDetails struct {
 	Hostname string `json:"hostname"`
 	Port     int    `json:"port"`
+	// SMTPSecurity selects the TLS mode used to validate the certificate
+	// presented on the port ("nostarttls", "secure" or "starttls"). Leave
+	// nil/unset to perform a plain TCP check without a TLS handshake.
+	SMTPSecurity *string `json:"smtpSecurity"`
+	// ExpiryNotification enables certificate expiry notifications. It is
+	// only honoured by the upstream server when SMTPSecurity is set to
+	// "secure" or "starttls".
+	ExpiryNotification bool `json:"expiryNotification"`
+	// ExpectedTLSAlert is the TLS alert name that the server is expected
+	// to return during the handshake (e.g. "certificate_required" for
+	// mTLS verification). Leave nil/unset for a successful TLS handshake.
+	ExpectedTLSAlert *string `json:"expectedTlsAlert"`
 }
 
 // Type returns the monitor type.

--- a/monitor/monitor_tcp_port.go
+++ b/monitor/monitor_tcp_port.go
@@ -94,9 +94,12 @@ func (t TCPPort) MarshalJSON() ([]byte, error) {
 type TCPPortDetails struct {
 	Hostname string `json:"hostname"`
 	Port     int    `json:"port"`
-	// SMTPSecurity selects the TLS mode used to validate the certificate
-	// presented on the port ("nostarttls", "secure" or "starttls"). Leave
-	// nil/unset to perform a plain TCP check without a TLS handshake.
+	// SMTPSecurity selects the TLS handshake mode used by the port
+	// monitor. Valid values are "nostarttls" (plain TCP, no TLS handshake
+	// or certificate validation), "secure" (immediate TLS handshake) and
+	// "starttls" (negotiate TLS via STARTTLS). Only "secure" and
+	// "starttls" perform a TLS handshake and certificate validation.
+	// Leave nil/unset to fall back to a plain TCP check.
 	SMTPSecurity *string `json:"smtpSecurity"`
 	// ExpiryNotification enables certificate expiry notifications. It is
 	// only honoured by the upstream server when SMTPSecurity is set to

--- a/monitor/monitor_tcp_port_test.go
+++ b/monitor/monitor_tcp_port_test.go
@@ -23,7 +23,7 @@ func TestMonitorTCPPort_Unmarshal(t *testing.T) {
 		{
 			name: "success",
 			data: []byte(
-				`{"id":4,"name":"tcp-port-monitor","description":"Test TCP Port monitor","pathName":"group / tcp-port-monitor","parent":1,"childrenIDs":[],"url":null,"method":"GET","hostname":"example.com","port":8080,"maxretries":2,"weight":2000,"active":true,"forceInactive":false,"type":"port","timeout":48,"interval":60,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":"A","dns_resolve_server":"1.1.1.1","dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{"1":true,"2":true},"tags":[],"maintenance":false,"mqttTopic":"","mqttSuccessMessage":"","databaseQuery":null,"authMethod":null,"grpcUrl":null,"grpcProtobuf":null,"grpcMethod":null,"grpcServiceName":null,"grpcEnableTls":false,"radiusCalledStationId":null,"radiusCallingStationId":null,"game":null,"gamedigGivenPortOnly":true,"httpBodyEncoding":"json","jsonPath":null,"expectedValue":null,"kafkaProducerTopic":null,"kafkaProducerBrokers":[],"kafkaProducerSsl":false,"kafkaProducerAllowAutoTopicCreation":false,"kafkaProducerMessage":null,"screenshot":null,"headers":null,"body":null,"grpcBody":null,"grpcMetadata":null,"basic_auth_user":null,"basic_auth_pass":null,"oauth_client_id":null,"oauth_client_secret":null,"oauth_token_url":null,"oauth_scopes":null,"oauth_auth_method":"client_secret_basic","pushToken":null,"databaseConnectionString":null,"radiusUsername":null,"radiusPassword":null,"radiusSecret":null,"mqttUsername":"","mqttPassword":"","authWorkstation":null,"authDomain":null,"tlsCa":null,"tlsCert":null,"tlsKey":null,"kafkaProducerSaslOptions":{"mechanism":"None"},"includeSensitiveData":true}`,
+				`{"id":4,"name":"tcp-port-monitor","description":"Test TCP Port monitor","pathName":"group / tcp-port-monitor","parent":1,"childrenIDs":[],"url":null,"method":"GET","hostname":"example.com","port":8080,"maxretries":2,"weight":2000,"active":true,"forceInactive":false,"type":"port","timeout":48,"interval":60,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":"A","dns_resolve_server":"1.1.1.1","dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{"1":true,"2":true},"tags":[],"maintenance":false,"mqttTopic":"","mqttSuccessMessage":"","databaseQuery":null,"authMethod":null,"grpcUrl":null,"grpcProtobuf":null,"grpcMethod":null,"grpcServiceName":null,"grpcEnableTls":false,"radiusCalledStationId":null,"radiusCallingStationId":null,"game":null,"gamedigGivenPortOnly":true,"httpBodyEncoding":"json","jsonPath":null,"expectedValue":null,"kafkaProducerTopic":null,"kafkaProducerBrokers":[],"kafkaProducerSsl":false,"kafkaProducerAllowAutoTopicCreation":false,"kafkaProducerMessage":null,"screenshot":null,"headers":null,"body":null,"grpcBody":null,"grpcMetadata":null,"basic_auth_user":null,"basic_auth_pass":null,"oauth_client_id":null,"oauth_client_secret":null,"oauth_token_url":null,"oauth_scopes":null,"oauth_auth_method":"client_secret_basic","pushToken":null,"databaseConnectionString":null,"radiusUsername":null,"radiusPassword":null,"radiusSecret":null,"mqttUsername":"","mqttPassword":"","authWorkstation":null,"authDomain":null,"tlsCa":null,"tlsCert":null,"tlsKey":null,"kafkaProducerSaslOptions":{"mechanism":"None"},"includeSensitiveData":true,"smtpSecurity":null,"expectedTlsAlert":null}`,
 			),
 
 			want: monitor.TCPPort{
@@ -46,7 +46,36 @@ func TestMonitorTCPPort_Unmarshal(t *testing.T) {
 					Port:     8080,
 				},
 			},
-			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":"Test TCP Port monitor","hostname":"example.com","id":4,"interval":60,"maxretries":2,"name":"tcp-port-monitor","notificationIDList":{"1":true,"2":true},"parent":1,"port":8080,"resendInterval":0,"retryInterval":60,"type":"port","upsideDown":false}`,
+			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":"Test TCP Port monitor","expectedTlsAlert":null,"expiryNotification":false,"hostname":"example.com","id":4,"interval":60,"maxretries":2,"name":"tcp-port-monitor","notificationIDList":{"1":true,"2":true},"parent":1,"port":8080,"resendInterval":0,"retryInterval":60,"smtpSecurity":null,"type":"port","upsideDown":false}`,
+		},
+		{
+			name: "with TLS fields",
+			data: []byte(
+				`{"id":5,"name":"tcp-tls-monitor","description":"TCP monitor with TLS","pathName":"tcp-tls-monitor","parent":null,"hostname":"smtp.example.com","port":465,"maxretries":3,"active":true,"type":"port","interval":120,"retryInterval":60,"resendInterval":0,"upsideDown":false,"smtpSecurity":"secure","expiryNotification":true,"expectedTlsAlert":"certificate_required","notificationIDList":{},"accepted_statuscodes":["200-299"]}`,
+			),
+
+			want: monitor.TCPPort{
+				Base: monitor.Base{
+					ID:             5,
+					Name:           "tcp-tls-monitor",
+					Description:    ptr.To("TCP monitor with TLS"),
+					PathName:       "tcp-tls-monitor",
+					Interval:       120,
+					RetryInterval:  60,
+					ResendInterval: 0,
+					MaxRetries:     3,
+					UpsideDown:     false,
+					IsActive:       true,
+				},
+				TCPPortDetails: monitor.TCPPortDetails{
+					Hostname:           "smtp.example.com",
+					Port:               465,
+					SMTPSecurity:       ptr.To("secure"),
+					ExpiryNotification: true,
+					ExpectedTLSAlert:   ptr.To("certificate_required"),
+				},
+			},
+			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":"TCP monitor with TLS","expectedTlsAlert":"certificate_required","expiryNotification":true,"hostname":"smtp.example.com","id":5,"interval":120,"maxretries":3,"name":"tcp-tls-monitor","notificationIDList":{},"parent":null,"port":465,"resendInterval":0,"retryInterval":60,"smtpSecurity":"secure","type":"port","upsideDown":false}`,
 		},
 	}
 

--- a/monitor_test.go
+++ b/monitor_test.go
@@ -260,7 +260,7 @@ func TestMonitorCRUD(t *testing.T) {
 
 				tcp.Name = "Updated TCP Port Monitor"
 				tcp.Hostname = "cloudflare.com"
-				tcp.Port = 443
+				tcp.Port = 465
 				tcp.SMTPSecurity = ptr.To("secure")
 				tcp.ExpiryNotification = true
 				tcp.ExpectedTLSAlert = ptr.To("certificate_required")
@@ -287,7 +287,7 @@ func TestMonitorCRUD(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, "Updated TCP Port Monitor", tcp.Name)
 				require.Equal(t, "cloudflare.com", tcp.Hostname)
-				require.Equal(t, 443, tcp.Port)
+				require.Equal(t, 465, tcp.Port)
 				require.NotNil(t, tcp.SMTPSecurity)
 				require.Equal(t, "secure", *tcp.SMTPSecurity)
 				require.True(t, tcp.ExpiryNotification)

--- a/monitor_test.go
+++ b/monitor_test.go
@@ -260,7 +260,10 @@ func TestMonitorCRUD(t *testing.T) {
 
 				tcp.Name = "Updated TCP Port Monitor"
 				tcp.Hostname = "cloudflare.com"
-				tcp.Port = 80
+				tcp.Port = 443
+				tcp.SMTPSecurity = ptr.To("secure")
+				tcp.ExpiryNotification = true
+				tcp.ExpectedTLSAlert = ptr.To("certificate_required")
 			},
 			verifyCreatedFunc: func(t *testing.T, actual monitor.Monitor, id int64) {
 				t.Helper()
@@ -284,7 +287,12 @@ func TestMonitorCRUD(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, "Updated TCP Port Monitor", tcp.Name)
 				require.Equal(t, "cloudflare.com", tcp.Hostname)
-				require.Equal(t, 80, tcp.Port)
+				require.Equal(t, 443, tcp.Port)
+				require.NotNil(t, tcp.SMTPSecurity)
+				require.Equal(t, "secure", *tcp.SMTPSecurity)
+				require.True(t, tcp.ExpiryNotification)
+				require.NotNil(t, tcp.ExpectedTLSAlert)
+				require.Equal(t, "certificate_required", *tcp.ExpectedTLSAlert)
 			},
 			testPauseResume: true,
 		},


### PR DESCRIPTION
Extends `monitor.TCPPortDetails` with the TLS-related fields the
upstream Uptime Kuma server now accepts on the `port` monitor type:

- `SMTPSecurity` (`smtpSecurity`) selects the TLS handshake mode
  (`nostarttls`, `secure` or `starttls`).
- `ExpiryNotification` (`expiryNotification`) toggles certificate
  expiry notifications.
- `ExpectedTLSAlert` (`expectedTlsAlert`) holds the expected TLS
  alert name for mTLS / cert verification scenarios.

Note: the JSON keys used by upstream differ from the field names
listed in the issue checklist (`tlsMonitor`, `certExpiryNotification`,
`checkTlsRevoke`); those keys do not exist in the upstream port
monitor. The implementation follows the issue's instruction to
"keep names consistent with upstream JSON keys" and uses the
actual upstream identifiers verified against
`.scratch/uptime-kuma/server/monitor-types/tcp.js`,
`server/server.js` and `src/pages/EditMonitor.vue`.

Tests cover the JSON marshal/unmarshal round-trip plus the
end-to-end CRUD flow against a live Uptime Kuma container.

Closes #250