### PR TITLE
docs(monitor): align GameDig Game field comment with gamedig v5 IDs

### DIFF
--- a/monitor/monitor_gamedig.go
+++ b/monitor/monitor_gamedig.go
@@ -95,7 +95,7 @@ type GameDigDetails struct {
 	Hostname string `json:"hostname"`
 	// Port is the game server port.
 	Port int `json:"port"`
-	// Game is the game type identifier (e.g., minecraft, csgo, etc.).
+	// Game is the gamedig v5 game type identifier (e.g., minecraft, valve, l4d2).
 	Game string `json:"game"`
 	// GameDigGivenPortOnly indicates whether to use only the given port without auto-detection.
 	GameDigGivenPortOnly bool `json:"gamedigGivenPortOnly"`


### PR DESCRIPTION
Verify GameDig monitor compatibility with the upstream gamedig v5 upgrade (commit `d096e290`).

**Findings:**

- The `Game` field is a string passthrough — no structural change needed. It accepts any gamedig v5 game-type identifier unchanged.
- `gamedigGivenPortOnly` remains the correct field name; the upstream query still passes it as `givenPortOnly`.
- No new query-type field (e.g. `gamedigQueryType`) was introduced in `EditMonitor.vue` or `gamedig.js`.

**Change:** Update the `Game` field comment to reference confirmed gamedig v5 game-id examples (`minecraft`, `valve`, `l4d2`).

Closes #258