### PR TITLE
feat(notification): add Whatsapp360messenger support

### DIFF
--- a/notification/notification_whatsapp360messenger.go
+++ b/notification/notification_whatsapp360messenger.go
@@ -1,0 +1,68 @@
+package notification
+
+import (
+	"fmt"
+)
+
+// Whatsapp360messenger represents a 360messenger WhatsApp notification provider.
+// 360messenger is a WhatsApp messaging service for sending notifications.
+type Whatsapp360messenger struct {
+	Base
+	Whatsapp360messengerDetails
+}
+
+// Whatsapp360messengerDetails contains the configuration fields for 360messenger notifications.
+type Whatsapp360messengerDetails struct {
+	// AuthToken is the Bearer authentication token.
+	AuthToken string `json:"Whatsapp360messengerAuthToken"`
+	// Recipient is a comma- or semicolon-separated list of phone numbers.
+	Recipient string `json:"Whatsapp360messengerRecipient"`
+	// GroupIDs is the list of WhatsApp group IDs (multi-select).
+	GroupIDs []string `json:"Whatsapp360messengerGroupIds,omitempty"`
+	// GroupID is the legacy single group ID kept for back-compat in upstream payloads.
+	GroupID *string `json:"Whatsapp360messengerGroupId,omitempty"`
+	// UseTemplate enables the use of a custom message template.
+	UseTemplate *bool `json:"Whatsapp360messengerUseTemplate,omitempty"`
+	// Template is the custom message template used when UseTemplate is enabled.
+	Template *string `json:"Whatsapp360messengerTemplate,omitempty"`
+}
+
+// Type returns the notification type identifier for Whatsapp360messenger.
+func (w Whatsapp360messenger) Type() string {
+	return w.Whatsapp360messengerDetails.Type()
+}
+
+// Type returns the notification type identifier for Whatsapp360messengerDetails.
+func (Whatsapp360messengerDetails) Type() string {
+	return "Whatsapp360messenger"
+}
+
+// String returns a string representation of the Whatsapp360messenger notification.
+func (w Whatsapp360messenger) String() string {
+	return fmt.Sprintf(
+		"%s, %s",
+		formatNotification(w.Base, false),
+		formatNotification(w.Whatsapp360messengerDetails, true),
+	)
+}
+
+// UnmarshalJSON unmarshals JSON data into a Whatsapp360messenger notification.
+func (w *Whatsapp360messenger) UnmarshalJSON(data []byte) error {
+	detail := Whatsapp360messengerDetails{}
+	base, err := unmarshalTo(data, &detail)
+	if err != nil {
+		return err
+	}
+
+	*w = Whatsapp360messenger{
+		Base:                        base,
+		Whatsapp360messengerDetails: detail,
+	}
+
+	return nil
+}
+
+// MarshalJSON marshals the Whatsapp360messenger notification into JSON.
+func (w Whatsapp360messenger) MarshalJSON() ([]byte, error) {
+	return marshalJSON(w.Base, w.Whatsapp360messengerDetails)
+}

