### PR TITLE
feat(monitor): add `RetryOnlyOnStatusCodeFailure` to JSON-Query monitor

### DIFF
--- a/monitor/monitor_http_json_query.go
+++ b/monitor/monitor_http_json_query.go
@@ -113,6 +113,7 @@ func (h HTTPJSONQuery) MarshalJSON() ([]byte, error) {
 	raw["jsonPath"] = h.JSONPath
 	raw["expectedValue"] = h.ExpectedValue
 	raw["jsonPathOperator"] = h.JSONPathOperator
+	raw["retryOnlyOnStatusCodeFailure"] = h.RetryOnlyOnStatusCodeFailure
 
 	// Uptime Kuma v2 requires conditions field (empty array by default)
 	raw["conditions"] = []any{}
@@ -127,9 +128,10 @@ func (h HTTPJSONQuery) MarshalJSON() ([]byte, error) {
 
 // HTTPJSONQueryDetails contains httpjsonquery-specific monitor configuration.
 type HTTPJSONQueryDetails struct {
-	JSONPath         string `json:"jsonPath"`
-	ExpectedValue    string `json:"expectedValue"`
-	JSONPathOperator string `json:"jsonPathOperator"`
+	JSONPath                     string `json:"jsonPath"`
+	ExpectedValue                string `json:"expectedValue"`
+	JSONPathOperator             string `json:"jsonPathOperator"`
+	RetryOnlyOnStatusCodeFailure bool   `json:"retryOnlyOnStatusCodeFailure"`
 }
 
 // Type returns the monitor type.

--- a/monitor/monitor_http_json_query_test.go
+++ b/monitor/monitor_http_json_query_test.go
@@ -23,7 +23,7 @@ func TestMonitorHTTPJSONQuery_Unmarshal(t *testing.T) {
 		{
 			name: "success",
 			data: []byte(
-				`{"id":3,"name":"api.example.com","description":"API health check","pathName":"group / api.example.com","parent":1,"childrenIDs":[],"url":"https://api.example.com/health","method":"GET","hostname":null,"port":null,"maxretries":2,"weight":2000,"active":true,"forceInactive":false,"type":"json-query","timeout":48,"interval":60,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":"A","dns_resolve_server":"1.1.1.1","dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{"1":true},"tags":[],"maintenance":false,"mqttTopic":"","mqttSuccessMessage":"","databaseQuery":null,"authMethod":null,"grpcUrl":null,"grpcProtobuf":null,"grpcMethod":null,"grpcServiceName":null,"grpcEnableTls":false,"radiusCalledStationId":null,"radiusCallingStationId":null,"game":null,"gamedigGivenPortOnly":true,"httpBodyEncoding":"json","jsonPath":"status","expectedValue":"ok","jsonPathOperator":"==","kafkaProducerTopic":null,"kafkaProducerBrokers":[],"kafkaProducerSsl":false,"kafkaProducerAllowAutoTopicCreation":false,"kafkaProducerMessage":null,"screenshot":null,"headers":null,"body":null,"grpcBody":null,"grpcMetadata":null,"basic_auth_user":null,"basic_auth_pass":null,"oauth_client_id":null,"oauth_client_secret":null,"oauth_token_url":null,"oauth_scopes":null,"oauth_auth_method":"client_secret_basic","pushToken":null,"databaseConnectionString":null,"radiusUsername":null,"radiusPassword":null,"radiusSecret":null,"mqttUsername":"","mqttPassword":"","authWorkstation":null,"authDomain":null,"tlsCa":null,"tlsCert":null,"tlsKey":null,"kafkaProducerSaslOptions":{"mechanism":"None"},"includeSensitiveData":true}`,
+				`{"id":3,"name":"api.example.com","description":"API health check","pathName":"group / api.example.com","parent":1,"childrenIDs":[],"url":"https://api.example.com/health","method":"GET","hostname":null,"port":null,"maxretries":2,"weight":2000,"active":true,"forceInactive":false,"type":"json-query","timeout":48,"interval":60,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":"A","dns_resolve_server":"1.1.1.1","dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{"1":true},"tags":[],"maintenance":false,"mqttTopic":"","mqttSuccessMessage":"","databaseQuery":null,"authMethod":null,"grpcUrl":null,"grpcProtobuf":null,"grpcMethod":null,"grpcServiceName":null,"grpcEnableTls":false,"radiusCalledStationId":null,"radiusCallingStationId":null,"game":null,"gamedigGivenPortOnly":true,"httpBodyEncoding":"json","jsonPath":"status","expectedValue":"ok","jsonPathOperator":"==","retryOnlyOnStatusCodeFailure":false,"kafkaProducerTopic":null,"kafkaProducerBrokers":[],"kafkaProducerSsl":false,"kafkaProducerAllowAutoTopicCreation":false,"kafkaProducerMessage":null,"screenshot":null,"headers":null,"body":null,"grpcBody":null,"grpcMetadata":null,"basic_auth_user":null,"basic_auth_pass":null,"oauth_client_id":null,"oauth_client_secret":null,"oauth_token_url":null,"oauth_scopes":null,"oauth_auth_method":"client_secret_basic","pushToken":null,"databaseConnectionString":null,"radiusUsername":null,"radiusPassword":null,"radiusSecret":null,"mqttUsername":"","mqttPassword":"","authWorkstation":null,"authDomain":null,"tlsCa":null,"tlsCert":null,"tlsKey":null,"kafkaProducerSaslOptions":{"mechanism":"None"},"includeSensitiveData":true}`,
 			),
 
 			want: monitor.HTTPJSONQuery{
@@ -68,12 +68,69 @@ func TestMonitorHTTPJSONQuery_Unmarshal(t *testing.T) {
 					OAuthScopes:         "",
 				},
 				HTTPJSONQueryDetails: monitor.HTTPJSONQueryDetails{
-					JSONPath:         "status",
-					ExpectedValue:    "ok",
-					JSONPathOperator: "==",
+					JSONPath:                     "status",
+					ExpectedValue:                "ok",
+					JSONPathOperator:             "==",
+					RetryOnlyOnStatusCodeFailure: false,
 				},
 			},
-			wantJSON: `{"accepted_statuscodes":["200-299"],"active":true,"authDomain":"","authMethod":"","authWorkstation":"","basic_auth_pass":"","basic_auth_user":"","body":"","cacheBust":false,"conditions":[],"description":"API health check","expectedValue":"ok","expiryNotification":false,"headers":"","httpBodyEncoding":"json","id":3,"ignoreTls":false,"interval":60,"jsonPath":"status","jsonPathOperator":"==","maxredirects":10,"maxretries":2,"method":"GET","name":"api.example.com","notificationIDList":{"1":true},"oauth_auth_method":"client_secret_basic","oauth_client_id":"","oauth_client_secret":"","oauth_scopes":"","oauth_token_url":"","parent":1,"proxyId":null,"resendInterval":0,"retryInterval":60,"timeout":48,"tlsCa":"","tlsCert":"","tlsKey":"","type":"json-query","upsideDown":false,"url":"https://api.example.com/health"}`,
+			wantJSON: `{"accepted_statuscodes":["200-299"],"active":true,"authDomain":"","authMethod":"","authWorkstation":"","basic_auth_pass":"","basic_auth_user":"","body":"","cacheBust":false,"conditions":[],"description":"API health check","expectedValue":"ok","expiryNotification":false,"headers":"","httpBodyEncoding":"json","id":3,"ignoreTls":false,"interval":60,"jsonPath":"status","jsonPathOperator":"==","maxredirects":10,"maxretries":2,"method":"GET","name":"api.example.com","notificationIDList":{"1":true},"oauth_auth_method":"client_secret_basic","oauth_client_id":"","oauth_client_secret":"","oauth_scopes":"","oauth_token_url":"","parent":1,"proxyId":null,"resendInterval":0,"retryInterval":60,"retryOnlyOnStatusCodeFailure":false,"timeout":48,"tlsCa":"","tlsCert":"","tlsKey":"","type":"json-query","upsideDown":false,"url":"https://api.example.com/health"}`,
+		},
+		{
+			name: "success_retry_only_on_status_code_failure",
+			data: []byte(
+				`{"id":5,"name":"api-retry-status-only","description":null,"pathName":"api-retry-status-only","parent":null,"childrenIDs":[],"url":"https://api.example.com/health","method":"GET","hostname":null,"port":null,"maxretries":3,"weight":2000,"active":true,"forceInactive":false,"type":"json-query","timeout":48,"interval":60,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":"A","dns_resolve_server":"1.1.1.1","dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{},"tags":[],"maintenance":false,"mqttTopic":"","mqttSuccessMessage":"","databaseQuery":null,"authMethod":null,"grpcUrl":null,"grpcProtobuf":null,"grpcMethod":null,"grpcServiceName":null,"grpcEnableTls":false,"radiusCalledStationId":null,"radiusCallingStationId":null,"game":null,"gamedigGivenPortOnly":true,"httpBodyEncoding":"json","jsonPath":"status","expectedValue":"ok","jsonPathOperator":"==","retryOnlyOnStatusCodeFailure":true,"kafkaProducerTopic":null,"kafkaProducerBrokers":[],"kafkaProducerSsl":false,"kafkaProducerAllowAutoTopicCreation":false,"kafkaProducerMessage":null,"screenshot":null,"headers":null,"body":null,"grpcBody":null,"grpcMetadata":null,"basic_auth_user":null,"basic_auth_pass":null,"oauth_client_id":null,"oauth_client_secret":null,"oauth_token_url":null,"oauth_scopes":null,"oauth_auth_method":"client_secret_basic","pushToken":null,"databaseConnectionString":null,"radiusUsername":null,"radiusPassword":null,"radiusSecret":null,"mqttUsername":"","mqttPassword":"","authWorkstation":null,"authDomain":null,"tlsCa":null,"tlsCert":null,"tlsKey":null,"kafkaProducerSaslOptions":{"mechanism":"None"},"includeSensitiveData":true}`,
+			),
+
+			want: monitor.HTTPJSONQuery{
+				Base: monitor.Base{
+					ID:              5,
+					Name:            "api-retry-status-only",
+					Description:     nil,
+					PathName:        "api-retry-status-only",
+					Parent:          nil,
+					ProxyID:         nil,
+					Interval:        60,
+					RetryInterval:   60,
+					ResendInterval:  0,
+					MaxRetries:      3,
+					UpsideDown:      false,
+					NotificationIDs: nil,
+					IsActive:        true,
+				},
+				HTTPDetails: monitor.HTTPDetails{
+					URL:                 "https://api.example.com/health",
+					Timeout:             48,
+					ExpiryNotification:  false,
+					IgnoreTLS:           false,
+					MaxRedirects:        10,
+					AcceptedStatusCodes: []string{"200-299"},
+					Method:              "GET",
+					HTTPBodyEncoding:    "json",
+					Body:                "",
+					Headers:             "",
+					AuthMethod:          monitor.AuthMethodNone,
+					BasicAuthUser:       "",
+					BasicAuthPass:       "",
+					AuthDomain:          "",
+					AuthWorkstation:     "",
+					TLSCert:             "",
+					TLSKey:              "",
+					TLSCa:               "",
+					OAuthAuthMethod:     "client_secret_basic",
+					OAuthTokenURL:       "",
+					OAuthClientID:       "",
+					OAuthClientSecret:   "",
+					OAuthScopes:         "",
+				},
+				HTTPJSONQueryDetails: monitor.HTTPJSONQueryDetails{
+					JSONPath:                     "status",
+					ExpectedValue:                "ok",
+					JSONPathOperator:             "==",
+					RetryOnlyOnStatusCodeFailure: true,
+				},
+			},
+			wantJSON: `{"accepted_statuscodes":["200-299"],"active":true,"authDomain":"","authMethod":"","authWorkstation":"","basic_auth_pass":"","basic_auth_user":"","body":"","cacheBust":false,"conditions":[],"description":null,"expectedValue":"ok","expiryNotification":false,"headers":"","httpBodyEncoding":"json","id":5,"ignoreTls":false,"interval":60,"jsonPath":"status","jsonPathOperator":"==","maxredirects":10,"maxretries":3,"method":"GET","name":"api-retry-status-only","notificationIDList":{},"oauth_auth_method":"client_secret_basic","oauth_client_id":"","oauth_client_secret":"","oauth_scopes":"","oauth_token_url":"","parent":null,"proxyId":null,"resendInterval":0,"retryInterval":60,"retryOnlyOnStatusCodeFailure":true,"timeout":48,"tlsCa":"","tlsCert":"","tlsKey":"","type":"json-query","upsideDown":false,"url":"https://api.example.com/health"}`,
 		},
 	}
 

--- a/monitor_test.go
+++ b/monitor_test.go
@@ -440,8 +440,9 @@ func TestMonitorCRUD(t *testing.T) {
 					AuthMethod:          monitor.AuthMethodNone,
 				},
 				HTTPJSONQueryDetails: monitor.HTTPJSONQueryDetails{
-					JSONPath:      "slideshow.title",
-					ExpectedValue: "Sample Slide Show",
+					JSONPath:                     "slideshow.title",
+					ExpectedValue:                "Sample Slide Show",
+					RetryOnlyOnStatusCodeFailure: false,
 				},
 			},
 			updateFunc: func(m monitor.Monitor) {
@@ -453,6 +454,7 @@ func TestMonitorCRUD(t *testing.T) {
 				json.Name = "Updated JSON Query Monitor"
 				json.JSONPath = "slideshow.author"
 				json.ExpectedValue = "Yours Truly"
+				json.RetryOnlyOnStatusCodeFailure = true
 			},
 			verifyCreatedFunc: func(t *testing.T, actual monitor.Monitor, id int64) {
 				t.Helper()
@@ -461,6 +463,7 @@ func TestMonitorCRUD(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, id, json.ID)
 				require.Equal(t, "Test JSON Query Monitor", json.Name)
+				require.False(t, json.RetryOnlyOnStatusCodeFailure)
 			},
 			createTypedFunc: func(t *testing.T, base monitor.Monitor) monitor.Monitor {
 				t.Helper()
@@ -477,6 +480,7 @@ func TestMonitorCRUD(t *testing.T) {
 				require.Equal(t, "Updated JSON Query Monitor", json.Name)
 				require.Equal(t, "slideshow.author", json.JSONPath)
 				require.Equal(t, "Yours Truly", json.ExpectedValue)
+				require.True(t, json.RetryOnlyOnStatusCodeFailure)
 			},
 			testPauseResume: true,
 		},


### PR DESCRIPTION
Expose the upstream Uptime Kuma `retryOnlyOnStatusCodeFailure` boolean on JSON-Query monitors. When enabled, retries only occur when the HTTP status code check fails; if the status code check passes but the JSON-Query evaluation fails, the monitor is marked DOWN immediately without retries.

## Changes

- Added `RetryOnlyOnStatusCodeFailure bool` (JSON tag `retryOnlyOnStatusCodeFailure`) to `HTTPJSONQueryDetails` in [monitor/monitor_http_json_query.go](../blob/feature-256-extend-http-keyword-json-query-with-status-code-only-retry-option/monitor/monitor_http_json_query.go).
- Updated `HTTPJSONQuery.MarshalJSON` to emit the new field.
- Extended round-trip unit-test coverage in [monitor/monitor_http_json_query_test.go](../blob/feature-256-extend-http-keyword-json-query-with-status-code-only-retry-option/monitor/monitor_http_json_query_test.go) (existing case updated, new `success_retry_only_on_status_code_failure` case added).
- Extended e2e CRUD test in [monitor_test.go](../blob/feature-256-extend-http-keyword-json-query-with-status-code-only-retry-option/monitor_test.go) to flip the field on update and verify the round-trip through Uptime Kuma.

## Note on issue scope

Issue #256 mentions both keyword and JSON-Query monitors and lists the wire field as `isStatusCodeOnlyRetry`. Inspection of the actual upstream PR (louislam/uptime-kuma#6687) shows:

- The wire field is `retryOnlyOnStatusCodeFailure`, not `isStatusCodeOnlyRetry`.
- The behavior is implemented only for `json-query` monitors (see the `this.type === "json-query"` guard in `server/model/monitor.js`); keyword monitors do not have this option.

This PR therefore implements the field as it actually exists upstream.

## Verification

- `task fmt` ✓
- `bin/golangci-lint run ./...` ✓ (the `task lint` markdown errors are pre-existing failures in the locally-ignored `TODO.md`, unrelated to this change)
- `task test-e2e` ✓ (full suite passes against a live Uptime Kuma container)

Closes #256