### PR TITLE
feat(monitor): add conditions support to MQTT and database monitors

### DIFF
--- a/monitor/conditions.go
+++ b/monitor/conditions.go
@@ -1,0 +1,75 @@
+package monitor
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// ConditionOperator represents the logical operator that joins a condition with
+// the previous one in the chain.
+type ConditionOperator string
+
+const (
+	// ConditionAnd combines a condition with the previous one using a logical AND.
+	ConditionAnd ConditionOperator = "and"
+	// ConditionOr combines a condition with the previous one using a logical OR.
+	ConditionOr ConditionOperator = "or"
+)
+
+// conditionTypeExpression is the wire-format value upstream Uptime Kuma uses for
+// flat expression-type conditions. Group-type conditions (with nested children)
+// are not modeled by this client.
+const conditionTypeExpression = "expression"
+
+// Condition represents a single assertion clause that an Uptime Kuma monitor
+// evaluates against its parsed result (query result, MQTT payload, JSON-query
+// value, etc.). Conditions are chained together using the AndOr field.
+//
+// The set of allowed Variable and Operator values is monitor-type specific and
+// validated server-side. See the upstream `EditMonitor.vue` for the available
+// variables per monitor type.
+type Condition struct {
+	// Variable is the name of the field to test against (monitor-type specific).
+	Variable string `json:"variable"`
+	// Operator is the comparison operator (e.g. "==", "!=", "<", ">", "contains").
+	Operator string `json:"operator"`
+	// Value is the value to compare against.
+	Value string `json:"value"`
+	// AndOr chains this condition with the previous one ("and" or "or").
+	AndOr ConditionOperator `json:"andOr"`
+}
+
+// MarshalJSON marshals a Condition to JSON, adding the wire-format
+// `type: "expression"` field expected by the upstream evaluator.
+func (c Condition) MarshalJSON() ([]byte, error) {
+	raw := struct {
+		Type     string            `json:"type"`
+		Variable string            `json:"variable"`
+		Operator string            `json:"operator"`
+		Value    string            `json:"value"`
+		AndOr    ConditionOperator `json:"andOr"`
+	}{
+		Type:     conditionTypeExpression,
+		Variable: c.Variable,
+		Operator: c.Operator,
+		Value:    c.Value,
+		AndOr:    c.AndOr,
+	}
+
+	data, err := json.Marshal(raw)
+	if err != nil {
+		return nil, fmt.Errorf("marshal condition: %w", err)
+	}
+
+	return data, nil
+}
+
+// conditionsForWire normalizes a Conditions slice so that nil is encoded as an
+// empty JSON array, matching the upstream wire-format expectation.
+func conditionsForWire(conditions []Condition) any {
+	if conditions == nil {
+		return []Condition{}
+	}
+
+	return conditions
+}

--- a/monitor/conditions_test.go
+++ b/monitor/conditions_test.go
@@ -1,0 +1,44 @@
+package monitor_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/breml/go-uptime-kuma-client/monitor"
+)
+
+func TestCondition_Marshal(t *testing.T) {
+	c := monitor.Condition{
+		Variable: "result",
+		Operator: "==",
+		Value:    "OK",
+		AndOr:    monitor.ConditionAnd,
+	}
+
+	data, err := json.Marshal(c)
+	require.NoError(t, err)
+
+	require.JSONEq(
+		t,
+		`{"type":"expression","variable":"result","operator":"==","value":"OK","andOr":"and"}`,
+		string(data),
+	)
+}
+
+func TestCondition_Unmarshal(t *testing.T) {
+	data := []byte(`{"type":"expression","variable":"result","operator":"contains","value":"foo","andOr":"or"}`)
+
+	var c monitor.Condition
+
+	err := json.Unmarshal(data, &c)
+	require.NoError(t, err)
+
+	require.Equal(t, monitor.Condition{
+		Variable: "result",
+		Operator: "contains",
+		Value:    "foo",
+		AndOr:    monitor.ConditionOr,
+	}, c)
+}

