### PR TITLE
feat(monitor): extend SNMP monitor with SNMPv3 noAuthNoPriv support

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -63,7 +63,7 @@ tasks:
   lint:
     desc: "Run linters"
     cmds:
-      - markdownlint-cli2 --fix --files '**/*.md' '!.scratch/**' '!.beads/**' '!docs/**'
+      - markdownlint-cli2 --fix --files '**/*.md' '!.scratch/**' '!.beads/**' '!docs/**' '!TODO.md'
       - bin/golangci-lint config verify
       - bin/golangci-lint run --fix ./...
 

--- a/monitor/monitor_snmp.go
+++ b/monitor/monitor_snmp.go
@@ -75,6 +75,7 @@ func (s SNMP) MarshalJSON() ([]byte, error) {
 	raw["snmpVersion"] = s.SNMPVersion
 	raw["snmpOid"] = s.SNMPOID
 	raw["radiusPassword"] = s.SNMPCommunity
+	raw["snmpV3Username"] = s.SNMPV3Username
 	raw["jsonPath"] = s.JSONPath
 	raw["jsonPathOperator"] = s.JSONPathOperator
 	raw["expectedValue"] = s.ExpectedValue
@@ -100,6 +101,7 @@ type SNMPDetails struct {
 	SNMPVersion      string  `json:"snmpVersion"`
 	SNMPOID          string  `json:"snmpOid"`
 	SNMPCommunity    string  `json:"radiusPassword"`
+	SNMPV3Username   *string `json:"snmpV3Username"`
 	JSONPath         *string `json:"jsonPath"`
 	JSONPathOperator *string `json:"jsonPathOperator"`
 	ExpectedValue    *string `json:"expectedValue"`

--- a/monitor/monitor_snmp_test.go
+++ b/monitor/monitor_snmp_test.go
@@ -53,7 +53,7 @@ func TestMonitorSNMP_Unmarshal(t *testing.T) {
 					ExpectedValue:    ptr.To("1000000000"),
 				},
 			},
-			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":"Test SNMP monitor","expectedValue":"1000000000","hostname":"192.168.1.1","id":10,"interval":60,"jsonPath":"ifSpeed","jsonPathOperator":"==","maxretries":2,"name":"snmp-monitor","notificationIDList":{"1":true,"2":true},"parent":1,"port":161,"radiusPassword":"public","resendInterval":0,"retryInterval":60,"snmpOid":"1.3.6.1.2.1.2.2.1.5.1","snmpVersion":"2c","type":"snmp","upsideDown":false}`,
+			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":"Test SNMP monitor","expectedValue":"1000000000","hostname":"192.168.1.1","id":10,"interval":60,"jsonPath":"ifSpeed","jsonPathOperator":"==","maxretries":2,"name":"snmp-monitor","notificationIDList":{"1":true,"2":true},"parent":1,"port":161,"radiusPassword":"public","resendInterval":0,"retryInterval":60,"snmpOid":"1.3.6.1.2.1.2.2.1.5.1","snmpV3Username":null,"snmpVersion":"2c","type":"snmp","upsideDown":false}`,
 		},
 		{
 			name: "success with minimal fields",
@@ -87,7 +87,42 @@ func TestMonitorSNMP_Unmarshal(t *testing.T) {
 					ExpectedValue:    nil,
 				},
 			},
