### PR TITLE
feat(monitor): add support for SIP Options monitor type

### DIFF
--- a/monitor/monitor_sip_options.go
+++ b/monitor/monitor_sip_options.go
@@ -1,0 +1,99 @@
+package monitor
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// SIPOptions represents a sip-options monitor.
+type SIPOptions struct {
+	Base
+	SIPOptionsDetails
+}
+
+// Type returns the monitor type.
+func (s SIPOptions) Type() string {
+	return s.SIPOptionsDetails.Type()
+}
+
+// String returns a string representation of the monitor.
+func (s SIPOptions) String() string {
+	return fmt.Sprintf("%s, %s", formatMonitor(s.Base, false), formatMonitor(s.SIPOptionsDetails, true))
+}
+
+// UnmarshalJSON unmarshals a JSON byte slice into a monitor.
+func (s *SIPOptions) UnmarshalJSON(data []byte) error {
+	base := Base{}
+	err := json.Unmarshal(data, &base)
+	if err != nil {
+		return fmt.Errorf("unmarshal: %w", err)
+	}
+
+	details := SIPOptionsDetails{}
+	err = json.Unmarshal(data, &details)
+	if err != nil {
+		return fmt.Errorf("unmarshal: %w", err)
+	}
+
+	*s = SIPOptions{
+		Base:              base,
+		SIPOptionsDetails: details,
+	}
+
+	return nil
+}
+
+// MarshalJSON marshals a monitor into a JSON byte slice.
+func (s SIPOptions) MarshalJSON() ([]byte, error) {
+	raw := map[string]any{}
+	raw["id"] = s.ID
+	raw["type"] = "sip-options"
+	raw["name"] = s.Name
+	raw["description"] = s.Description
+	// Don't set pathName, server generates it.
+	// raw["pathName"] = s.PathName
+	raw["parent"] = s.Parent
+	raw["interval"] = s.Interval
+	raw["retryInterval"] = s.RetryInterval
+	raw["resendInterval"] = s.ResendInterval
+	raw["maxretries"] = s.MaxRetries
+	raw["upsideDown"] = s.UpsideDown
+	raw["active"] = s.IsActive
+
+	// Update notification IDs.
+	ids := map[string]bool{}
+	for _, id := range s.NotificationIDs {
+		ids[strconv.FormatInt(id, 10)] = true
+	}
+
+	raw["notificationIDList"] = ids
+
+	// Always override with current SIPOptions-specific field values.
+	raw["hostname"] = s.Hostname
+	raw["port"] = s.Port
+
+	// Server expects these fields to be arrays and not null.
+	raw["accepted_statuscodes"] = []string{}
+
+	// Uptime Kuma v2 requires conditions field (empty array by default)
+	raw["conditions"] = []any{}
+
+	data, err := json.Marshal(raw)
+	if err != nil {
+		return nil, fmt.Errorf("marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// SIPOptionsDetails contains sip-options-specific monitor configuration.
+type SIPOptionsDetails struct {
+	Hostname string `json:"hostname"`
+	Port     int    `json:"port"`
+}
+
+// Type returns the monitor type.
+func (SIPOptionsDetails) Type() string {
+	return "sip-options"
+}

--- a/monitor/monitor_sip_options_test.go
+++ b/monitor/monitor_sip_options_test.go
@@ -1,0 +1,95 @@
+package monitor_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/breml/go-uptime-kuma-client/internal/ptr"
+	"github.com/breml/go-uptime-kuma-client/monitor"
+)
+
+func TestMonitorSIPOptions_Unmarshal(t *testing.T) {
+	parent1 := int64(1)
+
+	tests := []struct {
+		name string
+		data []byte
+
+		want     monitor.SIPOptions
+		wantJSON string
+	}{
+		{
+			name: "success",
+			data: []byte(
+				`{"id":4,"name":"sip-options-monitor","description":"Test SIP Options monitor","pathName":"group / sip-options-monitor","parent":1,"childrenIDs":[],"url":null,"method":"GET","hostname":"sip.example.com","port":5060,"maxretries":2,"weight":2000,"active":true,"forceInactive":false,"type":"sip-options","timeout":48,"interval":60,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":"A","dns_resolve_server":"1.1.1.1","dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{"1":true,"2":true},"tags":[],"maintenance":false,"mqttTopic":"","mqttSuccessMessage":"","databaseQuery":null,"authMethod":null,"grpcUrl":null,"grpcProtobuf":null,"grpcMethod":null,"grpcServiceName":null,"grpcEnableTls":false,"radiusCalledStationId":null,"radiusCallingStationId":null,"game":null,"gamedigGivenPortOnly":true,"httpBodyEncoding":"json","jsonPath":null,"expectedValue":null,"kafkaProducerTopic":null,"kafkaProducerBrokers":[],"kafkaProducerSsl":false,"kafkaProducerAllowAutoTopicCreation":false,"kafkaProducerMessage":null,"screenshot":null,"headers":null,"body":null,"grpcBody":null,"grpcMetadata":null,"basic_auth_user":null,"basic_auth_pass":null,"oauth_client_id":null,"oauth_client_secret":null,"oauth_token_url":null,"oauth_scopes":null,"oauth_auth_method":"client_secret_basic","pushToken":null,"databaseConnectionString":null,"radiusUsername":null,"radiusPassword":null,"radiusSecret":null,"mqttUsername":"","mqttPassword":"","authWorkstation":null,"authDomain":null,"tlsCa":null,"tlsCert":null,"tlsKey":null,"kafkaProducerSaslOptions":{"mechanism":"None"},"includeSensitiveData":true}`,
+			),
+
+			want: monitor.SIPOptions{
+				Base: monitor.Base{
+					ID:              4,
+					Name:            "sip-options-monitor",
+					Description:     ptr.To("Test SIP Options monitor"),
+					PathName:        "group / sip-options-monitor",
+					Parent:          &parent1,
+					Interval:        60,
+					RetryInterval:   60,
+					ResendInterval:  0,
+					MaxRetries:      2,
+					UpsideDown:      false,
+					NotificationIDs: []int64{1, 2},
+					IsActive:        true,
+				},
+				SIPOptionsDetails: monitor.SIPOptionsDetails{
+					Hostname: "sip.example.com",
+					Port:     5060,
+				},
+			},
+			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":"Test SIP Options monitor","hostname":"sip.example.com","id":4,"interval":60,"maxretries":2,"name":"sip-options-monitor","notificationIDList":{"1":true,"2":true},"parent":1,"port":5060,"resendInterval":0,"retryInterval":60,"type":"sip-options","upsideDown":false}`,
+		},
+		{
+			name: "success without parent",
+			data: []byte(
+				`{"id":5,"name":"sip-options-monitor-no-parent","description":null,"pathName":"sip-options-monitor-no-parent","parent":null,"childrenIDs":[],"url":null,"method":"GET","hostname":"192.168.1.10","port":5061,"maxretries":3,"weight":2000,"active":true,"forceInactive":false,"type":"sip-options","timeout":null,"interval":120,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":"A","dns_resolve_server":"1.1.1.1","dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{},"tags":[],"maintenance":false,"mqttTopic":"","mqttSuccessMessage":"","databaseQuery":null,"authMethod":null,"grpcUrl":null,"grpcProtobuf":null,"grpcMethod":null,"grpcServiceName":null,"grpcEnableTls":false,"radiusCalledStationId":null,"radiusCallingStationId":null,"game":null,"gamedigGivenPortOnly":true,"httpBodyEncoding":"json","jsonPath":null,"expectedValue":null,"kafkaProducerTopic":null,"kafkaProducerBrokers":[],"kafkaProducerSsl":false,"kafkaProducerAllowAutoTopicCreation":false,"kafkaProducerMessage":null,"screenshot":null,"headers":null,"body":null,"grpcBody":null,"grpcMetadata":null,"basic_auth_user":null,"basic_auth_pass":null,"oauth_client_id":null,"oauth_client_secret":null,"oauth_token_url":null,"oauth_scopes":null,"oauth_auth_method":"client_secret_basic","pushToken":null,"databaseConnectionString":null,"radiusUsername":null,"radiusPassword":null,"radiusSecret":null,"mqttUsername":"","mqttPassword":"","authWorkstation":null,"authDomain":null,"tlsCa":null,"tlsCert":null,"tlsKey":null,"kafkaProducerSaslOptions":{"mechanism":"None"},"includeSensitiveData":true}`,
+			),
+
+			want: monitor.SIPOptions{
+				Base: monitor.Base{
+					ID:             5,
+					Name:           "sip-options-monitor-no-parent",
+					Description:    nil,
+					PathName:       "sip-options-monitor-no-parent",
+					Parent:         nil,
+					Interval:       120,
+					RetryInterval:  60,
+					ResendInterval: 0,
+					MaxRetries:     3,
+					UpsideDown:     false,
+					IsActive:       true,
+				},
+				SIPOptionsDetails: monitor.SIPOptionsDetails{
+					Hostname: "192.168.1.10",
+					Port:     5061,
+				},
+			},
+			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":null,"hostname":"192.168.1.10","id":5,"interval":120,"maxretries":3,"name":"sip-options-monitor-no-parent","notificationIDList":{},"parent":null,"port":5061,"resendInterval":0,"retryInterval":60,"type":"sip-options","upsideDown":false}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sipOptionsMonitor := monitor.SIPOptions{}
+
+			err := json.Unmarshal(tc.data, &sipOptionsMonitor)
+			require.NoError(t, err)
+
+			require.EqualExportedValues(t, tc.want, sipOptionsMonitor)
+
+			data, err := json.Marshal(sipOptionsMonitor)
+			require.NoError(t, err)
+
+			require.JSONEq(t, tc.wantJSON, string(data))
+		})
+	}
+}

--- a/monitor_test.go
+++ b/monitor_test.go
@@ -1714,6 +1714,61 @@ func TestMonitorCRUD(t *testing.T) {
 			},
 			testPauseResume: true,
 		},