--- a/monitor/monitor_mongodb.go
+++ b/monitor/monitor_mongodb.go
@@ -79,7 +79,7 @@ func (m MongoDB) MarshalJSON() ([]byte, error) {
 	raw["accepted_statuscodes"] = []string{}
 
 	// Uptime Kuma v2 requires conditions field (empty array by default)
-	raw["conditions"] = []any{}
+	raw["conditions"] = conditionsForWire(m.Conditions)
 
 	data, err := json.Marshal(raw)
 	if err != nil {
@@ -99,6 +99,9 @@ type MongoDBDetails struct {
 	JSONPath *string `json:"jsonPath"`
 	// ExpectedValue is the expected value when using jsonPath.
 	ExpectedValue *string `json:"expectedValue"`
+	// Conditions is an optional list of assertion clauses evaluated against the
+	// numeric value extracted from the command result.
+	Conditions []Condition `json:"conditions,omitempty"`
 }
 
 // Type returns the monitor type.

--- a/monitor/monitor_mongodb_test.go
+++ b/monitor/monitor_mongodb_test.go
@@ -80,6 +80,39 @@ func TestMonitorMongoDB_Unmarshal(t *testing.T) {
 			},
 			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"databaseConnectionString":"mongodb://user:pass@mongodb.example.com:27017/admin","databaseQuery":"{\"dbStats\": 1}","description":"Test MongoDB with command","expectedValue":"1","id":2,"interval":120,"jsonPath":"$.ok","maxretries":3,"name":"mongodb-query","notificationIDList":{},"parent":1,"resendInterval":0,"retryInterval":60,"type":"mongodb","upsideDown":false}`,
 		},
+		{
+			name: "success with conditions",
+			data: []byte(
+				`{"id":3,"name":"mongodb-conditions","description":null,"pathName":"mongodb-conditions","parent":null,"childrenIDs":[],"url":null,"method":"GET","hostname":null,"port":null,"maxretries":1,"weight":2000,"active":true,"forceInactive":false,"type":"mongodb","timeout":48,"interval":60,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":null,"dns_resolve_server":null,"dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{},"tags":[],"maintenance":false,"databaseQuery":null,"jsonPath":null,"expectedValue":null,"databaseConnectionString":"mongodb://localhost:27017","conditions":[{"type":"expression","variable":"numericValue","operator":">=","value":"1","andOr":"and"}]}`,
+			),
+
+			want: monitor.MongoDB{
+				Base: monitor.Base{
+					ID:              3,
+					Name:            "mongodb-conditions",
+					Description:     nil,
+					PathName:        "mongodb-conditions",
+					Parent:          nil,
+					Interval:        60,
+					RetryInterval:   60,
+					ResendInterval:  0,
+					MaxRetries:      1,
+					UpsideDown:      false,
+					NotificationIDs: nil,
+					IsActive:        true,
+				},
+				MongoDBDetails: monitor.MongoDBDetails{
+					DatabaseConnectionString: "mongodb://localhost:27017",
+					DatabaseQuery:            nil,
+					JSONPath:                 nil,
+					ExpectedValue:            nil,
+					Conditions: []monitor.Condition{
+						{Variable: "numericValue", Operator: ">=", Value: "1", AndOr: monitor.ConditionAnd},
+					},
+				},
+			},
+			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[{"type":"expression","variable":"numericValue","operator":">=","value":"1","andOr":"and"}],"databaseConnectionString":"mongodb://localhost:27017","databaseQuery":null,"description":null,"expectedValue":null,"id":3,"interval":60,"jsonPath":null,"maxretries":1,"name":"mongodb-conditions","notificationIDList":{},"parent":null,"resendInterval":0,"retryInterval":60,"type":"mongodb","upsideDown":false}`,
+		},
 	}
 
 	for _, tc := range tests {

--- a/monitor/monitor_mqtt.go
+++ b/monitor/monitor_mqtt.go
@@ -85,7 +85,7 @@ func (m MQTT) MarshalJSON() ([]byte, error) {
 	raw["accepted_statuscodes"] = []string{}
 
 	// Uptime Kuma v2 requires conditions field (empty array by default)
-	raw["conditions"] = []any{}
+	raw["conditions"] = conditionsForWire(m.Conditions)
 
 	data, err := json.Marshal(raw)
 	if err != nil {
@@ -117,6 +117,10 @@ type MQTTDetails struct {
 	JSONPath *string `json:"jsonPath"`
 	// ExpectedValue is the expected value for json-query check.
 	ExpectedValue *string `json:"expectedValue"`
+	// Conditions is an optional list of assertion clauses evaluated against the
+	// received MQTT payload. When set, the keyword / json-query check is bypassed
+	// and the condition results determine the monitor status.
+	Conditions []Condition `json:"conditions,omitempty"`
 }
 
 // Type returns the monitor type string.

--- a/monitor/monitor_mqtt_test.go
+++ b/monitor/monitor_mqtt_test.go
@@ -133,6 +133,40 @@ func TestMonitorMQTT_Unmarshal(t *testing.T) {
 			},
 			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":null,"expectedValue":null,"hostname":"wss://mqtt.cloud.com","id":7,"interval":120,"jsonPath":null,"maxretries":1,"mqttCheckType":"keyword","mqttPassword":"cloudpass","mqttSuccessMessage":"valid","mqttTopic":"sensor/humidity","mqttUsername":"clouduser","mqttWebsocketPath":"/mqtt","name":"mqtt-ws-monitor","notificationIDList":{},"parent":null,"port":443,"resendInterval":0,"retryInterval":120,"type":"mqtt","upsideDown":false}`,
 		},
+		{
+			name: "success with conditions",
+			data: []byte(
+				`{"id":8,"name":"mqtt-conditions","description":null,"pathName":"mqtt-conditions","parent":null,"childrenIDs":[],"url":null,"method":"GET","hostname":"mqtt.example.com","port":1883,"mqttTopic":"sensors/temp","mqttUsername":null,"mqttPassword":null,"mqttWebsocketPath":null,"mqttCheckType":"keyword","mqttSuccessMessage":null,"jsonPath":null,"expectedValue":null,"maxretries":1,"weight":2000,"active":true,"forceInactive":false,"type":"mqtt","timeout":48,"interval":60,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":"A","dns_resolve_server":"1.1.1.1","dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{},"tags":[],"maintenance":false,"conditions":[{"type":"expression","variable":"topic","operator":"==","value":"sensors/temp","andOr":"and"},{"type":"expression","variable":"message","operator":"contains","value":"alert","andOr":"or"}]}`,
+			),
+
+			want: monitor.MQTT{
+				Base: monitor.Base{
+					ID:              8,
+					Name:            "mqtt-conditions",
+					Description:     nil,
+					PathName:        "mqtt-conditions",
+					Parent:          nil,
+					Interval:        60,
+					RetryInterval:   60,
+					ResendInterval:  0,
+					MaxRetries:      1,
+					UpsideDown:      false,
+					NotificationIDs: nil,
+					IsActive:        true,
+				},
+				MQTTDetails: monitor.MQTTDetails{
+					Hostname:      "mqtt.example.com",
+					Port:          &port1883,
+					MQTTTopic:     "sensors/temp",
+					MQTTCheckType: monitor.MQTTCheckTypeKeyword,
+					Conditions: []monitor.Condition{
+						{Variable: "topic", Operator: "==", Value: "sensors/temp", AndOr: monitor.ConditionAnd},
+						{Variable: "message", Operator: "contains", Value: "alert", AndOr: monitor.ConditionOr},
+					},
+				},
+			},
+			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[{"type":"expression","variable":"topic","operator":"==","value":"sensors/temp","andOr":"and"},{"type":"expression","variable":"message","operator":"contains","value":"alert","andOr":"or"}],"description":null,"expectedValue":null,"hostname":"mqtt.example.com","id":8,"interval":60,"jsonPath":null,"maxretries":1,"mqttCheckType":"keyword","mqttPassword":null,"mqttSuccessMessage":null,"mqttTopic":"sensors/temp","mqttUsername":null,"mqttWebsocketPath":null,"name":"mqtt-conditions","notificationIDList":{},"parent":null,"port":1883,"resendInterval":0,"retryInterval":60,"type":"mqtt","upsideDown":false}`,
+		},
 	}
 
 	for _, tc := range tests {

--- a/monitor/monitor_mysql.go
+++ b/monitor/monitor_mysql.go
@@ -77,7 +77,7 @@ func (m MySQL) MarshalJSON() ([]byte, error) {
 	raw["accepted_statuscodes"] = []string{}
 
 	// Uptime Kuma v2 requires conditions field (empty array by default)
-	raw["conditions"] = []any{}
+	raw["conditions"] = conditionsForWire(m.Conditions)
 
 	data, err := json.Marshal(raw)
 	if err != nil {
@@ -93,6 +93,10 @@ type MySQLDetails struct {
 	DatabaseConnectionString string `json:"databaseConnectionString"`
 	// DatabaseQuery is an optional SQL query to execute (default: SELECT 1).
 	DatabaseQuery *string `json:"databaseQuery"`
+	// Conditions is an optional list of assertion clauses evaluated against the
+	// query result. When set, the query is expected to return a single value
+	// that is matched against the conditions.
+	Conditions []Condition `json:"conditions,omitempty"`
 }
 
 // Type returns the monitor type.

--- a/monitor/monitor_mysql_test.go
+++ b/monitor/monitor_mysql_test.go
@@ -76,6 +76,38 @@ func TestMonitorMySQL_Unmarshal(t *testing.T) {
 			},
 			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"databaseConnectionString":"mysql://admin:secret@mysql.example.com:3306/mydb","databaseQuery":"SELECT COUNT(*) FROM information_schema.tables;","description":"Test MySQL with query","id":2,"interval":120,"maxretries":3,"name":"mysql-query","notificationIDList":{},"parent":1,"resendInterval":0,"retryInterval":60,"type":"mysql","upsideDown":false}`,
 		},
+		{
+			name: "success with conditions",
+			data: []byte(
+				`{"id":3,"name":"mysql-conditions","description":null,"pathName":"mysql-conditions","parent":null,"childrenIDs":[],"url":null,"method":"GET","hostname":null,"port":null,"maxretries":1,"weight":2000,"active":true,"forceInactive":false,"type":"mysql","timeout":48,"interval":60,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":null,"dns_resolve_server":null,"dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{},"tags":[],"maintenance":false,"databaseQuery":"SELECT COUNT(*) FROM users;","databaseConnectionString":"mysql://user:pass@localhost:3306/app","conditions":[{"type":"expression","variable":"result","operator":">","value":"0","andOr":"and"},{"type":"expression","variable":"result","operator":"<","value":"100","andOr":"and"}]}`,
+			),
+
+			want: monitor.MySQL{
+				Base: monitor.Base{
+					ID:              3,
+					Name:            "mysql-conditions",
+					Description:     nil,
+					PathName:        "mysql-conditions",
+					Parent:          nil,
+					Interval:        60,
+					RetryInterval:   60,
+					ResendInterval:  0,
+					MaxRetries:      1,
+					UpsideDown:      false,
+					NotificationIDs: nil,
+					IsActive:        true,
+				},
+				MySQLDetails: monitor.MySQLDetails{
+					DatabaseConnectionString: "mysql://user:pass@localhost:3306/app",
+					DatabaseQuery:            ptr.To("SELECT COUNT(*) FROM users;"),
+					Conditions: []monitor.Condition{
+						{Variable: "result", Operator: ">", Value: "0", AndOr: monitor.ConditionAnd},
+						{Variable: "result", Operator: "<", Value: "100", AndOr: monitor.ConditionAnd},
+					},
+				},
+			},
+			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[{"type":"expression","variable":"result","operator":">","value":"0","andOr":"and"},{"type":"expression","variable":"result","operator":"<","value":"100","andOr":"and"}],"databaseConnectionString":"mysql://user:pass@localhost:3306/app","databaseQuery":"SELECT COUNT(*) FROM users;","description":null,"id":3,"interval":60,"maxretries":1,"name":"mysql-conditions","notificationIDList":{},"parent":null,"resendInterval":0,"retryInterval":60,"type":"mysql","upsideDown":false}`,
+		},
 	}
 
 	for _, tc := range tests {

--- a/monitor/monitor_postgres.go
+++ b/monitor/monitor_postgres.go
@@ -77,7 +77,7 @@ func (p Postgres) MarshalJSON() ([]byte, error) {
 	raw["accepted_statuscodes"] = []string{}
 
 	// Uptime Kuma v2 requires conditions field (empty array by default)
-	raw["conditions"] = []any{}
+	raw["conditions"] = conditionsForWire(p.Conditions)
 
 	data, err := json.Marshal(raw)
 	if err != nil {
@@ -91,6 +91,10 @@ func (p Postgres) MarshalJSON() ([]byte, error) {
 type PostgresDetails struct {
 	DatabaseConnectionString string `json:"databaseConnectionString"`
 	DatabaseQuery            string `json:"databaseQuery"`
+	// Conditions is an optional list of assertion clauses evaluated against the
+	// query result. When set, the query is expected to return a single value
+	// that is matched against the conditions.
+	Conditions []Condition `json:"conditions,omitempty"`
 }
 
 // Type returns the monitor type.

--- a/monitor/monitor_postgres_test.go
+++ b/monitor/monitor_postgres_test.go
@@ -48,6 +48,37 @@ func TestMonitorPostgres_Unmarshal(t *testing.T) {
 			},
 			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"databaseConnectionString":"postgres://username:password@host:port/database","databaseQuery":"SELECT 1","description":"Test PostgreSQL monitor","id":6,"interval":60,"maxretries":2,"name":"postgres-monitor","notificationIDList":{"1":true,"2":true},"parent":1,"resendInterval":0,"retryInterval":60,"type":"postgres","upsideDown":false}`,
 		},
