### PR TITLE
feat(notification): add Bale messenger notification support

### DIFF
--- a/notification/notification_bale.go
+++ b/notification/notification_bale.go
@@ -1,0 +1,53 @@
+package notification
+
+import (
+	"fmt"
+)
+
+// Bale represents a Bale messenger notification.
+type Bale struct {
+	Base
+	BaleDetails
+}
+
+// BaleDetails contains bale-specific notification configuration.
+type BaleDetails struct {
+	BotToken string `json:"baleBotToken"`
+	ChatID   string `json:"baleChatID"`
+}
+
+// Type returns the notification type.
+func (b Bale) Type() string {
+	return b.BaleDetails.Type()
+}
+
+// Type returns the notification type.
+func (BaleDetails) Type() string {
+	return "bale"
+}
+
+// String returns a string representation of the notification.
+func (b Bale) String() string {
+	return fmt.Sprintf("%s, %s", formatNotification(b.Base, false), formatNotification(b.BaleDetails, true))
+}
+
+// UnmarshalJSON unmarshals a JSON byte slice into a notification.
+func (b *Bale) UnmarshalJSON(data []byte) error {
+	detail := BaleDetails{}
+	base, err := unmarshalTo(data, &detail)
+	if err != nil {
+		return err
+	}
+
+	*b = Bale{
+		Base:        base,
+		BaleDetails: detail,
+	}
+
+	return nil
+}
+
+// MarshalJSON marshals a notification into a JSON byte slice.
+func (b Bale) MarshalJSON() ([]byte, error) {
+	return marshalJSON(b.Base, &b.BaleDetails)
+}

--- a/notification/notification_bale_test.go
+++ b/notification/notification_bale_test.go
@@ -1,0 +1,81 @@
+package notification_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/breml/go-uptime-kuma-client/notification"
+)
+
+func TestNotificationBale_Unmarshal(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+
+		want     notification.Bale
+		wantJSON string
+	}{
+		{
+			name: "success",
+			data: []byte(
+				`{"id":1,"name":"My Bale Alert","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"My Bale Alert\",\"baleBotToken\":\"123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11\",\"baleChatID\":\"@mychannel\",\"type\":\"bale\"}"}`,
+			),
+
+			want: notification.Bale{
+				Base: notification.Base{
+					ID:            1,
+					Name:          "My Bale Alert",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     true,
+					ApplyExisting: true,
+				},
+				BaleDetails: notification.BaleDetails{
+					BotToken: "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11",
+					ChatID:   "@mychannel",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":true,"baleBotToken":"123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11","baleChatID":"@mychannel","id":1,"isDefault":true,"name":"My Bale Alert","type":"bale","userId":1}`,
+		},
+		{
+			name: "minimal",
+			data: []byte(
+				`{"id":2,"name":"Simple Bale","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Simple Bale\",\"baleBotToken\":\"123456:ABC\",\"baleChatID\":\"123456789\",\"type\":\"bale\"}"}`,
+			),
+
+			want: notification.Bale{
+				Base: notification.Base{
+					ID:            2,
+					Name:          "Simple Bale",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				BaleDetails: notification.BaleDetails{
+					BotToken: "123456:ABC",
+					ChatID:   "123456789",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"baleBotToken":"123456:ABC","baleChatID":"123456789","id":2,"isDefault":false,"name":"Simple Bale","type":"bale","userId":1}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			bale := notification.Bale{}
+
+			err := json.Unmarshal(tc.data, &bale)
+			require.NoError(t, err)
+
+			require.EqualExportedValues(t, tc.want, bale)
+
+			data, err := json.Marshal(bale)
+			require.NoError(t, err)
+
+			require.JSONEq(t, tc.wantJSON, string(data))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add `notification/notification_bale.go` with `Bale` struct and `BaleDetails` containing `baleBotToken` and `baleChatID` fields
- Implement `Type()`, `String()`, `MarshalJSON()`, and `UnmarshalJSON()` following the Telegram notification pattern
- Add `notification/notification_bale_test.go` with success and minimal test cases

Closes #237