### PR TITLE
feat(notification): add MAX messenger notification support

### DIFF
--- a/notification/notification_max.go
+++ b/notification/notification_max.go
@@ -1,0 +1,57 @@
+package notification
+
+import (
+	"fmt"
+)
+
+// Max represents a MAX messenger notification.
+type Max struct {
+	Base
+	MaxDetails
+}
+
+// MaxDetails contains MAX messenger-specific notification configuration.
+type MaxDetails struct {
+	APIURL         string `json:"maxApiUrl"`
+	BotToken       string `json:"maxBotToken"`
+	ChatID         string `json:"maxChatID"`
+	UseTemplate    bool   `json:"maxUseTemplate"`
+	Template       string `json:"maxTemplate"`
+	TemplateFormat string `json:"maxTemplateFormat"`
+}
+
+// Type returns the notification type.
+func (m Max) Type() string {
+	return m.MaxDetails.Type()
+}
+
+// Type returns the notification type.
+func (MaxDetails) Type() string {
+	return "max"
+}
+
+// String returns a string representation of the notification.
+func (m Max) String() string {
+	return fmt.Sprintf("%s, %s", formatNotification(m.Base, false), formatNotification(m.MaxDetails, true))
+}
+
+// UnmarshalJSON unmarshals a JSON byte slice into a notification.
+func (m *Max) UnmarshalJSON(data []byte) error {
+	detail := MaxDetails{}
+	base, err := unmarshalTo(data, &detail)
+	if err != nil {
+		return err
+	}
+
+	*m = Max{
+		Base:       base,
+		MaxDetails: detail,
+	}
+
+	return nil
+}
+
+// MarshalJSON marshals a notification into a JSON byte slice.
+func (m Max) MarshalJSON() ([]byte, error) {
+	return marshalJSON(m.Base, &m.MaxDetails)
+}

--- a/notification/notification_max_test.go
+++ b/notification/notification_max_test.go
@@ -1,0 +1,86 @@
+package notification_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/breml/go-uptime-kuma-client/notification"
+)
+
+func TestNotificationMax_Unmarshal(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+
+		want     notification.Max
+		wantJSON string
+	}{
+		{
+			name: "success",
+			data: []byte(
+				`{"id":1,"name":"My Max Alert","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"My Max Alert\",\"maxApiUrl\":\"https://platform-api.max.ru\",\"maxBotToken\":\"bot-token-123\",\"maxChatID\":\"-12345\",\"maxUseTemplate\":true,\"maxTemplate\":\"Monitor: {monitor.name}\\nStatus: {monitor.status}\",\"maxTemplateFormat\":\"markdown\",\"type\":\"max\"}"}`,
+			),
+
+			want: notification.Max{
+				Base: notification.Base{
+					ID:            1,
+					Name:          "My Max Alert",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     true,
+					ApplyExisting: true,
+				},
+				MaxDetails: notification.MaxDetails{
+					APIURL:         "https://platform-api.max.ru",
+					BotToken:       "bot-token-123",
+					ChatID:         "-12345",
+					UseTemplate:    true,
+					Template:       "Monitor: {monitor.name}\nStatus: {monitor.status}",
+					TemplateFormat: "markdown",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":true,"id":1,"isDefault":true,"name":"My Max Alert","maxApiUrl":"https://platform-api.max.ru","maxBotToken":"bot-token-123","maxChatID":"-12345","maxUseTemplate":true,"maxTemplate":"Monitor: {monitor.name}\nStatus: {monitor.status}","maxTemplateFormat":"markdown","type":"max","userId":1}`,
+		},
+		{
+			name: "minimal",
+			data: []byte(
+				`{"id":2,"name":"Simple Max","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Simple Max\",\"maxApiUrl\":\"https://platform-api.max.ru\",\"maxBotToken\":\"bot-token-123\",\"maxChatID\":\"-12345\",\"type\":\"max\"}"}`,
+			),
+
+			want: notification.Max{
+				Base: notification.Base{
+					ID:            2,
+					Name:          "Simple Max",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				MaxDetails: notification.MaxDetails{
+					APIURL:   "https://platform-api.max.ru",
+					BotToken: "bot-token-123",
+					ChatID:   "-12345",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"id":2,"isDefault":false,"name":"Simple Max","maxApiUrl":"https://platform-api.max.ru","maxBotToken":"bot-token-123","maxChatID":"-12345","maxUseTemplate":false,"maxTemplate":"","maxTemplateFormat":"","type":"max","userId":1}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			maxn := notification.Max{}
+
+			err := json.Unmarshal(tc.data, &maxn)
+			require.NoError(t, err)
+
+			require.EqualExportedValues(t, tc.want, maxn)
+
+			data, err := json.Marshal(maxn)
+			require.NoError(t, err)
+
+			require.JSONEq(t, tc.wantJSON, string(data))
+		})
+	}
+}


### PR DESCRIPTION
Implements the `max` notification provider (MAX messenger) introduced upstream in Uptime Kuma v2.x (PR louislam/uptime-kuma#7160).

## Changes
- Add `notification/notification_max.go` with the `Max` struct embedding `Base` and `MaxDetails`, mirroring the Telegram notification pattern (bot + template model).
- Add `notification/notification_max_test.go` with marshal/unmarshal round-trip tests covering both the full configuration (with template) and a minimal configuration.

## Fields
- `maxApiUrl` — base API URL (e.g. `https://platform-api.max.ru`)
- `maxBotToken` — bot token used as the `Authorization` header
- `maxChatID` — target chat ID
- `maxUseTemplate` — toggle template rendering
- `maxTemplate` — message template body
- `maxTemplateFormat` — format preset (`plain`, `markdown`, `html`)

## Notes
The CRUD integration test in `notification_test.go` was intentionally not added because the docker image pinned for end-to-end testing (`louislam/uptime-kuma:2.2.0`) does not yet ship the `max` provider (added in a later 2.x release). This matches the pattern used for the recently added `fluxer`, `bale` and `whatsapp360messenger` providers.

Closes #242