+		{
+			name: "success with conditions",
+			data: []byte(
+				`{"id":7,"name":"postgres-conditions","description":null,"pathName":"postgres-conditions","parent":null,"childrenIDs":[],"url":null,"method":"GET","hostname":null,"port":null,"maxretries":1,"weight":2000,"active":true,"forceInactive":false,"type":"postgres","timeout":48,"interval":60,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":null,"dns_resolve_server":null,"dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{},"tags":[],"maintenance":false,"databaseQuery":"SELECT version()","databaseConnectionString":"postgres://user:pass@localhost:5432/app","conditions":[{"type":"expression","variable":"result","operator":"contains","value":"PostgreSQL","andOr":"and"}]}`,
+			),
+
+			want: monitor.Postgres{
+				Base: monitor.Base{
+					ID:              7,
+					Name:            "postgres-conditions",
+					Description:     nil,
+					PathName:        "postgres-conditions",
+					Parent:          nil,
+					Interval:        60,
+					RetryInterval:   60,
+					ResendInterval:  0,
+					MaxRetries:      1,
+					UpsideDown:      false,
+					NotificationIDs: nil,
+					IsActive:        true,
+				},
+				PostgresDetails: monitor.PostgresDetails{
+					DatabaseConnectionString: "postgres://user:pass@localhost:5432/app",
+					DatabaseQuery:            "SELECT version()",
+					Conditions: []monitor.Condition{
+						{Variable: "result", Operator: "contains", Value: "PostgreSQL", AndOr: monitor.ConditionAnd},
+					},
+				},
+			},
+			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[{"type":"expression","variable":"result","operator":"contains","value":"PostgreSQL","andOr":"and"}],"databaseConnectionString":"postgres://user:pass@localhost:5432/app","databaseQuery":"SELECT version()","description":null,"id":7,"interval":60,"maxretries":1,"name":"postgres-conditions","notificationIDList":{},"parent":null,"resendInterval":0,"retryInterval":60,"type":"postgres","upsideDown":false}`,
+		},
 	}
 
 	for _, tc := range tests {

--- a/monitor/monitor_redis.go
+++ b/monitor/monitor_redis.go
@@ -77,7 +77,7 @@ func (r Redis) MarshalJSON() ([]byte, error) {
 	raw["accepted_statuscodes"] = []string{}
 
 	// Uptime Kuma v2 requires conditions field (empty array by default)
-	raw["conditions"] = []any{}
+	raw["conditions"] = conditionsForWire(r.Conditions)
 
 	data, err := json.Marshal(raw)
 	if err != nil {
@@ -91,6 +91,9 @@ func (r Redis) MarshalJSON() ([]byte, error) {
 type RedisDetails struct {
 	ConnectionString string `json:"databaseConnectionString"`
 	IgnoreTLS        bool   `json:"ignoreTls"`
+	// Conditions is an optional list of assertion clauses evaluated against the
+	// Redis command result.
+	Conditions []Condition `json:"conditions,omitempty"`
 }
 
 // Type returns the monitor type.

--- a/monitor/monitor_redis_test.go
+++ b/monitor/monitor_redis_test.go
@@ -48,6 +48,37 @@ func TestMonitorRedis_Unmarshal(t *testing.T) {
 			},
 			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"databaseConnectionString":"redis://user:password@localhost:6379","description":"Test Redis monitor","id":6,"ignoreTls":false,"interval":60,"maxretries":2,"name":"redis-monitor","notificationIDList":{"1":true,"2":true},"parent":1,"resendInterval":0,"retryInterval":60,"type":"redis","upsideDown":false}`,
 		},