+		{
+			name: "SIP Options",
+			create: &monitor.SIPOptions{
+				Base: monitor.Base{
+					Name:           "Test SIP Options Monitor",
+					Interval:       60,
+					RetryInterval:  60,
+					ResendInterval: 0,
+					MaxRetries:     3,
+					UpsideDown:     false,
+					IsActive:       true,
+				},
+				SIPOptionsDetails: monitor.SIPOptionsDetails{
+					Hostname: "sip.example.com",
+					Port:     5060,
+				},
+			},
+			updateFunc: func(m monitor.Monitor) {
+				sip, ok := m.(*monitor.SIPOptions)
+				if !ok {
+					panic("failed to assert SIPOptions monitor")
+				}
+
+				sip.Name = "Updated SIP Options Monitor"
+				sip.Hostname = "sip2.example.com"
+				sip.Port = 5061
+			},
+			verifyCreatedFunc: func(t *testing.T, actual monitor.Monitor, id int64) {
+				t.Helper()
+				var sip monitor.SIPOptions
+				err := actual.As(&sip)
+				require.NoError(t, err)
+				require.Equal(t, id, sip.ID)
+				require.Equal(t, "Test SIP Options Monitor", sip.Name)
+				require.Equal(t, "sip.example.com", sip.Hostname)
+				require.Equal(t, 5060, sip.Port)
+			},
+			createTypedFunc: func(t *testing.T, base monitor.Monitor) monitor.Monitor {
+				t.Helper()
+				var sip monitor.SIPOptions
+				err := base.As(&sip)
+				require.NoError(t, err)
+				return &sip
+			},
+			verifyUpdatedFunc: func(t *testing.T, actual monitor.Monitor) {
+				t.Helper()
+				var sip monitor.SIPOptions
+				err := actual.As(&sip)
+				require.NoError(t, err)
+				require.Equal(t, "Updated SIP Options Monitor", sip.Name)
+				require.Equal(t, "sip2.example.com", sip.Hostname)
+				require.Equal(t, 5061, sip.Port)
+			},
+			testPauseResume: true,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## Summary

- Add `SIPOptions` monitor type with `hostname` and `port` fields
- Implement `Type()`, `MarshalJSON()`, `UnmarshalJSON()` following the `TCPPort` pattern
- Add JSON round-trip tests covering monitor with and without parent

## References

Closes #233