### PR TITLE
fix(monitor-dns): address unresolved review comments from PR #283

### DIFF
--- a/monitor/monitor_dns.go
+++ b/monitor/monitor_dns.go
@@ -79,11 +79,7 @@ func (d DNS) MarshalJSON() ([]byte, error) {
 	// Server expects these fields to be arrays and not null.
 	raw["accepted_statuscodes"] = []string{}
 
-	if d.Conditions == nil {
-		raw["conditions"] = []any{}
-	} else {
-		raw["conditions"] = d.Conditions
-	}
+	raw["conditions"] = conditionsForWire(d.Conditions)
 
 	data, err := json.Marshal(raw)
 	if err != nil {
@@ -91,15 +87,6 @@ func (d DNS) MarshalJSON() ([]byte, error) {
 	}
 
 	return data, nil
-}
-
-// Condition carries the information that allow setting a condition on the monitor.
-type Condition struct {
-	Type     string `json:"type"`
-	AndOr    string `json:"andOr"`
-	Variable string `json:"variable"`
-	Operator string `json:"operator"`
-	Value    string `json:"value"`
 }
 
 // DNSDetails contains DNS-specific monitor configuration.
@@ -112,7 +99,7 @@ type DNSDetails struct {
 	ResolverServer string         `json:"dns_resolve_server"`
 	ResolveType    DNSResolveType `json:"dns_resolve_type"`
 	Port           int            `json:"port"`
-	Conditions     []Condition    `json:"conditions"`
+	Conditions     []Condition    `json:"conditions,omitempty"`
 }
 
 // Type returns the monitor type.

--- a/monitor/monitor_dns_test.go
+++ b/monitor/monitor_dns_test.go
@@ -51,6 +51,42 @@ func TestMonitorDNS_Unmarshal(t *testing.T) {
 			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":"Test DNS monitor","dns_resolve_server":"1.1.1.1","dns_resolve_type":"A","hostname":"example.com","id":5,"interval":60,"maxretries":2,"name":"dns-monitor","notificationIDList":{"1":true,"2":true},"parent":1,"port":53,"resendInterval":0,"retryInterval":60,"type":"dns","upsideDown":false}`,
 		},
 		{
+			name: "with conditions",
+			data: []byte(
+				`{"id":7,"name":"dns-cname","description":"Test CNAME DNS monitor","pathName":"dns-cname","parent":null,"childrenIDs":[],"url":null,"method":"GET","hostname":"example.com","port":53,"maxretries":2,"weight":2000,"active":true,"forceInactive":false,"type":"dns","timeout":48,"interval":60,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":"CNAME","dns_resolve_server":"9.9.9.9","dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{},"tags":[],"maintenance":false,"conditions":[{"type":"expression","andOr":"and","variable":"record","operator":"equals","value":"target.example.com."}],"mqttTopic":"","mqttSuccessMessage":"","databaseQuery":null,"authMethod":null,"grpcUrl":null,"grpcProtobuf":null,"grpcMethod":null,"grpcServiceName":null,"grpcEnableTls":false,"radiusCalledStationId":null,"radiusCallingStationId":null,"game":null,"gamedigGivenPortOnly":true,"httpBodyEncoding":"json","jsonPath":null,"expectedValue":null,"kafkaProducerTopic":null,"kafkaProducerBrokers":[],"kafkaProducerSsl":false,"kafkaProducerAllowAutoTopicCreation":false,"kafkaProducerMessage":null,"screenshot":null,"headers":null,"body":null,"grpcBody":null,"grpcMetadata":null,"basic_auth_user":null,"basic_auth_pass":null,"oauth_client_id":null,"oauth_client_secret":null,"oauth_token_url":null,"oauth_scopes":null,"oauth_auth_method":"client_secret_basic","pushToken":null,"databaseConnectionString":null,"radiusUsername":null,"radiusPassword":null,"radiusSecret":null,"mqttUsername":"","mqttPassword":"","authWorkstation":null,"authDomain":null,"tlsCa":null,"tlsCert":null,"tlsKey":null,"kafkaProducerSaslOptions":{"mechanism":"None"},"includeSensitiveData":true}`,
+			),
+
+			want: monitor.DNS{
+				Base: monitor.Base{
+					ID:             7,
+					Name:           "dns-cname",
+					Description:    ptr.To("Test CNAME DNS monitor"),
+					PathName:       "dns-cname",
+					Interval:       60,
+					RetryInterval:  60,
+					ResendInterval: 0,
+					MaxRetries:     2,
+					UpsideDown:     false,
+					IsActive:       true,
+				},
+				DNSDetails: monitor.DNSDetails{
+					Hostname:       "example.com",
+					ResolverServer: "9.9.9.9",
+					ResolveType:    monitor.DNSResolveTypeCNAME,
+					Port:           53,
+					Conditions: []monitor.Condition{
+						{
+							Variable: "record",
+							Operator: "equals",
+							Value:    "target.example.com.",
+							AndOr:    monitor.ConditionAnd,
+						},
+					},
+				},
+			},
+			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[{"type":"expression","variable":"record","operator":"equals","value":"target.example.com.","andOr":"and"}],"description":"Test CNAME DNS monitor","dns_resolve_server":"9.9.9.9","dns_resolve_type":"CNAME","hostname":"example.com","id":7,"interval":60,"maxretries":2,"name":"dns-cname","notificationIDList":{},"parent":null,"port":53,"resendInterval":0,"retryInterval":60,"type":"dns","upsideDown":false}`,
+		},
+		{
 			name: "multi resolver",
 			data: []byte(
 				`{"id":6,"name":"dns-multi-resolver","description":"Test multi-resolver DNS monitor","pathName":"group / dns-multi-resolver","parent":1,"childrenIDs":[],"url":null,"method":"GET","hostname":"example.com","port":53,"maxretries":2,"weight":2000,"active":true,"forceInactive":false,"type":"dns","timeout":48,"interval":60,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":"A","dns_resolve_server":"1.1.1.1,8.8.8.8","dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{"1":true,"2":true},"tags":[],"maintenance":false,"mqttTopic":"","mqttSuccessMessage":"","databaseQuery":null,"authMethod":null,"grpcUrl":null,"grpcProtobuf":null,"grpcMethod":null,"grpcServiceName":null,"grpcEnableTls":false,"radiusCalledStationId":null,"radiusCallingStationId":null,"game":null,"gamedigGivenPortOnly":true,"httpBodyEncoding":"json","jsonPath":null,"expectedValue":null,"kafkaProducerTopic":null,"kafkaProducerBrokers":[],"kafkaProducerSsl":false,"kafkaProducerAllowAutoTopicCreation":false,"kafkaProducerMessage":null,"screenshot":null,"headers":null,"body":null,"grpcBody":null,"grpcMetadata":null,"basic_auth_user":null,"basic_auth_pass":null,"oauth_client_id":null,"oauth_client_secret":null,"oauth_token_url":null,"oauth_scopes":null,"oauth_auth_method":"client_secret_basic","pushToken":null,"databaseConnectionString":null,"radiusUsername":null,"radiusPassword":null,"radiusSecret":null,"mqttUsername":"","mqttPassword":"","authWorkstation":null,"authDomain":null,"tlsCa":null,"tlsCert":null,"tlsKey":null,"kafkaProducerSaslOptions":{"mechanism":"None"},"includeSensitiveData":true}`,


### PR DESCRIPTION
## Summary

Addresses the two unresolved review comments left on #283 before it was merged.

**Comment 1 — missing test coverage** ([r3292539716](https://github.com/breml/go-uptime-kuma-client/pull/283#discussion_r3292539716))
- Adds a `"with conditions"` test case to `TestMonitorDNS_Unmarshal` that unmarshals a DNS monitor containing a populated `conditions` array and asserts the expected `Condition` slice and the round-trip marshaled JSON.

**Comment 2 — doc-comment grammar** ([r3292539723](https://github.com/breml/go-uptime-kuma-client/pull/283#discussion_r3292539723))
- Fixed `"allow"` → `"allows"` in the `Condition` doc comment.

**Additional cleanup (noticed during the fix)**
- The PR introduced a duplicate `Condition` type in `monitor_dns.go`; the type already exists (with proper `MarshalJSON` and typed `ConditionOperator`) in `conditions.go`. The duplicate has been removed and `DNSDetails` now references the shared type.
- The inline `nil`-check was replaced with the existing `conditionsForWire()` helper, consistent with every other monitor type that supports conditions.
- Added `omitempty` to `DNSDetails.Conditions`, matching the convention in all other monitor details structs.

## Test plan

- [ ] `go test ./monitor/` passes with the new `"with conditions"` test case
- [ ] `task lint` passes (0 issues)