-			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":null,"expectedValue":null,"hostname":"10.0.0.1","id":11,"interval":60,"jsonPath":null,"jsonPathOperator":null,"maxretries":3,"name":"snmp-minimal","notificationIDList":{},"parent":null,"port":161,"radiusPassword":"public","resendInterval":0,"retryInterval":60,"snmpOid":"1.3.6.1.2.1.1.3.0","snmpVersion":"1","type":"snmp","upsideDown":false}`,
+			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":null,"expectedValue":null,"hostname":"10.0.0.1","id":11,"interval":60,"jsonPath":null,"jsonPathOperator":null,"maxretries":3,"name":"snmp-minimal","notificationIDList":{},"parent":null,"port":161,"radiusPassword":"public","resendInterval":0,"retryInterval":60,"snmpOid":"1.3.6.1.2.1.1.3.0","snmpV3Username":null,"snmpVersion":"1","type":"snmp","upsideDown":false}`,
+		},
+		{
+			name: "success with SNMPv3 noAuthNoPriv",
+			data: []byte(
+				`{"id":12,"name":"snmp-v3","description":"Test SNMPv3 monitor","pathName":"snmp-v3","parent":null,"childrenIDs":[],"url":null,"method":"GET","hostname":"192.168.1.2","port":161,"maxretries":3,"weight":2000,"active":true,"forceInactive":false,"type":"snmp","timeout":48,"interval":60,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":"A","dns_resolve_server":"1.1.1.1","dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{},"tags":[],"maintenance":false,"mqttTopic":"","mqttSuccessMessage":"","databaseQuery":null,"authMethod":null,"grpcUrl":null,"grpcProtobuf":null,"grpcMethod":null,"grpcServiceName":null,"grpcEnableTls":false,"radiusCalledStationId":null,"radiusCallingStationId":null,"game":null,"gamedigGivenPortOnly":true,"httpBodyEncoding":"json","jsonPath":null,"jsonPathOperator":null,"expectedValue":null,"kafkaProducerTopic":null,"kafkaProducerBrokers":[],"kafkaProducerSsl":false,"kafkaProducerAllowAutoTopicCreation":false,"kafkaProducerMessage":null,"screenshot":null,"headers":null,"body":null,"grpcBody":null,"grpcMetadata":null,"basic_auth_user":null,"basic_auth_pass":null,"oauth_client_id":null,"oauth_client_secret":null,"oauth_token_url":null,"oauth_scopes":null,"oauth_auth_method":"client_secret_basic","pushToken":null,"databaseConnectionString":null,"radiusUsername":null,"radiusPassword":null,"radiusSecret":null,"snmpVersion":"3","snmpV3Username":"snmpuser","snmpOid":"1.3.6.1.2.1.1.3.0","mqttUsername":"","mqttPassword":"","authWorkstation":null,"authDomain":null,"tlsCa":null,"tlsCert":null,"tlsKey":null,"kafkaProducerSaslOptions":{"mechanism":"None"},"includeSensitiveData":true}`,
+			),
+
+			want: monitor.SNMP{
+				Base: monitor.Base{
+					ID:              12,
+					Name:            "snmp-v3",
+					Description:     ptr.To("Test SNMPv3 monitor"),
+					PathName:        "snmp-v3",
+					Parent:          nil,
+					Interval:        60,
+					RetryInterval:   60,
+					ResendInterval:  0,
+					MaxRetries:      3,
+					UpsideDown:      false,
+					NotificationIDs: nil,
+					IsActive:        true,
+				},
+				SNMPDetails: monitor.SNMPDetails{
+					Hostname:         "192.168.1.2",
+					Port:             &port161,
+					SNMPVersion:      "3",
+					SNMPOID:          "1.3.6.1.2.1.1.3.0",
+					SNMPCommunity:    "",
+					SNMPV3Username:   ptr.To("snmpuser"),
+					JSONPath:         nil,
+					JSONPathOperator: nil,
+					ExpectedValue:    nil,
+				},
+			},
+			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":"Test SNMPv3 monitor","expectedValue":null,"hostname":"192.168.1.2","id":12,"interval":60,"jsonPath":null,"jsonPathOperator":null,"maxretries":3,"name":"snmp-v3","notificationIDList":{},"parent":null,"port":161,"radiusPassword":"","resendInterval":0,"retryInterval":60,"snmpOid":"1.3.6.1.2.1.1.3.0","snmpV3Username":"snmpuser","snmpVersion":"3","type":"snmp","upsideDown":false}`,
 		},
 	}
 

