### PR TITLE
feat(monitor): add support for Globalping monitor type

### DIFF
--- a/monitor/monitor_globalping.go
+++ b/monitor/monitor_globalping.go
@@ -1,0 +1,200 @@
+package monitor
+
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"strconv"
+)
+
+// Globalping represents a globalping monitor.
+type Globalping struct {
+	Base
+	HTTPDetails
+	GlobalpingDetails
+}
+
+// Type returns the monitor type.
+func (g Globalping) Type() string {
+	return g.GlobalpingDetails.Type()
+}
+
+// String returns a string representation of the monitor.
+func (g Globalping) String() string {
+	return fmt.Sprintf(
+		"%s, %s, %s",
+		formatMonitor(g.Base, false),
+		formatMonitor(g.HTTPDetails, true),
+		formatMonitor(g.GlobalpingDetails, true),
+	)
+}
+
+// UnmarshalJSON unmarshals a JSON byte slice into a monitor.
+func (g *Globalping) UnmarshalJSON(data []byte) error {
+	base := Base{}
+	err := json.Unmarshal(data, &base)
+	if err != nil {
+		return fmt.Errorf("unmarshal: %w", err)
+	}
+
+	httpDetails := HTTPDetails{}
+	err = json.Unmarshal(data, &httpDetails)
+	if err != nil {
+		return fmt.Errorf("unmarshal: %w", err)
+	}
+
+	globalpingDetails := GlobalpingDetails{}
+	err = json.Unmarshal(data, &globalpingDetails)
+	if err != nil {
+		return fmt.Errorf("unmarshal: %w", err)
+	}
+
+	*g = Globalping{
+		Base:              base,
+		HTTPDetails:       httpDetails,
+		GlobalpingDetails: globalpingDetails,
+	}
+
+	return nil
+}
+
+// MarshalJSON marshals a monitor into a JSON byte slice.
+func (g Globalping) MarshalJSON() ([]byte, error) {
+	raw := map[string]any{}
+	raw["id"] = g.ID
+	raw["type"] = "globalping"
+	raw["name"] = g.Name
+	raw["description"] = g.Description
+	// Don't set pathName, server generates it.
+	// raw["pathName"] = g.PathName
+	raw["parent"] = g.Parent
+	raw["interval"] = g.Interval
+	raw["retryInterval"] = g.RetryInterval
+	raw["resendInterval"] = g.ResendInterval
+	raw["maxretries"] = g.MaxRetries
+	raw["upsideDown"] = g.UpsideDown
+	raw["active"] = g.IsActive
+
+	// Update notification IDs.
+	ids := map[string]bool{}
+	for _, id := range g.NotificationIDs {
+		ids[strconv.FormatInt(id, 10)] = true
+	}
+
+	raw["notificationIDList"] = ids
+
+	// Always override with current HTTP-specific field values.
+	raw["url"] = g.URL
+	raw["timeout"] = g.Timeout
+	raw["expiryNotification"] = g.ExpiryNotification
+	raw["ignoreTls"] = g.IgnoreTLS
+	raw["maxredirects"] = g.MaxRedirects
+	raw["accepted_statuscodes"] = g.AcceptedStatusCodes
+	raw["proxyId"] = g.ProxyID
+	raw["method"] = g.Method
+	raw["httpBodyEncoding"] = g.HTTPBodyEncoding
+	raw["body"] = g.Body
+	raw["headers"] = g.Headers
+	raw["authMethod"] = g.AuthMethod
+	raw["basic_auth_user"] = g.BasicAuthUser
+	raw["basic_auth_pass"] = g.BasicAuthPass
+	raw["authDomain"] = g.AuthDomain
+	raw["authWorkstation"] = g.AuthWorkstation
+	raw["tlsCert"] = g.TLSCert
+	raw["tlsKey"] = g.TLSKey
+	raw["tlsCa"] = g.TLSCa
+	raw["oauth_auth_method"] = g.OAuthAuthMethod
+	raw["oauth_token_url"] = g.OAuthTokenURL
+	raw["oauth_client_id"] = g.OAuthClientID
+	raw["oauth_client_secret"] = g.OAuthClientSecret
+	raw["oauth_scopes"] = g.OAuthScopes
+	raw["cacheBust"] = g.CacheBust
+
+	// Always override with current Globalping-specific field values.
+	maps.Copy(raw, g.toMap())
+
+	// Uptime Kuma v2 requires conditions field (empty array by default)
+	raw["conditions"] = []any{}
+
+	data, err := json.Marshal(raw)
+	if err != nil {
+		return nil, fmt.Errorf("marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// GlobalpingDetails contains globalping-specific monitor configuration.
+type GlobalpingDetails struct {
+	Subtype          GlobalpingSubtype  `json:"subtype"`
+	Location         string             `json:"location"`
+	IPFamily         GlobalpingIPFamily `json:"ipFamily"`
+	Protocol         string             `json:"protocol"`
+	PingCount        int                `json:"ping_count"`
+	Hostname         string             `json:"hostname"`
+	Port             int                `json:"port"`
+	DNSResolveType   DNSResolveType     `json:"dns_resolve_type"`
+	DNSResolveServer string             `json:"dns_resolve_server"`
+	Keyword          string             `json:"keyword"`
+	InvertKeyword    bool               `json:"invertKeyword"`
+	ExpectedValue    string             `json:"expectedValue"`
+	JSONPath         string             `json:"jsonPath"`
+	JSONPathOperator string             `json:"jsonPathOperator"`
+}
+
+// Type returns the monitor type.
+func (GlobalpingDetails) Type() string {
+	return "globalping"
+}
+
+// toMap returns the Globalping-specific fields as a map suitable for merging
+// into the JSON payload.
+func (d GlobalpingDetails) toMap() map[string]any {
+	return map[string]any{
+		"subtype":            d.Subtype,
+		"location":           d.Location,
+		"ipFamily":           d.IPFamily,
+		"protocol":           d.Protocol,
+		"ping_count":         d.PingCount,
+		"hostname":           d.Hostname,
+		"port":               d.Port,
+		"dns_resolve_type":   d.DNSResolveType,
+		"dns_resolve_server": d.DNSResolveServer,
+		"keyword":            d.Keyword,
+		"invertKeyword":      d.InvertKeyword,
+		"expectedValue":      d.ExpectedValue,
+		"jsonPath":           d.JSONPath,
+		"jsonPathOperator":   d.JSONPathOperator,
+	}
+}
+
+// GlobalpingSubtype represents the subtype of a Globalping monitor.
+type GlobalpingSubtype string
+
+// Globalping subtypes.
+const (
+	GlobalpingSubtypePing       GlobalpingSubtype = "ping"
+	GlobalpingSubtypeTraceroute GlobalpingSubtype = "traceroute"
+	GlobalpingSubtypeDNS        GlobalpingSubtype = "dns"
+	GlobalpingSubtypeHTTP       GlobalpingSubtype = "http"
+)
+
+// String returns the string representation of the Globalping subtype.
+func (s GlobalpingSubtype) String() string {
+	return string(s)
+}
+
+// GlobalpingIPFamily represents the IP family for a Globalping monitor.
+type GlobalpingIPFamily string
+
+// Globalping IP families. The empty value selects the IP family automatically.
+const (
+	GlobalpingIPFamilyAuto GlobalpingIPFamily = ""
+	GlobalpingIPFamilyIPv4 GlobalpingIPFamily = "ipv4"
+	GlobalpingIPFamilyIPv6 GlobalpingIPFamily = "ipv6"
+)
+
+// String returns the string representation of the Globalping IP family.
+func (f GlobalpingIPFamily) String() string {
+	return string(f)
+}

--- a/monitor/monitor_globalping_test.go
+++ b/monitor/monitor_globalping_test.go
@@ -1,0 +1,292 @@
+package monitor_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/breml/go-uptime-kuma-client/internal/ptr"
+	"github.com/breml/go-uptime-kuma-client/monitor"
+)
+
+func TestMonitorGlobalping_Unmarshal(t *testing.T) {
+	parent1 := int64(1)
+
+	tests := []struct {
+		name string
+		data []byte
+
+		want     monitor.Globalping
+		wantJSON string
+	}{
+		{
+			name: "ping",
+			data: []byte(
+				`{"id":10,"name":"globalping-ping","description":"Globalping ping","pathName":"globalping-ping","parent":1,"childrenIDs":[],"url":null,"method":"GET","hostname":"example.com","port":null,"maxretries":2,"weight":2000,"active":true,"forceInactive":false,"type":"globalping","subtype":"ping","timeout":48,"interval":60,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":"A","dns_resolve_server":"1.1.1.1","dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{"1":true},"tags":[],"maintenance":false,"location":"world","ipFamily":null,"protocol":"ICMP","ping_count":3,"mqttTopic":"","mqttSuccessMessage":"","databaseQuery":null,"authMethod":null,"grpcUrl":null,"grpcProtobuf":null,"grpcMethod":null,"grpcServiceName":null,"grpcEnableTls":false,"radiusCalledStationId":null,"radiusCallingStationId":null,"game":null,"gamedigGivenPortOnly":true,"httpBodyEncoding":"json","jsonPath":null,"expectedValue":null,"kafkaProducerTopic":null,"kafkaProducerBrokers":[],"kafkaProducerSsl":false,"kafkaProducerAllowAutoTopicCreation":false,"kafkaProducerMessage":null,"screenshot":null,"headers":null,"body":null,"grpcBody":null,"grpcMetadata":null,"basic_auth_user":null,"basic_auth_pass":null,"oauth_client_id":null,"oauth_client_secret":null,"oauth_token_url":null,"oauth_scopes":null,"oauth_auth_method":"client_secret_basic","pushToken":null,"databaseConnectionString":null,"radiusUsername":null,"radiusPassword":null,"radiusSecret":null,"mqttUsername":"","mqttPassword":"","authWorkstation":null,"authDomain":null,"tlsCa":null,"tlsCert":null,"tlsKey":null,"kafkaProducerSaslOptions":{"mechanism":"None"},"includeSensitiveData":true}`,
+			),
+
+			want: monitor.Globalping{
+				Base: monitor.Base{
+					ID:              10,
+					Name:            "globalping-ping",
+					Description:     ptr.To("Globalping ping"),
+					PathName:        "globalping-ping",
+					Parent:          &parent1,
+					Interval:        60,
+					RetryInterval:   60,
+					ResendInterval:  0,
+					MaxRetries:      2,
+					UpsideDown:      false,
+					NotificationIDs: []int64{1},
+					IsActive:        true,
+				},
+				HTTPDetails: monitor.HTTPDetails{
+					Timeout:             48,
+					ExpiryNotification:  false,
+					IgnoreTLS:           false,
+					MaxRedirects:        10,
+					AcceptedStatusCodes: []string{"200-299"},
+					Method:              "GET",
+					HTTPBodyEncoding:    "json",
+					AuthMethod:          monitor.AuthMethodNone,
+					OAuthAuthMethod:     "client_secret_basic",
+				},
+				GlobalpingDetails: monitor.GlobalpingDetails{
+					Subtype:          monitor.GlobalpingSubtypePing,
+					Location:         "world",
+					IPFamily:         monitor.GlobalpingIPFamilyAuto,
+					Protocol:         "ICMP",
+					PingCount:        3,
+					Hostname:         "example.com",
+					DNSResolveType:   monitor.DNSResolveTypeA,
+					DNSResolveServer: "1.1.1.1",
+				},
+			},
+			wantJSON: `{"accepted_statuscodes":["200-299"],"active":true,"authDomain":"","authMethod":"","authWorkstation":"","basic_auth_pass":"","basic_auth_user":"","body":"","cacheBust":false,"conditions":[],"description":"Globalping ping","dns_resolve_server":"1.1.1.1","dns_resolve_type":"A","expectedValue":"","expiryNotification":false,"headers":"","hostname":"example.com","httpBodyEncoding":"json","id":10,"ignoreTls":false,"interval":60,"invertKeyword":false,"ipFamily":"","jsonPath":"","jsonPathOperator":"","keyword":"","location":"world","maxredirects":10,"maxretries":2,"method":"GET","name":"globalping-ping","notificationIDList":{"1":true},"oauth_auth_method":"client_secret_basic","oauth_client_id":"","oauth_client_secret":"","oauth_scopes":"","oauth_token_url":"","parent":1,"ping_count":3,"port":0,"protocol":"ICMP","proxyId":null,"resendInterval":0,"retryInterval":60,"subtype":"ping","timeout":48,"tlsCa":"","tlsCert":"","tlsKey":"","type":"globalping","upsideDown":false,"url":""}`,
+		},
+		{
+			name: "ping_tcp_with_port",
+			data: []byte(
+				`{"id":11,"name":"globalping-ping-tcp","description":null,"pathName":"globalping-ping-tcp","parent":null,"childrenIDs":[],"url":null,"method":"GET","hostname":"example.com","port":443,"maxretries":3,"weight":2000,"active":true,"forceInactive":false,"type":"globalping","subtype":"ping","timeout":48,"interval":60,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":"A","dns_resolve_server":"1.1.1.1","dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{},"tags":[],"maintenance":false,"location":"europe","ipFamily":"ipv4","protocol":"TCP","ping_count":5,"mqttTopic":"","mqttSuccessMessage":"","databaseQuery":null,"authMethod":null,"grpcUrl":null,"grpcProtobuf":null,"grpcMethod":null,"grpcServiceName":null,"grpcEnableTls":false,"radiusCalledStationId":null,"radiusCallingStationId":null,"game":null,"gamedigGivenPortOnly":true,"httpBodyEncoding":"json","jsonPath":null,"expectedValue":null,"kafkaProducerTopic":null,"kafkaProducerBrokers":[],"kafkaProducerSsl":false,"kafkaProducerAllowAutoTopicCreation":false,"kafkaProducerMessage":null,"screenshot":null,"headers":null,"body":null,"grpcBody":null,"grpcMetadata":null,"basic_auth_user":null,"basic_auth_pass":null,"oauth_client_id":null,"oauth_client_secret":null,"oauth_token_url":null,"oauth_scopes":null,"oauth_auth_method":"client_secret_basic","pushToken":null,"databaseConnectionString":null,"radiusUsername":null,"radiusPassword":null,"radiusSecret":null,"mqttUsername":"","mqttPassword":"","authWorkstation":null,"authDomain":null,"tlsCa":null,"tlsCert":null,"tlsKey":null,"kafkaProducerSaslOptions":{"mechanism":"None"},"includeSensitiveData":true}`,
+			),
+
+			want: monitor.Globalping{
+				Base: monitor.Base{
+					ID:             11,
+					Name:           "globalping-ping-tcp",
+					Description:    nil,
+					PathName:       "globalping-ping-tcp",
+					Parent:         nil,
+					Interval:       60,
+					RetryInterval:  60,
+					ResendInterval: 0,
+					MaxRetries:     3,
+					UpsideDown:     false,
+					IsActive:       true,
+				},
+				HTTPDetails: monitor.HTTPDetails{
+					Timeout:             48,
+					MaxRedirects:        10,
+					AcceptedStatusCodes: []string{"200-299"},
+					Method:              "GET",
+					HTTPBodyEncoding:    "json",
+					AuthMethod:          monitor.AuthMethodNone,
+					OAuthAuthMethod:     "client_secret_basic",
+				},
+				GlobalpingDetails: monitor.GlobalpingDetails{
+					Subtype:          monitor.GlobalpingSubtypePing,
+					Location:         "europe",
+					IPFamily:         monitor.GlobalpingIPFamilyIPv4,
+					Protocol:         "TCP",
+					PingCount:        5,
+					Hostname:         "example.com",
+					Port:             443,
+					DNSResolveType:   monitor.DNSResolveTypeA,
+					DNSResolveServer: "1.1.1.1",
+				},
+			},
+			wantJSON: `{"accepted_statuscodes":["200-299"],"active":true,"authDomain":"","authMethod":"","authWorkstation":"","basic_auth_pass":"","basic_auth_user":"","body":"","cacheBust":false,"conditions":[],"description":null,"dns_resolve_server":"1.1.1.1","dns_resolve_type":"A","expectedValue":"","expiryNotification":false,"headers":"","hostname":"example.com","httpBodyEncoding":"json","id":11,"ignoreTls":false,"interval":60,"invertKeyword":false,"ipFamily":"ipv4","jsonPath":"","jsonPathOperator":"","keyword":"","location":"europe","maxredirects":10,"maxretries":3,"method":"GET","name":"globalping-ping-tcp","notificationIDList":{},"oauth_auth_method":"client_secret_basic","oauth_client_id":"","oauth_client_secret":"","oauth_scopes":"","oauth_token_url":"","parent":null,"ping_count":5,"port":443,"protocol":"TCP","proxyId":null,"resendInterval":0,"retryInterval":60,"subtype":"ping","timeout":48,"tlsCa":"","tlsCert":"","tlsKey":"","type":"globalping","upsideDown":false,"url":""}`,
+		},
+		{
+			name: "http",
+			data: []byte(
+				`{"id":12,"name":"globalping-http","description":"Globalping HTTP","pathName":"globalping-http","parent":null,"childrenIDs":[],"url":"https://www.example.com","method":"GET","hostname":null,"port":null,"maxretries":2,"weight":2000,"active":true,"forceInactive":false,"type":"globalping","subtype":"http","timeout":48,"interval":60,"retryInterval":60,"resendInterval":0,"keyword":"success","invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":"A","dns_resolve_server":"1.1.1.1","dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{},"tags":[],"maintenance":false,"location":"world","ipFamily":"ipv6","protocol":"HTTP2","ping_count":0,"mqttTopic":"","mqttSuccessMessage":"","databaseQuery":null,"authMethod":"basic","grpcUrl":null,"grpcProtobuf":null,"grpcMethod":null,"grpcServiceName":null,"grpcEnableTls":false,"radiusCalledStationId":null,"radiusCallingStationId":null,"game":null,"gamedigGivenPortOnly":true,"httpBodyEncoding":"json","jsonPath":null,"expectedValue":null,"kafkaProducerTopic":null,"kafkaProducerBrokers":[],"kafkaProducerSsl":false,"kafkaProducerAllowAutoTopicCreation":false,"kafkaProducerMessage":null,"screenshot":null,"headers":"X-Custom: test","body":"","grpcBody":null,"grpcMetadata":null,"basic_auth_user":"u","basic_auth_pass":"p","oauth_client_id":null,"oauth_client_secret":null,"oauth_token_url":null,"oauth_scopes":null,"oauth_auth_method":"client_secret_basic","pushToken":null,"databaseConnectionString":null,"radiusUsername":null,"radiusPassword":null,"radiusSecret":null,"mqttUsername":"","mqttPassword":"","authWorkstation":null,"authDomain":null,"tlsCa":null,"tlsCert":null,"tlsKey":null,"kafkaProducerSaslOptions":{"mechanism":"None"},"includeSensitiveData":true}`,
+			),
+
+			want: monitor.Globalping{
+				Base: monitor.Base{
+					ID:             12,
+					Name:           "globalping-http",
+					Description:    ptr.To("Globalping HTTP"),
+					PathName:       "globalping-http",
+					Parent:         nil,
+					Interval:       60,
+					RetryInterval:  60,
+					ResendInterval: 0,
+					MaxRetries:     2,
+					UpsideDown:     false,
+					IsActive:       true,
+				},
+				HTTPDetails: monitor.HTTPDetails{
+					URL:                 "https://www.example.com",
+					Timeout:             48,
+					MaxRedirects:        10,
+					AcceptedStatusCodes: []string{"200-299"},
+					Method:              "GET",
+					HTTPBodyEncoding:    "json",
+					Headers:             "X-Custom: test",
+					AuthMethod:          monitor.AuthMethodBasic,
+					BasicAuthUser:       "u",
+					BasicAuthPass:       "p",
+					OAuthAuthMethod:     "client_secret_basic",
+				},
+				GlobalpingDetails: monitor.GlobalpingDetails{
+					Subtype:          monitor.GlobalpingSubtypeHTTP,
+					Location:         "world",
+					IPFamily:         monitor.GlobalpingIPFamilyIPv6,
+					Protocol:         "HTTP2",
+					Keyword:          "success",
+					DNSResolveType:   monitor.DNSResolveTypeA,
+					DNSResolveServer: "1.1.1.1",
+				},
+			},
+			wantJSON: `{"accepted_statuscodes":["200-299"],"active":true,"authDomain":"","authMethod":"basic","authWorkstation":"","basic_auth_pass":"p","basic_auth_user":"u","body":"","cacheBust":false,"conditions":[],"description":"Globalping HTTP","dns_resolve_server":"1.1.1.1","dns_resolve_type":"A","expectedValue":"","expiryNotification":false,"headers":"X-Custom: test","hostname":"","httpBodyEncoding":"json","id":12,"ignoreTls":false,"interval":60,"invertKeyword":false,"ipFamily":"ipv6","jsonPath":"","jsonPathOperator":"","keyword":"success","location":"world","maxredirects":10,"maxretries":2,"method":"GET","name":"globalping-http","notificationIDList":{},"oauth_auth_method":"client_secret_basic","oauth_client_id":"","oauth_client_secret":"","oauth_scopes":"","oauth_token_url":"","parent":null,"ping_count":0,"port":0,"protocol":"HTTP2","proxyId":null,"resendInterval":0,"retryInterval":60,"subtype":"http","timeout":48,"tlsCa":"","tlsCert":"","tlsKey":"","type":"globalping","upsideDown":false,"url":"https://www.example.com"}`,
+		},
+		{
+			name: "dns",
+			data: []byte(
+				`{"id":13,"name":"globalping-dns","description":null,"pathName":"globalping-dns","parent":null,"childrenIDs":[],"url":null,"method":"GET","hostname":"example.com","port":53,"maxretries":2,"weight":2000,"active":true,"forceInactive":false,"type":"globalping","subtype":"dns","timeout":48,"interval":60,"retryInterval":60,"resendInterval":0,"keyword":"127\\.0\\.0\\.1","invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":"AAAA","dns_resolve_server":"8.8.8.8","dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{},"tags":[],"maintenance":false,"location":"asia","ipFamily":"ipv4","protocol":"UDP","ping_count":0,"mqttTopic":"","mqttSuccessMessage":"","databaseQuery":null,"authMethod":null,"grpcUrl":null,"grpcProtobuf":null,"grpcMethod":null,"grpcServiceName":null,"grpcEnableTls":false,"radiusCalledStationId":null,"radiusCallingStationId":null,"game":null,"gamedigGivenPortOnly":true,"httpBodyEncoding":"json","jsonPath":null,"expectedValue":null,"kafkaProducerTopic":null,"kafkaProducerBrokers":[],"kafkaProducerSsl":false,"kafkaProducerAllowAutoTopicCreation":false,"kafkaProducerMessage":null,"screenshot":null,"headers":null,"body":null,"grpcBody":null,"grpcMetadata":null,"basic_auth_user":null,"basic_auth_pass":null,"oauth_client_id":null,"oauth_client_secret":null,"oauth_token_url":null,"oauth_scopes":null,"oauth_auth_method":"client_secret_basic","pushToken":null,"databaseConnectionString":null,"radiusUsername":null,"radiusPassword":null,"radiusSecret":null,"mqttUsername":"","mqttPassword":"","authWorkstation":null,"authDomain":null,"tlsCa":null,"tlsCert":null,"tlsKey":null,"kafkaProducerSaslOptions":{"mechanism":"None"},"includeSensitiveData":true}`,
+			),
+
+			want: monitor.Globalping{
+				Base: monitor.Base{
+					ID:             13,
+					Name:           "globalping-dns",
+					Description:    nil,
+					PathName:       "globalping-dns",
+					Parent:         nil,
+					Interval:       60,
+					RetryInterval:  60,
+					ResendInterval: 0,
+					MaxRetries:     2,
+					UpsideDown:     false,
+					IsActive:       true,
+				},
+				HTTPDetails: monitor.HTTPDetails{
+					Timeout:             48,
+					MaxRedirects:        10,
+					AcceptedStatusCodes: []string{"200-299"},
+					Method:              "GET",
+					HTTPBodyEncoding:    "json",
+					AuthMethod:          monitor.AuthMethodNone,
+					OAuthAuthMethod:     "client_secret_basic",
+				},
+				GlobalpingDetails: monitor.GlobalpingDetails{
+					Subtype:          monitor.GlobalpingSubtypeDNS,
+					Location:         "asia",
+					IPFamily:         monitor.GlobalpingIPFamilyIPv4,
+					Protocol:         "UDP",
+					Hostname:         "example.com",
+					Port:             53,
+					DNSResolveType:   monitor.DNSResolveTypeAAAA,
+					DNSResolveServer: "8.8.8.8",
+					Keyword:          `127\.0\.0\.1`,
+				},
+			},
+			wantJSON: `{"accepted_statuscodes":["200-299"],"active":true,"authDomain":"","authMethod":"","authWorkstation":"","basic_auth_pass":"","basic_auth_user":"","body":"","cacheBust":false,"conditions":[],"description":null,"dns_resolve_server":"8.8.8.8","dns_resolve_type":"AAAA","expectedValue":"","expiryNotification":false,"headers":"","hostname":"example.com","httpBodyEncoding":"json","id":13,"ignoreTls":false,"interval":60,"invertKeyword":false,"ipFamily":"ipv4","jsonPath":"","jsonPathOperator":"","keyword":"127\\.0\\.0\\.1","location":"asia","maxredirects":10,"maxretries":2,"method":"GET","name":"globalping-dns","notificationIDList":{},"oauth_auth_method":"client_secret_basic","oauth_client_id":"","oauth_client_secret":"","oauth_scopes":"","oauth_token_url":"","parent":null,"ping_count":0,"port":53,"protocol":"UDP","proxyId":null,"resendInterval":0,"retryInterval":60,"subtype":"dns","timeout":48,"tlsCa":"","tlsCert":"","tlsKey":"","type":"globalping","upsideDown":false,"url":""}`,
+		},
+		{
+			name: "traceroute",
+			data: []byte(
+				`{"id":14,"name":"globalping-traceroute","description":null,"pathName":"globalping-traceroute","parent":null,"childrenIDs":[],"url":null,"method":"GET","hostname":"example.com","port":null,"maxretries":2,"weight":2000,"active":true,"forceInactive":false,"type":"globalping","subtype":"traceroute","timeout":48,"interval":60,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":"A","dns_resolve_server":"1.1.1.1","dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{},"tags":[],"maintenance":false,"location":"north-america","ipFamily":null,"protocol":"ICMP","ping_count":0,"mqttTopic":"","mqttSuccessMessage":"","databaseQuery":null,"authMethod":null,"grpcUrl":null,"grpcProtobuf":null,"grpcMethod":null,"grpcServiceName":null,"grpcEnableTls":false,"radiusCalledStationId":null,"radiusCallingStationId":null,"game":null,"gamedigGivenPortOnly":true,"httpBodyEncoding":"json","jsonPath":null,"expectedValue":null,"kafkaProducerTopic":null,"kafkaProducerBrokers":[],"kafkaProducerSsl":false,"kafkaProducerAllowAutoTopicCreation":false,"kafkaProducerMessage":null,"screenshot":null,"headers":null,"body":null,"grpcBody":null,"grpcMetadata":null,"basic_auth_user":null,"basic_auth_pass":null,"oauth_client_id":null,"oauth_client_secret":null,"oauth_token_url":null,"oauth_scopes":null,"oauth_auth_method":"client_secret_basic","pushToken":null,"databaseConnectionString":null,"radiusUsername":null,"radiusPassword":null,"radiusSecret":null,"mqttUsername":"","mqttPassword":"","authWorkstation":null,"authDomain":null,"tlsCa":null,"tlsCert":null,"tlsKey":null,"kafkaProducerSaslOptions":{"mechanism":"None"},"includeSensitiveData":true}`,
+			),
+
+			want: monitor.Globalping{
+				Base: monitor.Base{
+					ID:             14,
+					Name:           "globalping-traceroute",
+					Description:    nil,
+					PathName:       "globalping-traceroute",
+					Parent:         nil,
+					Interval:       60,
+					RetryInterval:  60,
+					ResendInterval: 0,
+					MaxRetries:     2,
+					UpsideDown:     false,
+					IsActive:       true,
+				},
+				HTTPDetails: monitor.HTTPDetails{
+					Timeout:             48,
+					MaxRedirects:        10,
+					AcceptedStatusCodes: []string{"200-299"},
+					Method:              "GET",
+					HTTPBodyEncoding:    "json",
+					AuthMethod:          monitor.AuthMethodNone,
+					OAuthAuthMethod:     "client_secret_basic",
+				},
+				GlobalpingDetails: monitor.GlobalpingDetails{
+					Subtype:          monitor.GlobalpingSubtypeTraceroute,
+					Location:         "north-america",
+					IPFamily:         monitor.GlobalpingIPFamilyAuto,
+					Protocol:         "ICMP",
+					Hostname:         "example.com",
+					DNSResolveType:   monitor.DNSResolveTypeA,
+					DNSResolveServer: "1.1.1.1",
+				},
+			},
+			wantJSON: `{"accepted_statuscodes":["200-299"],"active":true,"authDomain":"","authMethod":"","authWorkstation":"","basic_auth_pass":"","basic_auth_user":"","body":"","cacheBust":false,"conditions":[],"description":null,"dns_resolve_server":"1.1.1.1","dns_resolve_type":"A","expectedValue":"","expiryNotification":false,"headers":"","hostname":"example.com","httpBodyEncoding":"json","id":14,"ignoreTls":false,"interval":60,"invertKeyword":false,"ipFamily":"","jsonPath":"","jsonPathOperator":"","keyword":"","location":"north-america","maxredirects":10,"maxretries":2,"method":"GET","name":"globalping-traceroute","notificationIDList":{},"oauth_auth_method":"client_secret_basic","oauth_client_id":"","oauth_client_secret":"","oauth_scopes":"","oauth_token_url":"","parent":null,"ping_count":0,"port":0,"protocol":"ICMP","proxyId":null,"resendInterval":0,"retryInterval":60,"subtype":"traceroute","timeout":48,"tlsCa":"","tlsCert":"","tlsKey":"","type":"globalping","upsideDown":false,"url":""}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			globalpingMonitor := monitor.Globalping{}
+
+			err := json.Unmarshal(tc.data, &globalpingMonitor)
+			require.NoError(t, err)
+
+			require.EqualExportedValues(t, tc.want, globalpingMonitor)
+
+			data, err := json.Marshal(globalpingMonitor)
+			require.NoError(t, err)
+
+			require.JSONEq(t, tc.wantJSON, string(data))
+		})
+	}
+}
+
+func TestGlobalpingSubtype_String(t *testing.T) {
+	tests := []struct {
+		subtype monitor.GlobalpingSubtype
+		want    string
+	}{
+		{monitor.GlobalpingSubtypePing, "ping"},
+		{monitor.GlobalpingSubtypeTraceroute, "traceroute"},
+		{monitor.GlobalpingSubtypeDNS, "dns"},
+		{monitor.GlobalpingSubtypeHTTP, "http"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.want, func(t *testing.T) {
+			require.Equal(t, tc.want, tc.subtype.String())
+		})
+	}
+}
+
+func TestGlobalpingIPFamily_String(t *testing.T) {
+	tests := []struct {
+		family monitor.GlobalpingIPFamily
+		want   string
+	}{
+		{monitor.GlobalpingIPFamilyAuto, ""},
+		{monitor.GlobalpingIPFamilyIPv4, "ipv4"},
+		{monitor.GlobalpingIPFamilyIPv6, "ipv6"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.want, func(t *testing.T) {
+			require.Equal(t, tc.want, tc.family.String())
+		})
+	}
+}

--- a/monitor_test.go
+++ b/monitor_test.go
@@ -1569,6 +1569,78 @@ func TestMonitorCRUD(t *testing.T) {
 			},
 			testPauseResume: true,
 		},
+		{
+			name: "Globalping",
+			create: &monitor.Globalping{
+				Base: monitor.Base{
+					Name:           "Test Globalping Monitor",
+					Interval:       60,
+					RetryInterval:  60,
+					ResendInterval: 0,
+					MaxRetries:     3,
+					UpsideDown:     false,
+					IsActive:       true,
+				},
+				HTTPDetails: monitor.HTTPDetails{
+					Method:              "GET",
+					MaxRedirects:        10,
+					AcceptedStatusCodes: []string{"200-299"},
+					AuthMethod:          monitor.AuthMethodNone,
+				},
+				GlobalpingDetails: monitor.GlobalpingDetails{
+					Subtype:   monitor.GlobalpingSubtypePing,
+					Location:  "world",
+					IPFamily:  monitor.GlobalpingIPFamilyAuto,
+					Protocol:  "ICMP",
+					PingCount: 3,
+					Hostname:  "example.com",
+				},
+			},
+			updateFunc: func(m monitor.Monitor) {
+				g, ok := m.(*monitor.Globalping)
+				if !ok {
+					panic("failed to assert Globalping monitor")
+				}
+
+				g.Name = "Updated Globalping Monitor"
+				g.Hostname = "google.com"
+				g.Location = "europe"
+				g.IPFamily = monitor.GlobalpingIPFamilyIPv4
+				g.PingCount = 5
+			},
+			verifyCreatedFunc: func(t *testing.T, actual monitor.Monitor, id int64) {
+				t.Helper()
+				var g monitor.Globalping
+				err := actual.As(&g)
+				require.NoError(t, err)
+				require.Equal(t, id, g.ID)
+				require.Equal(t, "Test Globalping Monitor", g.Name)
+				require.Equal(t, monitor.GlobalpingSubtypePing, g.Subtype)
+				require.Equal(t, "world", g.Location)
+				require.Equal(t, "example.com", g.Hostname)
+				require.Equal(t, "ICMP", g.Protocol)
+				require.Equal(t, 3, g.PingCount)
+			},
+			createTypedFunc: func(t *testing.T, base monitor.Monitor) monitor.Monitor {
+				t.Helper()
+				var g monitor.Globalping
+				err := base.As(&g)
+				require.NoError(t, err)
+				return &g
+			},
+			verifyUpdatedFunc: func(t *testing.T, actual monitor.Monitor) {
+				t.Helper()
+				var g monitor.Globalping
+				err := actual.As(&g)
+				require.NoError(t, err)
+				require.Equal(t, "Updated Globalping Monitor", g.Name)
+				require.Equal(t, "google.com", g.Hostname)
+				require.Equal(t, "europe", g.Location)
+				require.Equal(t, monitor.GlobalpingIPFamilyIPv4, g.IPFamily)
+				require.Equal(t, 5, g.PingCount)
+			},
+			testPauseResume: true,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Add support for the new \`globalping\` monitor type, introduced upstream
in Uptime Kuma 2.1 ([louislam/uptime-kuma#6163](https://github.com/louislam/uptime-kuma/pull/6163)).

Globalping uses a network of community-hosted probes (globalping.io) to
run distributed checks (ping / DNS / HTTP) from many regions.

## Implementation

The new \`monitor.Globalping\` type mirrors the layered composition used
by \`monitor.HTTPKeyword\` and \`monitor.HTTPJSONQuery\`:

- \`monitor.Base\` — common monitor fields.
- \`monitor.HTTPDetails\` — many HTTP fields are reused when
  \`subtype == \"http\"\` (\`url\`, \`method\`, \`headers\`, \`body\`,
  \`authMethod\`, \`accepted_statuscodes\`, \`expiryNotification\`,
  \`ignoreTls\`, \`cacheBust\`, …).
- \`monitor.GlobalpingDetails\` — Globalping-specific fields plus the
  fields whose meaning is Globalping-subtype dependent (\`subtype\`,
  \`location\`, \`ipFamily\`, \`protocol\`, \`ping_count\`, \`hostname\`,
  \`port\`, \`dns_resolve_type\`, \`dns_resolve_server\`, \`keyword\`,
  \`invertKeyword\`, \`expectedValue\`, \`jsonPath\`, \`jsonPathOperator\`).

Two small enums are introduced for the well-known string-valued fields:

- \`GlobalpingSubtype\`: \`ping\`, \`traceroute\`, \`dns\`, \`http\`.
- \`GlobalpingIPFamily\`: auto (empty), \`ipv4\`, \`ipv6\`.

## Tests

- \`monitor/monitor_globalping_test.go\` covers JSON round-trip for the
  \`ping\`, \`ping + TCP/port\`, \`http\`, \`dns\` and \`traceroute\`
  subtypes, plus enum stringer tests.
- \`TestMonitorCRUD\` in \`monitor_test.go\` exercises end-to-end
  Create / Get / Update / Pause / Resume / Delete against a real Uptime
  Kuma instance for a Globalping ping monitor, including the typed
  \`As(&Globalping{})\` conversion (covers import-state, data-source
  read, and resource-style CRUD).

Closes #231