+		{
+			name: "success with conditions",
+			data: []byte(
+				`{"id":7,"name":"redis-conditions","description":null,"pathName":"redis-conditions","parent":null,"childrenIDs":[],"url":null,"method":"GET","hostname":null,"port":null,"maxretries":1,"weight":2000,"active":true,"forceInactive":false,"type":"redis","timeout":48,"interval":60,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":true,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":null,"dns_resolve_server":null,"dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{},"tags":[],"maintenance":false,"databaseQuery":null,"databaseConnectionString":"rediss://localhost:6380","conditions":[{"type":"expression","variable":"result","operator":"==","value":"PONG","andOr":"and"}]}`,
+			),
+
+			want: monitor.Redis{
+				Base: monitor.Base{
+					ID:              7,
+					Name:            "redis-conditions",
+					Description:     nil,
+					PathName:        "redis-conditions",
+					Parent:          nil,
+					Interval:        60,
+					RetryInterval:   60,
+					ResendInterval:  0,
+					MaxRetries:      1,
+					UpsideDown:      false,
+					NotificationIDs: nil,
+					IsActive:        true,
+				},
+				RedisDetails: monitor.RedisDetails{
+					ConnectionString: "rediss://localhost:6380",
+					IgnoreTLS:        true,
+					Conditions: []monitor.Condition{
+						{Variable: "result", Operator: "==", Value: "PONG", AndOr: monitor.ConditionAnd},
+					},
+				},
+			},
+			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[{"type":"expression","variable":"result","operator":"==","value":"PONG","andOr":"and"}],"databaseConnectionString":"rediss://localhost:6380","description":null,"id":7,"ignoreTls":true,"interval":60,"maxretries":1,"name":"redis-conditions","notificationIDList":{},"parent":null,"resendInterval":0,"retryInterval":60,"type":"redis","upsideDown":false}`,
+		},
 	}
 
 	for _, tc := range tests {

--- a/monitor/monitor_snmp.go
+++ b/monitor/monitor_snmp.go
@@ -84,7 +84,7 @@ func (s SNMP) MarshalJSON() ([]byte, error) {
 	raw["accepted_statuscodes"] = []string{}
 
 	// Uptime Kuma v2 requires conditions field (empty array by default)
-	raw["conditions"] = []any{}
+	raw["conditions"] = conditionsForWire(s.Conditions)
 
 	data, err := json.Marshal(raw)
 	if err != nil {
@@ -105,6 +105,9 @@ type SNMPDetails struct {
 	JSONPath         *string `json:"jsonPath"`
 	JSONPathOperator *string `json:"jsonPathOperator"`
 	ExpectedValue    *string `json:"expectedValue"`
+	// Conditions is an optional list of assertion clauses evaluated against the
+	// SNMP query result.
+	Conditions []Condition `json:"conditions,omitempty"`
 }
 
 // Type returns the monitor type.

--- a/monitor/monitor_snmp_test.go
+++ b/monitor/monitor_snmp_test.go
@@ -124,6 +124,40 @@ func TestMonitorSNMP_Unmarshal(t *testing.T) {
 			},
 			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":"Test SNMPv3 monitor","expectedValue":null,"hostname":"192.168.1.2","id":12,"interval":60,"jsonPath":null,"jsonPathOperator":null,"maxretries":3,"name":"snmp-v3","notificationIDList":{},"parent":null,"port":161,"radiusPassword":"","resendInterval":0,"retryInterval":60,"snmpOid":"1.3.6.1.2.1.1.3.0","snmpV3Username":"snmpuser","snmpVersion":"3","type":"snmp","upsideDown":false}`,
 		},