--- a/monitor_test.go
+++ b/monitor_test.go
@@ -819,6 +819,63 @@ func TestMonitorCRUD(t *testing.T) {
 			testPauseResume: true,
 		},
 		{
+			name: "SNMPv3",
+			create: &monitor.SNMP{
+				Base: monitor.Base{
+					Name:           "Test SNMPv3 Monitor",
+					Interval:       60,
+					RetryInterval:  60,
+					ResendInterval: 0,
+					MaxRetries:     3,
+					UpsideDown:     false,
+					IsActive:       true,
+				},
+				SNMPDetails: monitor.SNMPDetails{
+					Hostname:       "192.168.1.1",
+					Port:           ptr.To(int64(161)),
+					SNMPVersion:    "3",
+					SNMPOID:        "1.3.6.1.2.1.1.3.0",
+					SNMPV3Username: ptr.To("snmpuser"),
+				},
+			},
+			updateFunc: func(m monitor.Monitor) {
+				snmp, ok := m.(*monitor.SNMP)
+				if !ok {
+					panic("failed to assert SNMP monitor")
+				}
+
+				snmp.Name = "Updated SNMPv3 Monitor"
+				snmp.Hostname = "10.0.0.1"
+				snmp.SNMPV3Username = ptr.To("updateduser")
+			},
+			verifyCreatedFunc: func(t *testing.T, actual monitor.Monitor, id int64) {
+				t.Helper()
+				var snmp monitor.SNMP
+				err := actual.As(&snmp)
+				require.NoError(t, err)
+				require.Equal(t, id, snmp.ID)
+				require.Equal(t, "Test SNMPv3 Monitor", snmp.Name)
+				require.Equal(t, "3", snmp.SNMPVersion)
+			},
+			createTypedFunc: func(t *testing.T, base monitor.Monitor) monitor.Monitor {
+				t.Helper()
+				var snmp monitor.SNMP
+				err := base.As(&snmp)
+				require.NoError(t, err)
+				return &snmp
+			},
+			verifyUpdatedFunc: func(t *testing.T, actual monitor.Monitor) {
+				t.Helper()
+				var snmp monitor.SNMP
+				err := actual.As(&snmp)
+				require.NoError(t, err)
+				require.Equal(t, "Updated SNMPv3 Monitor", snmp.Name)
+				require.Equal(t, "10.0.0.1", snmp.Hostname)
+				require.Equal(t, "3", snmp.SNMPVersion)
+			},
+			testPauseResume: true,
+		},
+		{
 			name: "Docker",
 			create: &monitor.Docker{
 				Base: monitor.Base{

--- a/monitor_test.go
+++ b/monitor_test.go
@@ -856,6 +856,10 @@ func TestMonitorCRUD(t *testing.T) {
 				require.Equal(t, id, snmp.ID)
 				require.Equal(t, "Test SNMPv3 Monitor", snmp.Name)
 				require.Equal(t, "3", snmp.SNMPVersion)
+				// Upstream Uptime Kuma (verified up to 2.3.2) does not include
+				// snmpV3Username in toJSON(); see
+				// https://github.com/louislam/uptime-kuma/pull/6552. The wire
+				// format is exercised by TestMonitorSNMP_Unmarshal.
 			},
 			createTypedFunc: func(t *testing.T, base monitor.Monitor) monitor.Monitor {
 				t.Helper()


### PR DESCRIPTION
## Summary

Adds the optional `SNMPV3Username` field to `SNMPDetails`, matching the new `snmp_v3_username` field introduced by upstream PR [louislam/uptime-kuma#6552](https://github.com/louislam/uptime-kuma/pull/6552).

## Details

- New optional `SNMPV3Username *string` field on `SNMPDetails`
- Marshaled as `snmpV3Username` to match the camelCase JSON wire format used by upstream `EditMonitor.vue`
- Only the username field is added: the upstream PR implements SNMPv3 **noAuthNoPriv** only, which by definition has no password or auth/priv protocols
- The existing `SNMPCommunity` (`radiusPassword`) field is retained for v1/v2c

## Tests

- Unit: added round-trip JSON marshal/unmarshal test for SNMPv3 noAuthNoPriv in `monitor/monitor_snmp_test.go`
- E2E: added `TestMonitorCRUD/SNMPv3` case covering create/update/pause/resume of an SNMPv3 monitor in `monitor_test.go`

Closes #252