--- a/notification/notification_whatsapp360messenger.go
+++ b/notification/notification_whatsapp360messenger.go
@@ -18,7 +18,7 @@ type Whatsapp360messengerDetails struct {
 	// Recipient is a comma- or semicolon-separated list of phone numbers.
 	Recipient string `json:"Whatsapp360messengerRecipient"`
 	// GroupIDs is the list of WhatsApp group IDs (multi-select).
-	GroupIDs []string `json:"Whatsapp360messengerGroupIds,omitempty"`
+	GroupIDs []string `json:"Whatsapp360messengerGroupIds,omitzero"`
 	// GroupID is the legacy single group ID kept for back-compat in upstream payloads.
 	GroupID *string `json:"Whatsapp360messengerGroupId,omitempty"`
 	// UseTemplate enables the use of a custom message template.

--- a/notification/notification_whatsapp360messenger_test.go
+++ b/notification/notification_whatsapp360messenger_test.go
@@ -1,0 +1,155 @@
+package notification_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/breml/go-uptime-kuma-client/internal/ptr"
+	"github.com/breml/go-uptime-kuma-client/notification"
+)
+
+func TestNotificationWhatsapp360messenger_Unmarshal(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+
+		want     notification.Whatsapp360messenger
+		wantJSON string
+	}{
+		{
+			name: "success with all fields",
+			data: []byte(
+				`{"id":1,"name":"My 360messenger Alert","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"My 360messenger Alert\",\"Whatsapp360messengerAuthToken\":\"token123\",\"Whatsapp360messengerRecipient\":\"447488888888\",\"Whatsapp360messengerGroupIds\":[\"group1\",\"group2\"],\"Whatsapp360messengerUseTemplate\":true,\"Whatsapp360messengerTemplate\":\"Alert: {{ msg }}\",\"type\":\"Whatsapp360messenger\"}"}`,
+			),
+
+			want: notification.Whatsapp360messenger{
+				Base: notification.Base{
+					ID:            1,
+					Name:          "My 360messenger Alert",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     true,
+					ApplyExisting: true,
+				},
+				Whatsapp360messengerDetails: notification.Whatsapp360messengerDetails{
+					AuthToken:   "token123",
+					Recipient:   "447488888888",
+					GroupIDs:    []string{"group1", "group2"},
+					UseTemplate: ptr.To(true),
+					Template:    ptr.To("Alert: {{ msg }}"),
+				},
+			},
+			wantJSON: `{"Whatsapp360messengerAuthToken":"token123","Whatsapp360messengerGroupIds":["group1","group2"],"Whatsapp360messengerRecipient":"447488888888","Whatsapp360messengerTemplate":"Alert: {{ msg }}","Whatsapp360messengerUseTemplate":true,"active":true,"applyExisting":true,"id":1,"isDefault":true,"name":"My 360messenger Alert","type":"Whatsapp360messenger","userId":1}`,
+		},
+		{
+			name: "minimal configuration with recipient only",
+			data: []byte(
+				`{"id":2,"name":"Simple 360messenger","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Simple 360messenger\",\"Whatsapp360messengerAuthToken\":\"key\",\"Whatsapp360messengerRecipient\":\"447499999999\",\"type\":\"Whatsapp360messenger\"}"}`,
+			),
+
+			want: notification.Whatsapp360messenger{
+				Base: notification.Base{
+					ID:            2,
+					Name:          "Simple 360messenger",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				Whatsapp360messengerDetails: notification.Whatsapp360messengerDetails{
+					AuthToken: "key",
+					Recipient: "447499999999",
+				},
+			},
+			wantJSON: `{"Whatsapp360messengerAuthToken":"key","Whatsapp360messengerRecipient":"447499999999","active":true,"applyExisting":false,"id":2,"isDefault":false,"name":"Simple 360messenger","type":"Whatsapp360messenger","userId":1}`,
+		},
+		{
+			name: "with group IDs only (no recipient)",
+			data: []byte(
+				`{"id":3,"name":"Group 360messenger","active":false,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Group 360messenger\",\"Whatsapp360messengerAuthToken\":\"grptoken\",\"Whatsapp360messengerRecipient\":\"\",\"Whatsapp360messengerGroupIds\":[\"grp1\",\"grp2\",\"grp3\"],\"type\":\"Whatsapp360messenger\"}"}`,
+			),
+
+			want: notification.Whatsapp360messenger{
+				Base: notification.Base{
+					ID:            3,
+					Name:          "Group 360messenger",
+					IsActive:      false,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				Whatsapp360messengerDetails: notification.Whatsapp360messengerDetails{
+					AuthToken: "grptoken",
+					Recipient: "",
+					GroupIDs:  []string{"grp1", "grp2", "grp3"},
+				},
+			},
+			wantJSON: `{"Whatsapp360messengerAuthToken":"grptoken","Whatsapp360messengerGroupIds":["grp1","grp2","grp3"],"Whatsapp360messengerRecipient":"","active":false,"applyExisting":false,"id":3,"isDefault":false,"name":"Group 360messenger","type":"Whatsapp360messenger","userId":1}`,
+		},
+		{
+			name: "with legacy GroupId field",
+			data: []byte(
+				`{"id":4,"name":"Legacy 360messenger","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Legacy 360messenger\",\"Whatsapp360messengerAuthToken\":\"legtoken\",\"Whatsapp360messengerRecipient\":\"\",\"Whatsapp360messengerGroupId\":\"legacygrp\",\"type\":\"Whatsapp360messenger\"}"}`,
+			),
+
+			want: notification.Whatsapp360messenger{
+				Base: notification.Base{
+					ID:            4,
+					Name:          "Legacy 360messenger",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				Whatsapp360messengerDetails: notification.Whatsapp360messengerDetails{
+					AuthToken: "legtoken",
+					Recipient: "",
+					GroupID:   ptr.To("legacygrp"),
+				},
+			},
+			wantJSON: `{"Whatsapp360messengerAuthToken":"legtoken","Whatsapp360messengerGroupId":"legacygrp","Whatsapp360messengerRecipient":"","active":true,"applyExisting":false,"id":4,"isDefault":false,"name":"Legacy 360messenger","type":"Whatsapp360messenger","userId":1}`,
+		},
+		{
+			name: "with template disabled (pointer to false)",
+			data: []byte(
+				`{"id":5,"name":"No Template 360messenger","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"No Template 360messenger\",\"Whatsapp360messengerAuthToken\":\"tok\",\"Whatsapp360messengerRecipient\":\"447488888888\",\"Whatsapp360messengerUseTemplate\":false,\"Whatsapp360messengerTemplate\":\"\",\"type\":\"Whatsapp360messenger\"}"}`,
+			),
+
+			want: notification.Whatsapp360messenger{
+				Base: notification.Base{
+					ID:            5,
+					Name:          "No Template 360messenger",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				Whatsapp360messengerDetails: notification.Whatsapp360messengerDetails{
+					AuthToken:   "tok",
+					Recipient:   "447488888888",
+					UseTemplate: ptr.To(false),
+					Template:    ptr.To(""),
+				},
+			},
+			wantJSON: `{"Whatsapp360messengerAuthToken":"tok","Whatsapp360messengerRecipient":"447488888888","Whatsapp360messengerTemplate":"","Whatsapp360messengerUseTemplate":false,"active":true,"applyExisting":false,"id":5,"isDefault":false,"name":"No Template 360messenger","type":"Whatsapp360messenger","userId":1}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			wa := notification.Whatsapp360messenger{}
+
+			err := json.Unmarshal(tc.data, &wa)
+			require.NoError(t, err)
+
+			require.EqualExportedValues(t, tc.want, wa)
+
+			data, err := json.Marshal(wa)
+			require.NoError(t, err)
+
+			require.JSONEq(t, tc.wantJSON, string(data))
+		})
+	}
+}

--- a/notification/notification_whatsapp360messenger_test.go
+++ b/notification/notification_whatsapp360messenger_test.go
@@ -135,6 +135,29 @@ func TestNotificationWhatsapp360messenger_Unmarshal(t *testing.T) {
 			},
 			wantJSON: `{"Whatsapp360messengerAuthToken":"tok","Whatsapp360messengerRecipient":"447488888888","Whatsapp360messengerTemplate":"","Whatsapp360messengerUseTemplate":false,"active":true,"applyExisting":false,"id":5,"isDefault":false,"name":"No Template 360messenger","type":"Whatsapp360messenger","userId":1}`,
 		},
+		{
+			name: "with explicitly empty GroupIDs slice serializes as empty array",
+			data: []byte(
+				`{"id":6,"name":"Empty Groups 360messenger","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Empty Groups 360messenger\",\"Whatsapp360messengerAuthToken\":\"tok\",\"Whatsapp360messengerRecipient\":\"447488888888\",\"Whatsapp360messengerGroupIds\":[],\"type\":\"Whatsapp360messenger\"}"}`,
+			),
+
+			want: notification.Whatsapp360messenger{
+				Base: notification.Base{
+					ID:            6,
+					Name:          "Empty Groups 360messenger",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				Whatsapp360messengerDetails: notification.Whatsapp360messengerDetails{
+					AuthToken: "tok",
+					Recipient: "447488888888",
+					GroupIDs:  []string{},
+				},
+			},
+			wantJSON: `{"Whatsapp360messengerAuthToken":"tok","Whatsapp360messengerGroupIds":[],"Whatsapp360messengerRecipient":"447488888888","active":true,"applyExisting":false,"id":6,"isDefault":false,"name":"Empty Groups 360messenger","type":"Whatsapp360messenger","userId":1}`,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary

- Adds `Whatsapp360messenger` notification type introduced upstream in Uptime Kuma v2.x (louislam/uptime-kuma#7046)
- Implements `Whatsapp360messengerDetails` struct with all required fields: auth token, recipient, group IDs (multi-select), legacy single group ID, and optional custom message template
- Follows the existing pattern from `notification_evolution.go` (similar template + recipient model)

## Fields

| Field | Type | Description |
|---|---|---|
| `Whatsapp360messengerAuthToken` | `string` | Bearer authentication token |
| `Whatsapp360messengerRecipient` | `string` | Comma/semicolon-separated phone numbers |
| `Whatsapp360messengerGroupIds` | `[]string` | Multi-select list of WhatsApp group IDs |
| `Whatsapp360messengerGroupId` | `*string` | Legacy single group ID (back-compat) |
| `Whatsapp360messengerUseTemplate` | `*bool` | Enable custom message template |
| `Whatsapp360messengerTemplate` | `*string` | Custom message template |

## Test plan

- [x] Unit tests covering all fields, minimal configuration, group-only, legacy GroupId, and template-disabled cases
- [x] `task lint` passes
- [x] `task test-e2e` passes

Closes #236