### PR TITLE
feat(monitor): support multi-resolver DNS monitor configuration

### DIFF
--- a/monitor/monitor_dns.go
+++ b/monitor/monitor_dns.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 )
 
 // DNS represents a DNS monitor.
@@ -91,7 +92,11 @@ func (d DNS) MarshalJSON() ([]byte, error) {
 
 // DNSDetails contains DNS-specific monitor configuration.
 type DNSDetails struct {
-	Hostname       string         `json:"hostname"`
+	Hostname string `json:"hostname"`
+	// ResolverServer holds one or more DNS resolver servers as a
+	// comma-separated list of IP addresses or hostnames (e.g.
+	// "1.1.1.1,8.8.8.8"). Use ResolverServers and SetResolverServers for
+	// access as a []string.
 	ResolverServer string         `json:"dns_resolve_server"`
 	ResolveType    DNSResolveType `json:"dns_resolve_type"`
 	Port           int            `json:"port"`
@@ -100,6 +105,49 @@ type DNSDetails struct {
 // Type returns the monitor type.
 func (DNSDetails) Type() string {
 	return "dns"
+}
+
+// ResolverServers returns the configured DNS resolver servers as a slice.
+// Whitespace around each entry is trimmed and empty entries are dropped,
+// matching the parsing performed by the Uptime Kuma server.
+func (d DNSDetails) ResolverServers() []string {
+	if d.ResolverServer == "" {
+		return nil
+	}
+
+	parts := strings.Split(d.ResolverServer, ",")
+	servers := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+
+		servers = append(servers, p)
+	}
+
+	if len(servers) == 0 {
+		return nil
+	}
+
+	return servers
+}
+
+// SetResolverServers sets the DNS resolver servers from a slice. The values
+// are joined with "," into the comma-separated form expected by the Uptime
+// Kuma server. Empty and whitespace-only entries are dropped.
+func (d *DNSDetails) SetResolverServers(servers []string) {
+	cleaned := make([]string, 0, len(servers))
+	for _, s := range servers {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+
+		cleaned = append(cleaned, s)
+	}
+
+	d.ResolverServer = strings.Join(cleaned, ",")
 }
 
 // DNSResolveType represents the DNS record type to resolve.

--- a/monitor/monitor_dns_test.go
+++ b/monitor/monitor_dns_test.go
@@ -50,6 +50,36 @@ func TestMonitorDNS_Unmarshal(t *testing.T) {
 			},
 			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":"Test DNS monitor","dns_resolve_server":"1.1.1.1","dns_resolve_type":"A","hostname":"example.com","id":5,"interval":60,"maxretries":2,"name":"dns-monitor","notificationIDList":{"1":true,"2":true},"parent":1,"port":53,"resendInterval":0,"retryInterval":60,"type":"dns","upsideDown":false}`,
 		},
+		{
+			name: "multi resolver",
+			data: []byte(
+				`{"id":6,"name":"dns-multi-resolver","description":"Test multi-resolver DNS monitor","pathName":"group / dns-multi-resolver","parent":1,"childrenIDs":[],"url":null,"method":"GET","hostname":"example.com","port":53,"maxretries":2,"weight":2000,"active":true,"forceInactive":false,"type":"dns","timeout":48,"interval":60,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":"A","dns_resolve_server":"1.1.1.1,8.8.8.8","dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{"1":true,"2":true},"tags":[],"maintenance":false,"mqttTopic":"","mqttSuccessMessage":"","databaseQuery":null,"authMethod":null,"grpcUrl":null,"grpcProtobuf":null,"grpcMethod":null,"grpcServiceName":null,"grpcEnableTls":false,"radiusCalledStationId":null,"radiusCallingStationId":null,"game":null,"gamedigGivenPortOnly":true,"httpBodyEncoding":"json","jsonPath":null,"expectedValue":null,"kafkaProducerTopic":null,"kafkaProducerBrokers":[],"kafkaProducerSsl":false,"kafkaProducerAllowAutoTopicCreation":false,"kafkaProducerMessage":null,"screenshot":null,"headers":null,"body":null,"grpcBody":null,"grpcMetadata":null,"basic_auth_user":null,"basic_auth_pass":null,"oauth_client_id":null,"oauth_client_secret":null,"oauth_token_url":null,"oauth_scopes":null,"oauth_auth_method":"client_secret_basic","pushToken":null,"databaseConnectionString":null,"radiusUsername":null,"radiusPassword":null,"radiusSecret":null,"mqttUsername":"","mqttPassword":"","authWorkstation":null,"authDomain":null,"tlsCa":null,"tlsCert":null,"tlsKey":null,"kafkaProducerSaslOptions":{"mechanism":"None"},"includeSensitiveData":true}`,
+			),
+
+			want: monitor.DNS{
+				Base: monitor.Base{
+					ID:              6,
+					Name:            "dns-multi-resolver",
+					Description:     ptr.To("Test multi-resolver DNS monitor"),
+					PathName:        "group / dns-multi-resolver",
+					Parent:          &parent1,
+					Interval:        60,
+					RetryInterval:   60,
+					ResendInterval:  0,
+					MaxRetries:      2,
+					UpsideDown:      false,
+					NotificationIDs: []int64{1, 2},
+					IsActive:        true,
+				},
+				DNSDetails: monitor.DNSDetails{
+					Hostname:       "example.com",
+					ResolverServer: "1.1.1.1,8.8.8.8",
+					ResolveType:    monitor.DNSResolveTypeA,
+					Port:           53,
+				},
+			},
+			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":"Test multi-resolver DNS monitor","dns_resolve_server":"1.1.1.1,8.8.8.8","dns_resolve_type":"A","hostname":"example.com","id":6,"interval":60,"maxretries":2,"name":"dns-multi-resolver","notificationIDList":{"1":true,"2":true},"parent":1,"port":53,"resendInterval":0,"retryInterval":60,"type":"dns","upsideDown":false}`,
+		},
 	}
 
 	for _, tc := range tests {
@@ -65,6 +95,84 @@ func TestMonitorDNS_Unmarshal(t *testing.T) {
 			require.NoError(t, err)
 
 			require.JSONEq(t, tc.wantJSON, string(data))
+		})
+	}
+}
+
+func TestDNSDetails_ResolverServers(t *testing.T) {
+	tests := []struct {
+		name  string
+		field string
+		want  []string
+	}{
+		{
+			name:  "empty",
+			field: "",
+			want:  nil,
+		},
+		{
+			name:  "single",
+			field: "1.1.1.1",
+			want:  []string{"1.1.1.1"},
+		},
+		{
+			name:  "multiple",
+			field: "1.1.1.1,8.8.8.8",
+			want:  []string{"1.1.1.1", "8.8.8.8"},
+		},
+		{
+			name:  "trim and skip empty",
+			field: " 1.1.1.1 , , 8.8.8.8 ,",
+			want:  []string{"1.1.1.1", "8.8.8.8"},
+		},
+		{
+			name:  "only separators",
+			field: " , , ",
+			want:  nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			d := monitor.DNSDetails{ResolverServer: tc.field}
+			require.Equal(t, tc.want, d.ResolverServers())
+		})
+	}
+}
+
+func TestDNSDetails_SetResolverServers(t *testing.T) {
+	tests := []struct {
+		name    string
+		servers []string
+		want    string
+	}{
+		{
+			name:    "nil",
+			servers: nil,
+			want:    "",
+		},
+		{
+			name:    "single",
+			servers: []string{"1.1.1.1"},
+			want:    "1.1.1.1",
+		},
+		{
+			name:    "multiple",
+			servers: []string{"1.1.1.1", "8.8.8.8"},
+			want:    "1.1.1.1,8.8.8.8",
+		},
+		{
+			name:    "trim and skip empty",
+			servers: []string{" 1.1.1.1 ", "", " ", " 8.8.8.8"},
+			want:    "1.1.1.1,8.8.8.8",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			d := monitor.DNSDetails{}
+			d.SetResolverServers(tc.servers)
+			require.Equal(t, tc.want, d.ResolverServer)
 		})
 	}
 }

