### PR TITLE
feat(monitor): treat PostgreSQL `databaseQuery` as optional

### DIFF
--- a/monitor/helpers.go
+++ b/monitor/helpers.go
@@ -48,10 +48,24 @@ func formatMonitor(s any, includeType bool) string {
 			name = field.Name
 		}
 
+		// Render pointer fields by dereferencing so optional values such as
+		// *string appear as their underlying value (or <nil>) instead of as
+		// a pointer address.
 		var valueStr string
-		if value.Kind() == reflect.String {
+		switch {
+		case value.Kind() == reflect.String:
 			valueStr = fmt.Sprintf("%q", value.String())
-		} else {
+
+		case value.Kind() == reflect.Pointer && value.IsNil():
+			valueStr = "<nil>"
+
+		case value.Kind() == reflect.Pointer && value.Elem().Kind() == reflect.String:
+			valueStr = fmt.Sprintf("%q", value.Elem().String())
+
+		case value.Kind() == reflect.Pointer:
+			valueStr = fmt.Sprintf("%v", value.Elem().Interface())
+
+		default:
 			valueStr = fmt.Sprintf("%v", value.Interface())
 		}
 

--- a/monitor/monitor_postgres.go
+++ b/monitor/monitor_postgres.go
@@ -89,8 +89,10 @@ func (p Postgres) MarshalJSON() ([]byte, error) {
 
 // PostgresDetails contains postgres-specific monitor configuration.
 type PostgresDetails struct {
+	// DatabaseConnectionString is the PostgreSQL connection string.
 	DatabaseConnectionString string `json:"databaseConnectionString"`
-	DatabaseQuery            string `json:"databaseQuery"`
+	// DatabaseQuery is an optional SQL query to execute (default: SELECT 1).
+	DatabaseQuery *string `json:"databaseQuery"`
 	// Conditions is an optional list of assertion clauses evaluated against the
 	// query result. When set, the query is expected to return a single value
 	// that is matched against the conditions.

--- a/monitor/monitor_postgres_test.go
+++ b/monitor/monitor_postgres_test.go
@@ -21,6 +21,34 @@ func TestMonitorPostgres_Unmarshal(t *testing.T) {
 		wantJSON string
 	}{
 		{
+			name: "success with connection string only",
+			data: []byte(
+				`{"id":5,"name":"postgres-default","description":null,"pathName":"postgres-default","parent":null,"childrenIDs":[],"url":null,"method":"GET","hostname":null,"port":null,"maxretries":1,"weight":2000,"active":true,"forceInactive":false,"type":"postgres","timeout":48,"interval":60,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":null,"dns_resolve_server":null,"dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{},"tags":[],"maintenance":false,"databaseQuery":null,"databaseConnectionString":"postgres://user:pass@localhost:5432/app"}`,
+			),
+
+			want: monitor.Postgres{
+				Base: monitor.Base{
+					ID:              5,
+					Name:            "postgres-default",
+					Description:     nil,
+					PathName:        "postgres-default",
+					Parent:          nil,
+					Interval:        60,
+					RetryInterval:   60,
+					ResendInterval:  0,
+					MaxRetries:      1,
+					UpsideDown:      false,
+					NotificationIDs: nil,
+					IsActive:        true,
+				},
+				PostgresDetails: monitor.PostgresDetails{
+					DatabaseConnectionString: "postgres://user:pass@localhost:5432/app",
+					DatabaseQuery:            nil,
+				},
+			},
+			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"databaseConnectionString":"postgres://user:pass@localhost:5432/app","databaseQuery":null,"description":null,"id":5,"interval":60,"maxretries":1,"name":"postgres-default","notificationIDList":{},"parent":null,"resendInterval":0,"retryInterval":60,"type":"postgres","upsideDown":false}`,
+		},
+		{
 			name: "success",
 			data: []byte(
 				`{"id":6,"name":"postgres-monitor","description":"Test PostgreSQL monitor","pathName":"group / postgres-monitor","parent":1,"childrenIDs":[],"url":null,"method":"GET","hostname":null,"port":null,"maxretries":2,"weight":2000,"active":true,"forceInactive":false,"type":"postgres","timeout":48,"interval":60,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":"A","dns_resolve_server":"1.1.1.1","dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{"1":true,"2":true},"tags":[],"maintenance":false,"mqttTopic":"","mqttSuccessMessage":"","databaseQuery":"SELECT 1","authMethod":null,"grpcUrl":null,"grpcProtobuf":null,"grpcMethod":null,"grpcServiceName":null,"grpcEnableTls":false,"radiusCalledStationId":null,"radiusCallingStationId":null,"game":null,"gamedigGivenPortOnly":true,"httpBodyEncoding":"json","jsonPath":null,"expectedValue":null,"kafkaProducerTopic":null,"kafkaProducerBrokers":[],"kafkaProducerSsl":false,"kafkaProducerAllowAutoTopicCreation":false,"kafkaProducerMessage":null,"screenshot":null,"headers":null,"body":null,"grpcBody":null,"grpcMetadata":null,"basic_auth_user":null,"basic_auth_pass":null,"oauth_client_id":null,"oauth_client_secret":null,"oauth_token_url":null,"oauth_scopes":null,"oauth_auth_method":"client_secret_basic","pushToken":null,"databaseConnectionString":"postgres://username:password@host:port/database","radiusUsername":null,"radiusPassword":null,"radiusSecret":null,"mqttUsername":"","mqttPassword":"","authWorkstation":null,"authDomain":null,"tlsCa":null,"tlsCert":null,"tlsKey":null,"kafkaProducerSaslOptions":{"mechanism":"None"},"includeSensitiveData":true}`,
@@ -43,7 +71,7 @@ func TestMonitorPostgres_Unmarshal(t *testing.T) {
 				},
 				PostgresDetails: monitor.PostgresDetails{
 					DatabaseConnectionString: "postgres://username:password@host:port/database",
-					DatabaseQuery:            "SELECT 1",
+					DatabaseQuery:            ptr.To("SELECT 1"),
 				},
 			},
 			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"databaseConnectionString":"postgres://username:password@host:port/database","databaseQuery":"SELECT 1","description":"Test PostgreSQL monitor","id":6,"interval":60,"maxretries":2,"name":"postgres-monitor","notificationIDList":{"1":true,"2":true},"parent":1,"resendInterval":0,"retryInterval":60,"type":"postgres","upsideDown":false}`,
@@ -71,7 +99,7 @@ func TestMonitorPostgres_Unmarshal(t *testing.T) {
 				},
 				PostgresDetails: monitor.PostgresDetails{
 					DatabaseConnectionString: "postgres://user:pass@localhost:5432/app",
-					DatabaseQuery:            "SELECT version()",
+					DatabaseQuery:            ptr.To("SELECT version()"),
 					Conditions: []monitor.Condition{
 						{Variable: "result", Operator: "contains", Value: "PostgreSQL", AndOr: monitor.ConditionAnd},
 					},

--- a/monitor/monitor_postgres_test.go
+++ b/monitor/monitor_postgres_test.go
@@ -23,22 +23,22 @@ func TestMonitorPostgres_Unmarshal(t *testing.T) {
 		{
 			name: "success with connection string only",
 			data: []byte(
-				`{"id":5,"name":"postgres-default","description":null,"pathName":"postgres-default","parent":null,"childrenIDs":[],"url":null,"method":"GET","hostname":null,"port":null,"maxretries":1,"weight":2000,"active":true,"forceInactive":false,"type":"postgres","timeout":48,"interval":60,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":null,"dns_resolve_server":null,"dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{},"tags":[],"maintenance":false,"databaseQuery":null,"databaseConnectionString":"postgres://user:pass@localhost:5432/app"}`,
+				`{"id":5,"name":"postgres-default","description":"PostgreSQL with default query","pathName":"group / postgres-default","parent":1,"childrenIDs":[],"url":null,"method":"GET","hostname":null,"port":null,"maxretries":1,"weight":2000,"active":true,"forceInactive":false,"type":"postgres","timeout":48,"interval":60,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":"A","dns_resolve_server":"1.1.1.1","dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{"1":true,"2":true},"tags":[],"maintenance":false,"mqttTopic":"","mqttSuccessMessage":"","databaseQuery":null,"authMethod":null,"grpcUrl":null,"grpcProtobuf":null,"grpcMethod":null,"grpcServiceName":null,"grpcEnableTls":false,"radiusCalledStationId":null,"radiusCallingStationId":null,"game":null,"gamedigGivenPortOnly":true,"httpBodyEncoding":"json","jsonPath":null,"expectedValue":null,"kafkaProducerTopic":null,"kafkaProducerBrokers":[],"kafkaProducerSsl":false,"kafkaProducerAllowAutoTopicCreation":false,"kafkaProducerMessage":null,"screenshot":null,"headers":null,"body":null,"grpcBody":null,"grpcMetadata":null,"basic_auth_user":null,"basic_auth_pass":null,"oauth_client_id":null,"oauth_client_secret":null,"oauth_token_url":null,"oauth_scopes":null,"oauth_auth_method":"client_secret_basic","pushToken":null,"databaseConnectionString":"postgres://user:pass@localhost:5432/app","radiusUsername":null,"radiusPassword":null,"radiusSecret":null,"mqttUsername":"","mqttPassword":"","authWorkstation":null,"authDomain":null,"tlsCa":null,"tlsCert":null,"tlsKey":null,"kafkaProducerSaslOptions":{"mechanism":"None"},"includeSensitiveData":true}`,
 			),
 
 			want: monitor.Postgres{
 				Base: monitor.Base{
 					ID:              5,
 					Name:            "postgres-default",
-					Description:     nil,
-					PathName:        "postgres-default",
-					Parent:          nil,
+					Description:     ptr.To("PostgreSQL with default query"),
+					PathName:        "group / postgres-default",
+					Parent:          &parent1,
 					Interval:        60,
 					RetryInterval:   60,
 					ResendInterval:  0,
 					MaxRetries:      1,
 					UpsideDown:      false,
-					NotificationIDs: nil,
+					NotificationIDs: []int64{1, 2},
 					IsActive:        true,
 				},
 				PostgresDetails: monitor.PostgresDetails{
@@ -46,7 +46,7 @@ func TestMonitorPostgres_Unmarshal(t *testing.T) {
 					DatabaseQuery:            nil,
 				},
 			},
-			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"databaseConnectionString":"postgres://user:pass@localhost:5432/app","databaseQuery":null,"description":null,"id":5,"interval":60,"maxretries":1,"name":"postgres-default","notificationIDList":{},"parent":null,"resendInterval":0,"retryInterval":60,"type":"postgres","upsideDown":false}`,
+			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"databaseConnectionString":"postgres://user:pass@localhost:5432/app","databaseQuery":null,"description":"PostgreSQL with default query","id":5,"interval":60,"maxretries":1,"name":"postgres-default","notificationIDList":{"1":true,"2":true},"parent":1,"resendInterval":0,"retryInterval":60,"type":"postgres","upsideDown":false}`,
 		},
 		{
 			name: "success",

--- a/monitor/monitor_postgres_test.go
+++ b/monitor/monitor_postgres_test.go
@@ -125,3 +125,53 @@ func TestMonitorPostgres_Unmarshal(t *testing.T) {
 		})
 	}
 }
+
+func TestMonitorPostgres_String(t *testing.T) {
+	tests := []struct {
+		name string
+
+		details monitor.PostgresDetails
+
+		wantContains    []string
+		wantNotContains []string
+	}{
+		{
+			name: "query set",
+			details: monitor.PostgresDetails{
+				DatabaseConnectionString: "postgres://user:pass@localhost:5432/app",
+				DatabaseQuery:            ptr.To("SELECT 1"),
+			},
+			wantContains: []string{
+				`databaseConnectionString: "postgres://user:pass@localhost:5432/app"`,
+				`databaseQuery: "SELECT 1"`,
+			},
+			wantNotContains: []string{"0x"},
+		},
+		{
+			name: "query nil",
+			details: monitor.PostgresDetails{
+				DatabaseConnectionString: "postgres://user:pass@localhost:5432/app",
+				DatabaseQuery:            nil,
+			},
+			wantContains: []string{
+				`databaseConnectionString: "postgres://user:pass@localhost:5432/app"`,
+				"databaseQuery: <nil>",
+			},
+			wantNotContains: []string{"0x"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := monitor.Postgres{PostgresDetails: tc.details}.String()
+
+			for _, want := range tc.wantContains {
+				require.Contains(t, got, want)
+			}
+
+			for _, notWant := range tc.wantNotContains {
+				require.NotContains(t, got, notWant)
+			}
+		})
+	}
+}

--- a/monitor_test.go
+++ b/monitor_test.go
@@ -499,7 +499,7 @@ func TestMonitorCRUD(t *testing.T) {
 				},
 				PostgresDetails: monitor.PostgresDetails{
 					DatabaseConnectionString: "postgres://testuser:testpass@localhost:5432/testdb",
-					DatabaseQuery:            "SELECT 1",
+					DatabaseQuery:            ptr.To("SELECT 1"),
 				},
 			},
 			updateFunc: func(m monitor.Monitor) {
@@ -510,7 +510,7 @@ func TestMonitorCRUD(t *testing.T) {
 
 				postgres.Name = "Updated Postgres Monitor"
 				postgres.DatabaseConnectionString = "postgres://newuser:newpass@localhost:5432/newdb"
-				postgres.DatabaseQuery = "SELECT version()"
+				postgres.DatabaseQuery = ptr.To("SELECT version()")
 				postgres.Conditions = []monitor.Condition{
 					{Variable: "result", Operator: "contains", Value: "PostgreSQL", AndOr: monitor.ConditionAnd},
 				}
@@ -537,7 +537,7 @@ func TestMonitorCRUD(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, "Updated Postgres Monitor", postgres.Name)
 				require.Equal(t, "postgres://newuser:newpass@localhost:5432/newdb", postgres.DatabaseConnectionString)
-				require.Equal(t, "SELECT version()", postgres.DatabaseQuery)
+				require.Equal(t, ptr.To("SELECT version()"), postgres.DatabaseQuery)
 				require.Equal(t, []monitor.Condition{
 					{Variable: "result", Operator: "contains", Value: "PostgreSQL", AndOr: monitor.ConditionAnd},
 				}, postgres.Conditions)


### PR DESCRIPTION
## Summary

Aligns the Go client's PostgreSQL monitor with the upstream change from
louislam/uptime-kuma#6736 (query-result monitoring) by treating
`databaseQuery` as an optional check query.

`PostgresDetails.DatabaseQuery` is changed from `string` to `*string`
so the Go client correctly round-trips a missing / `null` query, matching
the existing `MySQLDetails` pattern. Conditions support for PostgreSQL
was already added by #291 (issue #253) and is preserved here.

## Tests

- **Unit** (`monitor/monitor_postgres_test.go`): new
  `success with connection string only` case exercises the `null`
  `databaseQuery` branch; the existing `success` and
  `success with conditions` cases are updated to use `ptr.To`.
- **E2E** (`monitor_test.go`): the `TestMonitorCRUD` PostgreSQL case
  now uses `ptr.To` for `DatabaseQuery` while still covering create,
  update with query + conditions, and round-trip verification against
  a live Uptime Kuma server.

`task lint`, `task fmt` and `task test-e2e` all pass.

Closes #254