+		{
+			name: "success with conditions",
+			data: []byte(
+				`{"id":13,"name":"snmp-conditions","description":null,"pathName":"snmp-conditions","parent":null,"childrenIDs":[],"url":null,"method":"GET","hostname":"10.0.0.2","port":161,"maxretries":1,"weight":2000,"active":true,"forceInactive":false,"type":"snmp","timeout":48,"interval":60,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":null,"dns_resolve_server":null,"dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{},"tags":[],"maintenance":false,"jsonPath":null,"jsonPathOperator":null,"expectedValue":null,"databaseConnectionString":null,"radiusPassword":"public","snmpVersion":"2c","snmpOid":"1.3.6.1.2.1.1.3.0","conditions":[{"type":"expression","variable":"snmp","operator":">","value":"0","andOr":"and"}]}`,
+			),
+
+			want: monitor.SNMP{
+				Base: monitor.Base{
+					ID:              13,
+					Name:            "snmp-conditions",
+					Description:     nil,
+					PathName:        "snmp-conditions",
+					Parent:          nil,
+					Interval:        60,
+					RetryInterval:   60,
+					ResendInterval:  0,
+					MaxRetries:      1,
+					UpsideDown:      false,
+					NotificationIDs: nil,
+					IsActive:        true,
+				},
+				SNMPDetails: monitor.SNMPDetails{
+					Hostname:      "10.0.0.2",
+					Port:          &port161,
+					SNMPVersion:   "2c",
+					SNMPOID:       "1.3.6.1.2.1.1.3.0",
+					SNMPCommunity: "public",
+					Conditions: []monitor.Condition{
+						{Variable: "snmp", Operator: ">", Value: "0", AndOr: monitor.ConditionAnd},
+					},
+				},
+			},
+			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[{"type":"expression","variable":"snmp","operator":">","value":"0","andOr":"and"}],"description":null,"expectedValue":null,"hostname":"10.0.0.2","id":13,"interval":60,"jsonPath":null,"jsonPathOperator":null,"maxretries":1,"name":"snmp-conditions","notificationIDList":{},"parent":null,"port":161,"radiusPassword":"public","resendInterval":0,"retryInterval":60,"snmpOid":"1.3.6.1.2.1.1.3.0","snmpV3Username":null,"snmpVersion":"2c","type":"snmp","upsideDown":false}`,
+		},
 	}
 
 	for _, tc := range tests {

--- a/monitor/monitor_sqlserver.go
+++ b/monitor/monitor_sqlserver.go
@@ -77,7 +77,7 @@ func (s SQLServer) MarshalJSON() ([]byte, error) {
 	raw["accepted_statuscodes"] = []string{}
 
 	// Uptime Kuma v2 requires conditions field (empty array by default)
-	raw["conditions"] = []any{}
+	raw["conditions"] = conditionsForWire(s.Conditions)
 
 	data, err := json.Marshal(raw)
 	if err != nil {
@@ -93,6 +93,10 @@ type SQLServerDetails struct {
 	DatabaseConnectionString string `json:"databaseConnectionString"`
 	// DatabaseQuery is an optional SQL query to execute (default: basic connection test).
 	DatabaseQuery *string `json:"databaseQuery"`
+	// Conditions is an optional list of assertion clauses evaluated against the
+	// query result. When set, the query is expected to return a single value
+	// that is matched against the conditions.
+	Conditions []Condition `json:"conditions,omitempty"`
 }
 
 // Type returns the monitor type.

--- a/monitor/monitor_sqlserver_test.go
+++ b/monitor/monitor_sqlserver_test.go
@@ -76,6 +76,37 @@ func TestMonitorSQLServer_Unmarshal(t *testing.T) {
 			},
 			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"databaseConnectionString":"Server=sqlserver.example.com,1433;Database=testdb;User Id=user;Password=pass;","databaseQuery":"SELECT COUNT(*) FROM sys.tables;","description":"Test SQL Server with query","id":2,"interval":120,"maxretries":3,"name":"sqlserver-query","notificationIDList":{},"parent":1,"resendInterval":0,"retryInterval":60,"type":"sqlserver","upsideDown":false}`,
 		},