--- a/monitor_test.go
+++ b/monitor_test.go
@@ -386,7 +386,7 @@ func TestMonitorCRUD(t *testing.T) {
 
 				dns.Name = "Updated DNS Monitor"
 				dns.Hostname = "google.com"
-				dns.ResolverServer = "8.8.8.8"
+				dns.SetResolverServers([]string{"8.8.8.8", "1.1.1.1"})
 				dns.ResolveType = monitor.DNSResolveTypeAAAA
 			},
 			verifyCreatedFunc: func(t *testing.T, actual monitor.Monitor, id int64) {
@@ -412,7 +412,8 @@ func TestMonitorCRUD(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, "Updated DNS Monitor", dns.Name)
 				require.Equal(t, "google.com", dns.Hostname)
-				require.Equal(t, "8.8.8.8", dns.ResolverServer)
+				require.Equal(t, "8.8.8.8,1.1.1.1", dns.ResolverServer)
+				require.Equal(t, []string{"8.8.8.8", "1.1.1.1"}, dns.ResolverServers())
 				require.Equal(t, monitor.DNSResolveTypeAAAA, dns.ResolveType)
 			},
 			testPauseResume: true,


### PR DESCRIPTION
## Summary

Upstream Uptime Kuma (louislam/uptime-kuma#6524) changed the DNS monitor's
`dns_resolve_server` field from a single hostname/IP to a comma-separated
list, enabling multi-resolver checks.

This change keeps `monitor.DNSDetails.ResolverServer` as a `string` so the
wire format is preserved and existing consumers continue to compile, and
adds ergonomic helpers for working with the list form:

- `(DNSDetails).ResolverServers() []string` — read the configured
  servers as a slice (whitespace-trimmed, empty entries dropped, matching
  the server-side parsing).
- `(*DNSDetails).SetResolverServers([]string)` — write the slice form,
  joining with `,`.

## Tests

- New unit tests for `ResolverServers` and `SetResolverServers` covering
  empty, single, multiple, whitespace and empty-entry cases.
- Existing round-trip test extended with a multi-resolver case
  (`"1.1.1.1,8.8.8.8"`).
- E2E `TestMonitorCRUD/DNS` updated to set and verify multiple resolvers
  via `SetResolverServers` / `ResolverServers`.

Closes #251