### PR TITLE
feat(monitor): add support for OracleDB monitor type

### DIFF
--- a/monitor/monitor_oracledb.go
+++ b/monitor/monitor_oracledb.go
@@ -1,0 +1,111 @@
+package monitor
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// OracleDB represents an OracleDB monitor for testing Oracle Database connectivity and queries.
+type OracleDB struct {
+	Base
+	OracleDBDetails
+}
+
+// Type returns the monitor type.
+func (o OracleDB) Type() string {
+	return o.OracleDBDetails.Type()
+}
+
+// String returns a string representation of the OracleDB monitor.
+func (o OracleDB) String() string {
+	return fmt.Sprintf("%s, %s", formatMonitor(o.Base, false), formatMonitor(o.OracleDBDetails, true))
+}
+
+// UnmarshalJSON unmarshals an OracleDB monitor from JSON data.
+func (o *OracleDB) UnmarshalJSON(data []byte) error {
+	base := Base{}
+	err := json.Unmarshal(data, &base)
+	if err != nil {
+		return fmt.Errorf("unmarshal: %w", err)
+	}
+
+	details := OracleDBDetails{}
+	err = json.Unmarshal(data, &details)
+	if err != nil {
+		return fmt.Errorf("unmarshal: %w", err)
+	}
+
+	*o = OracleDB{
+		Base:            base,
+		OracleDBDetails: details,
+	}
+
+	return nil
+}
+
+// MarshalJSON marshals an OracleDB monitor to JSON data.
+func (o OracleDB) MarshalJSON() ([]byte, error) {
+	raw := map[string]any{}
+	raw["id"] = o.ID
+	raw["type"] = "oracledb"
+	raw["name"] = o.Name
+	raw["description"] = o.Description
+	// Don't set pathName, server generates it.
+	// raw["pathName"] = o.PathName
+	raw["parent"] = o.Parent
+	raw["interval"] = o.Interval
+	raw["retryInterval"] = o.RetryInterval
+	raw["resendInterval"] = o.ResendInterval
+	raw["maxretries"] = o.MaxRetries
+	raw["upsideDown"] = o.UpsideDown
+	raw["active"] = o.IsActive
+
+	// Update notification IDs.
+	ids := map[string]bool{}
+	for _, id := range o.NotificationIDs {
+		ids[strconv.FormatInt(id, 10)] = true
+	}
+
+	raw["notificationIDList"] = ids
+
+	// Always override with current OracleDB-specific field values.
+	raw["databaseConnectionString"] = o.DatabaseConnectionString
+	raw["databaseQuery"] = o.DatabaseQuery
+	raw["basic_auth_user"] = o.Username
+	raw["basic_auth_pass"] = o.Password
+
+	// Server expects these fields to be arrays and not null.
+	raw["accepted_statuscodes"] = []string{}
+
+	// Uptime Kuma v2 requires conditions field (empty array by default)
+	raw["conditions"] = conditionsForWire(o.Conditions)
+
+	data, err := json.Marshal(raw)
+	if err != nil {
+		return nil, fmt.Errorf("marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// OracleDBDetails contains OracleDB-specific monitor configuration.
+type OracleDBDetails struct {
+	// DatabaseConnectionString is the Oracle EZCONNECT string, e.g. host:port/service.
+	DatabaseConnectionString string `json:"databaseConnectionString"`
+	// DatabaseQuery is an optional SQL query to execute (default: SELECT 1 FROM DUAL).
+	DatabaseQuery *string `json:"databaseQuery"`
+	// Username is the Oracle Database user.
+	Username string `json:"basic_auth_user"`
+	// Password is the Oracle Database password.
+	Password string `json:"basic_auth_pass"`
+	// Conditions is an optional list of assertion clauses evaluated against the
+	// query result. When set, the query is expected to return a single value
+	// that is matched against the conditions.
+	Conditions []Condition `json:"conditions,omitempty"`
+}
+
+// Type returns the monitor type.
+func (OracleDBDetails) Type() string {
+	return "oracledb"
+}

--- a/monitor/monitor_oracledb_test.go
+++ b/monitor/monitor_oracledb_test.go
@@ -113,6 +113,36 @@ func TestMonitorOracleDB_Unmarshal(t *testing.T) {
 			},
 			wantJSON: `{"accepted_statuscodes":[],"active":true,"basic_auth_pass":"oracle","basic_auth_user":"system","conditions":[{"type":"expression","variable":"result","operator":"contains","value":"Oracle","andOr":"and"}],"databaseConnectionString":"db.example.com:1521/ORCL","databaseQuery":"SELECT banner FROM v$version WHERE banner LIKE 'Oracle%'","description":null,"id":3,"interval":60,"maxretries":1,"name":"oracledb-conditions","notificationIDList":{},"parent":null,"resendInterval":0,"retryInterval":60,"type":"oracledb","upsideDown":false}`,
 		},
+		{
+			name: "success with null credentials",
+			data: []byte(
+				`{"id":4,"name":"oracledb-nocreds","description":null,"pathName":"oracledb-nocreds","parent":null,"childrenIDs":[],"type":"oracledb","active":true,"interval":60,"retryInterval":60,"resendInterval":0,"maxretries":1,"upsideDown":false,"notificationIDList":{},"databaseConnectionString":"localhost:1521/XEPDB1","databaseQuery":null,"basic_auth_user":null,"basic_auth_pass":null}`,
+			),
+
+			want: monitor.OracleDB{
+				Base: monitor.Base{
+					ID:              4,
+					Name:            "oracledb-nocreds",
+					Description:     nil,
+					PathName:        "oracledb-nocreds",
+					Parent:          nil,
+					Interval:        60,
+					RetryInterval:   60,
+					ResendInterval:  0,
+					MaxRetries:      1,
+					UpsideDown:      false,
+					NotificationIDs: nil,
+					IsActive:        true,
+				},
+				OracleDBDetails: monitor.OracleDBDetails{
+					DatabaseConnectionString: "localhost:1521/XEPDB1",
+					DatabaseQuery:            nil,
+					Username:                 "",
+					Password:                 "",
+				},
+			},
+			wantJSON: `{"accepted_statuscodes":[],"active":true,"basic_auth_pass":"","basic_auth_user":"","conditions":[],"databaseConnectionString":"localhost:1521/XEPDB1","databaseQuery":null,"description":null,"id":4,"interval":60,"maxretries":1,"name":"oracledb-nocreds","notificationIDList":{},"parent":null,"resendInterval":0,"retryInterval":60,"type":"oracledb","upsideDown":false}`,
+		},
 	}
 
 	for _, tc := range tests {
@@ -152,6 +182,8 @@ func TestMonitorOracleDB_String(t *testing.T) {
 			wantContains: []string{
 				`databaseConnectionString: "localhost:1521/XEPDB1"`,
 				`databaseQuery: "SELECT 1 FROM DUAL"`,
+				`basic_auth_user: "oracle"`,
+				`basic_auth_pass: "secret"`,
 			},
 			wantNotContains: []string{"0x"},
 		},
@@ -166,6 +198,8 @@ func TestMonitorOracleDB_String(t *testing.T) {
 			wantContains: []string{
 				`databaseConnectionString: "localhost:1521/XEPDB1"`,
 				"databaseQuery: <nil>",
+				`basic_auth_user: "oracle"`,
+				`basic_auth_pass: "secret"`,
 			},
 			wantNotContains: []string{"0x"},
 		},

--- a/monitor/monitor_oracledb_test.go
+++ b/monitor/monitor_oracledb_test.go
@@ -1,0 +1,187 @@
+package monitor_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/breml/go-uptime-kuma-client/internal/ptr"
+	"github.com/breml/go-uptime-kuma-client/monitor"
+)
+
+func TestMonitorOracleDB_Unmarshal(t *testing.T) {
+	parent1 := int64(1)
+
+	tests := []struct {
+		name string
+		data []byte
+
+		want     monitor.OracleDB
+		wantJSON string
+	}{
+		{
+			name: "success with connection string only",
+			data: []byte(
+				`{"id":1,"name":"oracledb-monitor","description":"Test OracleDB monitor","pathName":"group / oracledb-monitor","parent":1,"childrenIDs":[],"url":null,"method":"GET","hostname":null,"port":null,"maxretries":2,"weight":2000,"active":true,"forceInactive":false,"type":"oracledb","timeout":48,"interval":60,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":"A","dns_resolve_server":"1.1.1.1","dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{"1":true,"2":true},"tags":[],"maintenance":false,"mqttTopic":"","mqttSuccessMessage":"","databaseQuery":null,"authMethod":null,"grpcUrl":null,"grpcProtobuf":null,"grpcMethod":null,"grpcServiceName":null,"grpcEnableTls":false,"radiusCalledStationId":null,"radiusCallingStationId":null,"game":null,"gamedigGivenPortOnly":true,"httpBodyEncoding":"json","jsonPath":null,"expectedValue":null,"kafkaProducerTopic":null,"kafkaProducerBrokers":[],"kafkaProducerSsl":false,"kafkaProducerAllowAutoTopicCreation":false,"kafkaProducerMessage":null,"screenshot":null,"headers":null,"body":null,"grpcBody":null,"grpcMetadata":null,"basic_auth_user":"oracle","basic_auth_pass":"secret","oauth_client_id":null,"oauth_client_secret":null,"oauth_token_url":null,"oauth_scopes":null,"oauth_auth_method":"client_secret_basic","pushToken":null,"databaseConnectionString":"localhost:1521/XEPDB1","radiusUsername":null,"radiusPassword":null,"radiusSecret":null,"mqttUsername":"","mqttPassword":"","authWorkstation":null,"authDomain":null,"tlsCa":null,"tlsCert":null,"tlsKey":null,"kafkaProducerSaslOptions":{"mechanism":"None"},"includeSensitiveData":true}`,
+			),
+
+			want: monitor.OracleDB{
+				Base: monitor.Base{
+					ID:              1,
+					Name:            "oracledb-monitor",
+					Description:     ptr.To("Test OracleDB monitor"),
+					PathName:        "group / oracledb-monitor",
+					Parent:          &parent1,
+					Interval:        60,
+					RetryInterval:   60,
+					ResendInterval:  0,
+					MaxRetries:      2,
+					UpsideDown:      false,
+					NotificationIDs: []int64{1, 2},
+					IsActive:        true,
+				},
+				OracleDBDetails: monitor.OracleDBDetails{
+					DatabaseConnectionString: "localhost:1521/XEPDB1",
+					DatabaseQuery:            nil,
+					Username:                 "oracle",
+					Password:                 "secret",
+				},
+			},
+			wantJSON: `{"accepted_statuscodes":[],"active":true,"basic_auth_pass":"secret","basic_auth_user":"oracle","conditions":[],"databaseConnectionString":"localhost:1521/XEPDB1","databaseQuery":null,"description":"Test OracleDB monitor","id":1,"interval":60,"maxretries":2,"name":"oracledb-monitor","notificationIDList":{"1":true,"2":true},"parent":1,"resendInterval":0,"retryInterval":60,"type":"oracledb","upsideDown":false}`,
+		},
+		{
+			name: "success with connection string and query",
+			data: []byte(
+				`{"id":2,"name":"oracledb-query","description":"Test OracleDB with query","pathName":"group / oracledb-query","parent":1,"childrenIDs":[],"url":null,"method":"GET","hostname":null,"port":null,"maxretries":3,"weight":2000,"active":true,"forceInactive":false,"type":"oracledb","timeout":60,"interval":120,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":null,"dns_resolve_server":null,"dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{},"tags":[],"maintenance":false,"mqttTopic":"","mqttSuccessMessage":"","databaseQuery":"SELECT COUNT(*) FROM user_tables","authMethod":null,"grpcUrl":null,"grpcProtobuf":null,"grpcMethod":null,"grpcServiceName":null,"grpcEnableTls":false,"radiusCalledStationId":null,"radiusCallingStationId":null,"game":null,"gamedigGivenPortOnly":true,"httpBodyEncoding":"json","jsonPath":null,"expectedValue":null,"kafkaProducerTopic":null,"kafkaProducerBrokers":[],"kafkaProducerSsl":false,"kafkaProducerAllowAutoTopicCreation":false,"kafkaProducerMessage":null,"screenshot":null,"headers":null,"body":null,"grpcBody":null,"grpcMetadata":null,"basic_auth_user":"admin","basic_auth_pass":"adminpass","oauth_client_id":null,"oauth_client_secret":null,"oauth_token_url":null,"oauth_scopes":null,"oauth_auth_method":"client_secret_basic","pushToken":null,"databaseConnectionString":"oracle.example.com:1521/PROD","radiusUsername":null,"radiusPassword":null,"radiusSecret":null,"mqttUsername":"","mqttPassword":"","authWorkstation":null,"authDomain":null,"tlsCa":null,"tlsCert":null,"tlsKey":null,"kafkaProducerSaslOptions":{"mechanism":"None"},"includeSensitiveData":true}`,
+			),
+
+			want: monitor.OracleDB{
+				Base: monitor.Base{
+					ID:              2,
+					Name:            "oracledb-query",
+					Description:     ptr.To("Test OracleDB with query"),
+					PathName:        "group / oracledb-query",
+					Parent:          &parent1,
+					Interval:        120,
+					RetryInterval:   60,
+					ResendInterval:  0,
+					MaxRetries:      3,
+					UpsideDown:      false,
+					NotificationIDs: nil,
+					IsActive:        true,
+				},
+				OracleDBDetails: monitor.OracleDBDetails{
+					DatabaseConnectionString: "oracle.example.com:1521/PROD",
+					DatabaseQuery:            ptr.To("SELECT COUNT(*) FROM user_tables"),
+					Username:                 "admin",
+					Password:                 "adminpass",
+				},
+			},
+			wantJSON: `{"accepted_statuscodes":[],"active":true,"basic_auth_pass":"adminpass","basic_auth_user":"admin","conditions":[],"databaseConnectionString":"oracle.example.com:1521/PROD","databaseQuery":"SELECT COUNT(*) FROM user_tables","description":"Test OracleDB with query","id":2,"interval":120,"maxretries":3,"name":"oracledb-query","notificationIDList":{},"parent":1,"resendInterval":0,"retryInterval":60,"type":"oracledb","upsideDown":false}`,
+		},
+		{
+			name: "success with conditions",
+			data: []byte(
+				`{"id":3,"name":"oracledb-conditions","description":null,"pathName":"oracledb-conditions","parent":null,"childrenIDs":[],"url":null,"method":"GET","hostname":null,"port":null,"maxretries":1,"weight":2000,"active":true,"forceInactive":false,"type":"oracledb","timeout":48,"interval":60,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":null,"dns_resolve_server":null,"dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{},"tags":[],"maintenance":false,"databaseQuery":"SELECT banner FROM v$version WHERE banner LIKE 'Oracle%'","databaseConnectionString":"db.example.com:1521/ORCL","basic_auth_user":"system","basic_auth_pass":"oracle","conditions":[{"type":"expression","variable":"result","operator":"contains","value":"Oracle","andOr":"and"}]}`,
+			),
+
+			want: monitor.OracleDB{
+				Base: monitor.Base{
+					ID:              3,
+					Name:            "oracledb-conditions",
+					Description:     nil,
+					PathName:        "oracledb-conditions",
+					Parent:          nil,
+					Interval:        60,
+					RetryInterval:   60,
+					ResendInterval:  0,
+					MaxRetries:      1,
+					UpsideDown:      false,
+					NotificationIDs: nil,
+					IsActive:        true,
+				},
+				OracleDBDetails: monitor.OracleDBDetails{
+					DatabaseConnectionString: "db.example.com:1521/ORCL",
+					DatabaseQuery:            ptr.To("SELECT banner FROM v$version WHERE banner LIKE 'Oracle%'"),
+					Username:                 "system",
+					Password:                 "oracle",
+					Conditions: []monitor.Condition{
+						{Variable: "result", Operator: "contains", Value: "Oracle", AndOr: monitor.ConditionAnd},
+					},
+				},
+			},
+			wantJSON: `{"accepted_statuscodes":[],"active":true,"basic_auth_pass":"oracle","basic_auth_user":"system","conditions":[{"type":"expression","variable":"result","operator":"contains","value":"Oracle","andOr":"and"}],"databaseConnectionString":"db.example.com:1521/ORCL","databaseQuery":"SELECT banner FROM v$version WHERE banner LIKE 'Oracle%'","description":null,"id":3,"interval":60,"maxretries":1,"name":"oracledb-conditions","notificationIDList":{},"parent":null,"resendInterval":0,"retryInterval":60,"type":"oracledb","upsideDown":false}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			oracleMonitor := monitor.OracleDB{}
+
+			err := json.Unmarshal(tc.data, &oracleMonitor)
+			require.NoError(t, err)
+
+			require.EqualExportedValues(t, tc.want, oracleMonitor)
+
+			data, err := json.Marshal(oracleMonitor)
+			require.NoError(t, err)
+
+			require.JSONEq(t, tc.wantJSON, string(data))
+		})
+	}
+}
+
+func TestMonitorOracleDB_String(t *testing.T) {
+	tests := []struct {
+		name string
+
+		details monitor.OracleDBDetails
+
+		wantContains    []string
+		wantNotContains []string
+	}{
+		{
+			name: "query set",
+			details: monitor.OracleDBDetails{
+				DatabaseConnectionString: "localhost:1521/XEPDB1",
+				DatabaseQuery:            ptr.To("SELECT 1 FROM DUAL"),
+				Username:                 "oracle",
+				Password:                 "secret",
+			},
+			wantContains: []string{
+				`databaseConnectionString: "localhost:1521/XEPDB1"`,
+				`databaseQuery: "SELECT 1 FROM DUAL"`,
+			},
+			wantNotContains: []string{"0x"},
+		},
+		{
+			name: "query nil",
+			details: monitor.OracleDBDetails{
+				DatabaseConnectionString: "localhost:1521/XEPDB1",
+				DatabaseQuery:            nil,
+				Username:                 "oracle",
+				Password:                 "secret",
+			},
+			wantContains: []string{
+				`databaseConnectionString: "localhost:1521/XEPDB1"`,
+				"databaseQuery: <nil>",
+			},
+			wantNotContains: []string{"0x"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := monitor.OracleDB{OracleDBDetails: tc.details}.String()
+
+			for _, want := range tc.wantContains {
+				require.Contains(t, got, want)
+			}
+
+			for _, notWant := range tc.wantNotContains {
+				require.NotContains(t, got, notWant)
+			}
+		})
+	}
+}

--- a/monitor_test.go
+++ b/monitor_test.go
@@ -545,6 +545,75 @@ func TestMonitorCRUD(t *testing.T) {
 			testPauseResume: false,
 		},
 		{
+			name: "OracleDB",
+			create: &monitor.OracleDB{
+				Base: monitor.Base{
+					Name:           "Test OracleDB Monitor",
+					Interval:       60,
+					RetryInterval:  60,
+					ResendInterval: 0,
+					MaxRetries:     3,
+					UpsideDown:     false,
+					IsActive:       false,
+				},
+				OracleDBDetails: monitor.OracleDBDetails{
+					DatabaseConnectionString: "localhost:1521/XEPDB1",
+					DatabaseQuery:            ptr.To("SELECT 1 FROM DUAL"),
+					Username:                 "oracle",
+					Password:                 "oraclepass",
+				},
+			},
+			updateFunc: func(m monitor.Monitor) {
+				oracledb, ok := m.(*monitor.OracleDB)
+				if !ok {
+					panic("failed to assert OracleDB monitor")
+				}
+
+				oracledb.Name = "Updated OracleDB Monitor"
+				oracledb.DatabaseConnectionString = "oracle.example.com:1521/PROD"
+				oracledb.DatabaseQuery = ptr.To("SELECT banner FROM v$version WHERE banner LIKE 'Oracle%'")
+				oracledb.Username = "system"
+				oracledb.Password = "newsecret"
+				oracledb.Conditions = []monitor.Condition{
+					{Variable: "result", Operator: "contains", Value: "Oracle", AndOr: monitor.ConditionAnd},
+				}
+			},
+			verifyCreatedFunc: func(t *testing.T, actual monitor.Monitor, id int64) {
+				t.Helper()
+				var oracledb monitor.OracleDB
+				err := actual.As(&oracledb)
+				require.NoError(t, err)
+				require.Equal(t, id, oracledb.ID)
+				require.Equal(t, "Test OracleDB Monitor", oracledb.Name)
+			},
+			createTypedFunc: func(t *testing.T, base monitor.Monitor) monitor.Monitor {
+				t.Helper()
+				var oracledb monitor.OracleDB
+				err := base.As(&oracledb)
+				require.NoError(t, err)
+				return &oracledb
+			},
+			verifyUpdatedFunc: func(t *testing.T, actual monitor.Monitor) {
+				t.Helper()
+				var oracledb monitor.OracleDB
+				err := actual.As(&oracledb)
+				require.NoError(t, err)
+				require.Equal(t, "Updated OracleDB Monitor", oracledb.Name)
+				require.Equal(t, "oracle.example.com:1521/PROD", oracledb.DatabaseConnectionString)
+				require.Equal(
+					t,
+					ptr.To("SELECT banner FROM v$version WHERE banner LIKE 'Oracle%'"),
+					oracledb.DatabaseQuery,
+				)
+				require.Equal(t, "system", oracledb.Username)
+				require.Equal(t, "newsecret", oracledb.Password)
+				require.Equal(t, []monitor.Condition{
+					{Variable: "result", Operator: "contains", Value: "Oracle", AndOr: monitor.ConditionAnd},
+				}, oracledb.Conditions)
+			},
+			testPauseResume: false,
+		},
+		{
 			name: "Real Browser",
 			create: &monitor.RealBrowser{
 				Base: monitor.Base{

--- a/monitor_test.go
+++ b/monitor_test.go
@@ -585,6 +585,8 @@ func TestMonitorCRUD(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, id, oracledb.ID)
 				require.Equal(t, "Test OracleDB Monitor", oracledb.Name)
+				require.Equal(t, "oracle", oracledb.Username)
+				require.Equal(t, "oraclepass", oracledb.Password)
 			},
 			createTypedFunc: func(t *testing.T, base monitor.Monitor) monitor.Monitor {
 				t.Helper()


### PR DESCRIPTION
## Summary

Adds support for the OracleDB monitor type (`oracledb`) introduced upstream in Uptime Kuma v2.x (louislam/uptime-kuma#7156).

The monitor performs a connection check and optionally executes a query against an Oracle Database instance (default `SELECT 1 FROM DUAL`), with assertion conditions on the query result.

## Fields

- `databaseConnectionString` — Oracle EZCONNECT string (e.g. `host:port/service`)
- `databaseQuery` — optional query, single-row/single-value when conditions are set
- `username` / `password` — mapped to `basic_auth_user` / `basic_auth_pass` on the wire (required by the upstream server)
- `conditions` — assertion clauses evaluated against the query result

## Tests

- `monitor/monitor_oracledb_test.go`: JSON round-trip coverage (connection-string only, with query, with conditions) and `String()` test
- `monitor_test.go`: CRUD end-to-end case (create / update / `As` typed accessor)

## Validation

- `task fmt`
- `task lint`
- `task test-e2e` (all tests pass, including `TestMonitorCRUD/OracleDB`)

Mirrors the existing `monitor.Postgres` / `monitor.MySQL` patterns.

Closes #232