+		{
+			name: "success with conditions",
+			data: []byte(
+				`{"id":3,"name":"sqlserver-conditions","description":null,"pathName":"sqlserver-conditions","parent":null,"childrenIDs":[],"url":null,"method":"GET","hostname":null,"port":null,"maxretries":1,"weight":2000,"active":true,"forceInactive":false,"type":"sqlserver","timeout":48,"interval":60,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":null,"dns_resolve_server":null,"dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{},"tags":[],"maintenance":false,"databaseQuery":"SELECT COUNT(*) FROM sys.tables;","databaseConnectionString":"Server=sqlserver.example.com,1433;Database=testdb;User Id=user;Password=pass;","conditions":[{"type":"expression","variable":"result","operator":">","value":"10","andOr":"and"}]}`,
+			),
+
+			want: monitor.SQLServer{
+				Base: monitor.Base{
+					ID:              3,
+					Name:            "sqlserver-conditions",
+					Description:     nil,
+					PathName:        "sqlserver-conditions",
+					Parent:          nil,
+					Interval:        60,
+					RetryInterval:   60,
+					ResendInterval:  0,
+					MaxRetries:      1,
+					UpsideDown:      false,
+					NotificationIDs: nil,
+					IsActive:        true,
+				},
+				SQLServerDetails: monitor.SQLServerDetails{
+					DatabaseConnectionString: "Server=sqlserver.example.com,1433;Database=testdb;User Id=user;Password=pass;",
+					DatabaseQuery:            ptr.To("SELECT COUNT(*) FROM sys.tables;"),
+					Conditions: []monitor.Condition{
+						{Variable: "result", Operator: ">", Value: "10", AndOr: monitor.ConditionAnd},
+					},
+				},
+			},
+			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[{"type":"expression","variable":"result","operator":">","value":"10","andOr":"and"}],"databaseConnectionString":"Server=sqlserver.example.com,1433;Database=testdb;User Id=user;Password=pass;","databaseQuery":"SELECT COUNT(*) FROM sys.tables;","description":null,"id":3,"interval":60,"maxretries":1,"name":"sqlserver-conditions","notificationIDList":{},"parent":null,"resendInterval":0,"retryInterval":60,"type":"sqlserver","upsideDown":false}`,
+		},
 	}
 
 	for _, tc := range tests {

--- a/monitor_test.go
+++ b/monitor_test.go
@@ -511,6 +511,9 @@ func TestMonitorCRUD(t *testing.T) {
 				postgres.Name = "Updated Postgres Monitor"
 				postgres.DatabaseConnectionString = "postgres://newuser:newpass@localhost:5432/newdb"
 				postgres.DatabaseQuery = "SELECT version()"
+				postgres.Conditions = []monitor.Condition{
+					{Variable: "result", Operator: "contains", Value: "PostgreSQL", AndOr: monitor.ConditionAnd},
+				}
 			},
 			verifyCreatedFunc: func(t *testing.T, actual monitor.Monitor, id int64) {
 				t.Helper()
@@ -535,6 +538,9 @@ func TestMonitorCRUD(t *testing.T) {
 				require.Equal(t, "Updated Postgres Monitor", postgres.Name)
 				require.Equal(t, "postgres://newuser:newpass@localhost:5432/newdb", postgres.DatabaseConnectionString)
 				require.Equal(t, "SELECT version()", postgres.DatabaseQuery)
+				require.Equal(t, []monitor.Condition{
+					{Variable: "result", Operator: "contains", Value: "PostgreSQL", AndOr: monitor.ConditionAnd},
+				}, postgres.Conditions)
 			},
 			testPauseResume: false,
 		},
@@ -616,6 +622,9 @@ func TestMonitorCRUD(t *testing.T) {
 
 				redis.Name = "Updated Redis Monitor"
 				redis.ConnectionString = "redis://user:password@localhost:6380"
+				redis.Conditions = []monitor.Condition{
+					{Variable: "result", Operator: "==", Value: "PONG", AndOr: monitor.ConditionAnd},
+				}
 			},
 			verifyCreatedFunc: func(t *testing.T, actual monitor.Monitor, id int64) {
 				t.Helper()
@@ -639,6 +648,9 @@ func TestMonitorCRUD(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, "Updated Redis Monitor", redis.Name)
 				require.Equal(t, "redis://user:password@localhost:6380", redis.ConnectionString)
+				require.Equal(t, []monitor.Condition{
+					{Variable: "result", Operator: "==", Value: "PONG", AndOr: monitor.ConditionAnd},
+				}, redis.Conditions)
 			},
 			testPauseResume: true,
 		},
@@ -792,6 +804,9 @@ func TestMonitorCRUD(t *testing.T) {
 				snmp.Name = "Updated SNMP Monitor"
 				snmp.Hostname = "10.0.0.1"
 				snmp.SNMPOID = "1.3.6.1.2.1.2.2.1.5.1"
+				snmp.Conditions = []monitor.Condition{
+					{Variable: "snmp", Operator: ">", Value: "0", AndOr: monitor.ConditionAnd},
+				}
 			},
 			verifyCreatedFunc: func(t *testing.T, actual monitor.Monitor, id int64) {
 				t.Helper()
@@ -816,6 +831,9 @@ func TestMonitorCRUD(t *testing.T) {
 				require.Equal(t, "Updated SNMP Monitor", snmp.Name)
 				require.Equal(t, "10.0.0.1", snmp.Hostname)
 				require.Equal(t, "1.3.6.1.2.1.2.2.1.5.1", snmp.SNMPOID)
+				require.Equal(t, []monitor.Condition{
+					{Variable: "snmp", Operator: ">", Value: "0", AndOr: monitor.ConditionAnd},
+				}, snmp.Conditions)
 			},
 			testPauseResume: true,
 		},
@@ -1082,6 +1100,10 @@ func TestMonitorCRUD(t *testing.T) {
 				mqtt.MQTTSuccessMessage = nil
 				mqtt.JSONPath = ptr.To("status")
 				mqtt.ExpectedValue = ptr.To("online")
+				mqtt.Conditions = []monitor.Condition{
+					{Variable: "topic", Operator: "==", Value: "home/temperature", AndOr: monitor.ConditionAnd},
+					{Variable: "message", Operator: "contains", Value: "online", AndOr: monitor.ConditionAnd},
+				}
 			},
 			verifyCreatedFunc: func(t *testing.T, actual monitor.Monitor, id int64) {
 				t.Helper()
@@ -1109,6 +1131,10 @@ func TestMonitorCRUD(t *testing.T) {
 				require.Equal(t, monitor.MQTTCheckTypeJSONQuery, mqtt.MQTTCheckType)
 				require.Equal(t, "status", *mqtt.JSONPath)
 				require.Equal(t, "online", *mqtt.ExpectedValue)
+				require.Equal(t, []monitor.Condition{
+					{Variable: "topic", Operator: "==", Value: "home/temperature", AndOr: monitor.ConditionAnd},
+					{Variable: "message", Operator: "contains", Value: "online", AndOr: monitor.ConditionAnd},
+				}, mqtt.Conditions)
 			},
 			testPauseResume: true,
 		},
@@ -1260,6 +1286,9 @@ func TestMonitorCRUD(t *testing.T) {
 				sqlserver.Name = "Updated SQL Server Monitor"
 				sqlserver.DatabaseConnectionString = "Server=sqlserver.example.com,1433;Database=testdb;User Id=user;Password=pass;"
 				sqlserver.DatabaseQuery = ptr.To("SELECT COUNT(*) FROM sys.tables;")
+				sqlserver.Conditions = []monitor.Condition{
+					{Variable: "result", Operator: ">", Value: "0", AndOr: monitor.ConditionAnd},
+				}
 			},
 			verifyCreatedFunc: func(t *testing.T, actual monitor.Monitor, id int64) {
 				t.Helper()
@@ -1288,6 +1317,9 @@ func TestMonitorCRUD(t *testing.T) {
 					sqlserver.DatabaseConnectionString,
 				)
 				require.Equal(t, "SELECT COUNT(*) FROM sys.tables;", *sqlserver.DatabaseQuery)
+				require.Equal(t, []monitor.Condition{
+					{Variable: "result", Operator: ">", Value: "0", AndOr: monitor.ConditionAnd},
+				}, sqlserver.Conditions)
 			},
 			testPauseResume: false,
 		},
@@ -1317,6 +1349,9 @@ func TestMonitorCRUD(t *testing.T) {
 				mysql.Name = "Updated MySQL Monitor"
 				mysql.DatabaseConnectionString = "mysql://admin:secret@mysql.example.com:3306/mydb"
 				mysql.DatabaseQuery = ptr.To("SELECT COUNT(*) FROM information_schema.tables;")
+				mysql.Conditions = []monitor.Condition{
+					{Variable: "result", Operator: ">", Value: "0", AndOr: monitor.ConditionAnd},
+				}
 			},
 			verifyCreatedFunc: func(t *testing.T, actual monitor.Monitor, id int64) {
 				t.Helper()
@@ -1341,6 +1376,9 @@ func TestMonitorCRUD(t *testing.T) {
 				require.Equal(t, "Updated MySQL Monitor", mysql.Name)
 				require.Equal(t, "mysql://admin:secret@mysql.example.com:3306/mydb", mysql.DatabaseConnectionString)
 				require.Equal(t, "SELECT COUNT(*) FROM information_schema.tables;", *mysql.DatabaseQuery)
+				require.Equal(t, []monitor.Condition{
+					{Variable: "result", Operator: ">", Value: "0", AndOr: monitor.ConditionAnd},
+				}, mysql.Conditions)
 			},
 			testPauseResume: false,
 		},
@@ -1374,6 +1412,9 @@ func TestMonitorCRUD(t *testing.T) {
 				mongodb.DatabaseQuery = ptr.To("{\"dbStats\": 1}")
 				mongodb.JSONPath = ptr.To("$.ok")
 				mongodb.ExpectedValue = ptr.To("1")
+				mongodb.Conditions = []monitor.Condition{
+					{Variable: "numericValue", Operator: ">=", Value: "1", AndOr: monitor.ConditionAnd},
+				}
 			},
 			verifyCreatedFunc: func(t *testing.T, actual monitor.Monitor, id int64) {
 				t.Helper()
@@ -1404,6 +1445,9 @@ func TestMonitorCRUD(t *testing.T) {
 				require.Equal(t, "{\"dbStats\": 1}", *mongodb.DatabaseQuery)
 				require.Equal(t, "$.ok", *mongodb.JSONPath)
 				require.Equal(t, "1", *mongodb.ExpectedValue)
+				require.Equal(t, []monitor.Condition{
+					{Variable: "numericValue", Operator: ">=", Value: "1", AndOr: monitor.ConditionAnd},
+				}, mongodb.Conditions)
 			},
 			testPauseResume: false,
 		},


### PR DESCRIPTION
## Summary

Adds support for the upstream Uptime Kuma "conditions" mechanism: an array of assertion clauses evaluated against a monitor's parsed result (query result, MQTT payload, JSON-query value, etc.).

## Details

- New shared `monitor.Condition` struct (`monitor/conditions.go`) with `Variable`, `Operator`, `Value`, `AndOr` fields.
- Custom `MarshalJSON` emits the upstream wire-format `"type": "expression"` field so the server-side condition evaluator picks the entries up.
- Added `Conditions []Condition \`json:"conditions,omitempty"\`` field to each affected `*Details` struct:
  - `MQTTDetails`
  - `MySQLDetails`
  - `PostgresDetails`
  - `SQLServerDetails`
  - `MongoDBDetails`
  - `RedisDetails`
  - `SNMPDetails`
- Each affected monitor's `MarshalJSON` now emits the conditions slice (defaulting to an empty array, preserving the existing v2 server expectation).
- `UnmarshalJSON` round-trips the field via the existing per-`*Details` JSON decoding.

The `oracledb` monitor type is not modeled by this client yet and is left for a separate new-monitor-type issue (see #253 description).

## Tests

- Unit: added `Condition` marshal/unmarshal tests in `monitor/conditions_test.go` and a "success with conditions" round-trip case to each affected monitor's `_test.go`.
- E2E: extended each affected monitor's `TestMonitorCRUD` case to create / update / verify conditions against a live Uptime Kuma server. `task test-e2e` passes locally.

Closes #253