### PR TITLE
feat(monitor): add support for System Service monitor type

### DIFF
--- a/monitor/monitor_system_service.go
+++ b/monitor/monitor_system_service.go
@@ -27,13 +27,13 @@ func (s *SystemService) UnmarshalJSON(data []byte) error {
 	base := Base{}
 	err := json.Unmarshal(data, &base)
 	if err != nil {
-		return fmt.Errorf("unmarshal: %w", err)
+		return fmt.Errorf("unmarshal system-service monitor base: %w", err)
 	}
 
 	details := SystemServiceDetails{}
 	err = json.Unmarshal(data, &details)
 	if err != nil {
-		return fmt.Errorf("unmarshal: %w", err)
+		return fmt.Errorf("unmarshal system-service monitor details: %w", err)
 	}
 
 	*s = SystemService{
@@ -80,7 +80,7 @@ func (s SystemService) MarshalJSON() ([]byte, error) {
 
 	data, err := json.Marshal(raw)
 	if err != nil {
-		return nil, fmt.Errorf("marshal: %w", err)
+		return nil, fmt.Errorf("marshal system-service monitor: %w", err)
 	}
 
 	return data, nil
@@ -88,7 +88,10 @@ func (s SystemService) MarshalJSON() ([]byte, error) {
 
 // SystemServiceDetails contains system-service-specific monitor configuration.
 type SystemServiceDetails struct {
-	// SystemServiceName is the name of the service to check (e.g. "nginx.service" on Linux, "Spooler" on Windows).
+	// SystemServiceName is the name of the service to check. Must be non-empty.
+	// On Linux (systemd), valid characters are alphanumeric plus '.', '_', '-', and '@'
+	// (e.g. "nginx.service", "sshd@0.service"). On Windows, valid characters are
+	// alphanumeric plus '.', '_', '-' (e.g. "Spooler").
 	// Note: the upstream API uses snake_case for this field, unlike most other Uptime Kuma fields.
 	SystemServiceName string `json:"system_service_name"`
 }

--- a/monitor/monitor_system_service.go
+++ b/monitor/monitor_system_service.go
@@ -1,0 +1,99 @@
+package monitor
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// SystemService represents a system-service monitor.
+type SystemService struct {
+	Base
+	SystemServiceDetails
+}
+
+// Type returns the monitor type.
+func (s SystemService) Type() string {
+	return s.SystemServiceDetails.Type()
+}
+
+// String returns a string representation of the monitor.
+func (s SystemService) String() string {
+	return fmt.Sprintf("%s, %s", formatMonitor(s.Base, false), formatMonitor(s.SystemServiceDetails, true))
+}
+
+// UnmarshalJSON unmarshals a JSON byte slice into a monitor.
+func (s *SystemService) UnmarshalJSON(data []byte) error {
+	base := Base{}
+	err := json.Unmarshal(data, &base)
+	if err != nil {
+		return fmt.Errorf("unmarshal: %w", err)
+	}
+
+	details := SystemServiceDetails{}
+	err = json.Unmarshal(data, &details)
+	if err != nil {
+		return fmt.Errorf("unmarshal: %w", err)
+	}
+
+	*s = SystemService{
+		Base:                 base,
+		SystemServiceDetails: details,
+	}
+
+	return nil
+}
+
+// MarshalJSON marshals a monitor into a JSON byte slice.
+func (s SystemService) MarshalJSON() ([]byte, error) {
+	raw := map[string]any{}
+	raw["id"] = s.ID
+	raw["type"] = "system-service"
+	raw["name"] = s.Name
+	raw["description"] = s.Description
+	// Don't set pathName, server generates it.
+	// raw["pathName"] = s.PathName
+	raw["parent"] = s.Parent
+	raw["interval"] = s.Interval
+	raw["retryInterval"] = s.RetryInterval
+	raw["resendInterval"] = s.ResendInterval
+	raw["maxretries"] = s.MaxRetries
+	raw["upsideDown"] = s.UpsideDown
+	raw["active"] = s.IsActive
+
+	// Update notification IDs.
+	ids := map[string]bool{}
+	for _, id := range s.NotificationIDs {
+		ids[strconv.FormatInt(id, 10)] = true
+	}
+
+	raw["notificationIDList"] = ids
+
+	// Always override with current SystemService-specific field values.
+	raw["system_service_name"] = s.SystemServiceName
+
+	// Server expects these fields to be arrays and not null.
+	raw["accepted_statuscodes"] = []string{}
+
+	// Uptime Kuma v2 requires conditions field (empty array by default)
+	raw["conditions"] = []any{}
+
+	data, err := json.Marshal(raw)
+	if err != nil {
+		return nil, fmt.Errorf("marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// SystemServiceDetails contains system-service-specific monitor configuration.
+type SystemServiceDetails struct {
+	// SystemServiceName is the name of the service to check (e.g. "nginx.service" on Linux, "Spooler" on Windows).
+	// Note: the upstream API uses snake_case for this field, unlike most other Uptime Kuma fields.
+	SystemServiceName string `json:"system_service_name"`
+}
+
+// Type returns the monitor type.
+func (SystemServiceDetails) Type() string {
+	return "system-service"
+}

--- a/monitor/monitor_system_service_test.go
+++ b/monitor/monitor_system_service_test.go
@@ -1,0 +1,93 @@
+package monitor_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/breml/go-uptime-kuma-client/internal/ptr"
+	"github.com/breml/go-uptime-kuma-client/monitor"
+)
+
+func TestMonitorSystemService_Unmarshal(t *testing.T) {
+	parent1 := int64(1)
+
+	tests := []struct {
+		name string
+		data []byte
+
+		want     monitor.SystemService
+		wantJSON string
+	}{
+		{
+			name: "success",
+			data: []byte(
+				`{"id":4,"name":"system-service-monitor","description":"Test System Service monitor","pathName":"group / system-service-monitor","parent":1,"childrenIDs":[],"url":null,"method":"GET","hostname":null,"port":null,"maxretries":2,"weight":2000,"active":true,"forceInactive":false,"type":"system-service","timeout":48,"interval":60,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":"A","dns_resolve_server":"1.1.1.1","dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{"1":true,"2":true},"tags":[],"maintenance":false,"mqttTopic":"","mqttSuccessMessage":"","databaseQuery":null,"authMethod":null,"grpcUrl":null,"grpcProtobuf":null,"grpcMethod":null,"grpcServiceName":null,"grpcEnableTls":false,"radiusCalledStationId":null,"radiusCallingStationId":null,"game":null,"gamedigGivenPortOnly":true,"httpBodyEncoding":"json","jsonPath":null,"expectedValue":null,"kafkaProducerTopic":null,"kafkaProducerBrokers":[],"kafkaProducerSsl":false,"kafkaProducerAllowAutoTopicCreation":false,"kafkaProducerMessage":null,"screenshot":null,"headers":null,"body":null,"grpcBody":null,"grpcMetadata":null,"basic_auth_user":null,"basic_auth_pass":null,"oauth_client_id":null,"oauth_client_secret":null,"oauth_token_url":null,"oauth_scopes":null,"oauth_auth_method":"client_secret_basic","pushToken":null,"databaseConnectionString":null,"radiusUsername":null,"radiusPassword":null,"radiusSecret":null,"mqttUsername":"","mqttPassword":"","authWorkstation":null,"authDomain":null,"tlsCa":null,"tlsCert":null,"tlsKey":null,"kafkaProducerSaslOptions":{"mechanism":"None"},"system_service_name":"nginx.service","includeSensitiveData":true}`,
+			),
+
+			want: monitor.SystemService{
+				Base: monitor.Base{
+					ID:              4,
+					Name:            "system-service-monitor",
+					Description:     ptr.To("Test System Service monitor"),
+					PathName:        "group / system-service-monitor",
+					Parent:          &parent1,
+					Interval:        60,
+					RetryInterval:   60,
+					ResendInterval:  0,
+					MaxRetries:      2,
+					UpsideDown:      false,
+					NotificationIDs: []int64{1, 2},
+					IsActive:        true,
+				},
+				SystemServiceDetails: monitor.SystemServiceDetails{
+					SystemServiceName: "nginx.service",
+				},
+			},
+			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":"Test System Service monitor","id":4,"interval":60,"maxretries":2,"name":"system-service-monitor","notificationIDList":{"1":true,"2":true},"parent":1,"resendInterval":0,"retryInterval":60,"system_service_name":"nginx.service","type":"system-service","upsideDown":false}`,
+		},
+		{
+			name: "success without parent",
+			data: []byte(
+				`{"id":5,"name":"system-service-monitor-no-parent","description":null,"pathName":"system-service-monitor-no-parent","parent":null,"childrenIDs":[],"url":null,"method":"GET","hostname":null,"port":null,"maxretries":3,"weight":2000,"active":true,"forceInactive":false,"type":"system-service","timeout":null,"interval":120,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":"A","dns_resolve_server":"1.1.1.1","dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{},"tags":[],"maintenance":false,"mqttTopic":"","mqttSuccessMessage":"","databaseQuery":null,"authMethod":null,"grpcUrl":null,"grpcProtobuf":null,"grpcMethod":null,"grpcServiceName":null,"grpcEnableTls":false,"radiusCalledStationId":null,"radiusCallingStationId":null,"game":null,"gamedigGivenPortOnly":true,"httpBodyEncoding":"json","jsonPath":null,"expectedValue":null,"kafkaProducerTopic":null,"kafkaProducerBrokers":[],"kafkaProducerSsl":false,"kafkaProducerAllowAutoTopicCreation":false,"kafkaProducerMessage":null,"screenshot":null,"headers":null,"body":null,"grpcBody":null,"grpcMetadata":null,"basic_auth_user":null,"basic_auth_pass":null,"oauth_client_id":null,"oauth_client_secret":null,"oauth_token_url":null,"oauth_scopes":null,"oauth_auth_method":"client_secret_basic","pushToken":null,"databaseConnectionString":null,"radiusUsername":null,"radiusPassword":null,"radiusSecret":null,"mqttUsername":"","mqttPassword":"","authWorkstation":null,"authDomain":null,"tlsCa":null,"tlsCert":null,"tlsKey":null,"kafkaProducerSaslOptions":{"mechanism":"None"},"system_service_name":"Spooler","includeSensitiveData":true}`,
+			),
+
+			want: monitor.SystemService{
+				Base: monitor.Base{
+					ID:             5,
+					Name:           "system-service-monitor-no-parent",
+					Description:    nil,
+					PathName:       "system-service-monitor-no-parent",
+					Parent:         nil,
+					Interval:       120,
+					RetryInterval:  60,
+					ResendInterval: 0,
+					MaxRetries:     3,
+					UpsideDown:     false,
+					IsActive:       true,
+				},
+				SystemServiceDetails: monitor.SystemServiceDetails{
+					SystemServiceName: "Spooler",
+				},
+			},
+			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":null,"id":5,"interval":120,"maxretries":3,"name":"system-service-monitor-no-parent","notificationIDList":{},"parent":null,"resendInterval":0,"retryInterval":60,"system_service_name":"Spooler","type":"system-service","upsideDown":false}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			systemServiceMonitor := monitor.SystemService{}
+
+			err := json.Unmarshal(tc.data, &systemServiceMonitor)
+			require.NoError(t, err)
+
+			require.EqualExportedValues(t, tc.want, systemServiceMonitor)
+
+			data, err := json.Marshal(systemServiceMonitor)
+			require.NoError(t, err)
+
+			require.JSONEq(t, tc.wantJSON, string(data))
+		})
+	}
+}

--- a/monitor/monitor_system_service_test.go
+++ b/monitor/monitor_system_service_test.go
@@ -73,6 +73,32 @@ func TestMonitorSystemService_Unmarshal(t *testing.T) {
 			},
 			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":null,"id":5,"interval":120,"maxretries":3,"name":"system-service-monitor-no-parent","notificationIDList":{},"parent":null,"resendInterval":0,"retryInterval":60,"system_service_name":"Spooler","type":"system-service","upsideDown":false}`,
 		},
+		{
+			name: "success with empty service name",
+			data: []byte(
+				`{"id":6,"name":"system-service-empty","description":null,"pathName":"system-service-empty","parent":null,"childrenIDs":[],"url":null,"method":"GET","hostname":null,"port":null,"maxretries":0,"weight":2000,"active":true,"forceInactive":false,"type":"system-service","timeout":null,"interval":60,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":"A","dns_resolve_server":"1.1.1.1","dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{},"tags":[],"maintenance":false,"mqttTopic":"","mqttSuccessMessage":"","databaseQuery":null,"authMethod":null,"grpcUrl":null,"grpcProtobuf":null,"grpcMethod":null,"grpcServiceName":null,"grpcEnableTls":false,"radiusCalledStationId":null,"radiusCallingStationId":null,"game":null,"gamedigGivenPortOnly":true,"httpBodyEncoding":"json","jsonPath":null,"expectedValue":null,"kafkaProducerTopic":null,"kafkaProducerBrokers":[],"kafkaProducerSsl":false,"kafkaProducerAllowAutoTopicCreation":false,"kafkaProducerMessage":null,"screenshot":null,"headers":null,"body":null,"grpcBody":null,"grpcMetadata":null,"basic_auth_user":null,"basic_auth_pass":null,"oauth_client_id":null,"oauth_client_secret":null,"oauth_token_url":null,"oauth_scopes":null,"oauth_auth_method":"client_secret_basic","pushToken":null,"databaseConnectionString":null,"radiusUsername":null,"radiusPassword":null,"radiusSecret":null,"mqttUsername":"","mqttPassword":"","authWorkstation":null,"authDomain":null,"tlsCa":null,"tlsCert":null,"tlsKey":null,"kafkaProducerSaslOptions":{"mechanism":"None"},"system_service_name":"","includeSensitiveData":true}`,
+			),
+
+			want: monitor.SystemService{
+				Base: monitor.Base{
+					ID:             6,
+					Name:           "system-service-empty",
+					Description:    nil,
+					PathName:       "system-service-empty",
+					Parent:         nil,
+					Interval:       60,
+					RetryInterval:  60,
+					ResendInterval: 0,
+					MaxRetries:     0,
+					UpsideDown:     false,
+					IsActive:       true,
+				},
+				SystemServiceDetails: monitor.SystemServiceDetails{
+					SystemServiceName: "",
+				},
+			},
+			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":null,"id":6,"interval":60,"maxretries":0,"name":"system-service-empty","notificationIDList":{},"parent":null,"resendInterval":0,"retryInterval":60,"system_service_name":"","type":"system-service","upsideDown":false}`,
+		},
 	}
 
 	for _, tc := range tests {

--- a/monitor_test.go
+++ b/monitor_test.go
@@ -1769,6 +1769,57 @@ func TestMonitorCRUD(t *testing.T) {
 			},
 			testPauseResume: true,
 		},
+		{
+			name: "System Service",
+			create: &monitor.SystemService{
+				Base: monitor.Base{
+					Name:           "Test System Service Monitor",
+					Interval:       60,
+					RetryInterval:  60,
+					ResendInterval: 0,
+					MaxRetries:     3,
+					UpsideDown:     false,
+					IsActive:       true,
+				},
+				SystemServiceDetails: monitor.SystemServiceDetails{
+					SystemServiceName: "nginx.service",
+				},
+			},
+			updateFunc: func(m monitor.Monitor) {
+				ss, ok := m.(*monitor.SystemService)
+				if !ok {
+					panic("failed to assert SystemService monitor")
+				}
+
+				ss.Name = "Updated System Service Monitor"
+				ss.SystemServiceName = "sshd.service"
+			},
+			verifyCreatedFunc: func(t *testing.T, actual monitor.Monitor, id int64) {
+				t.Helper()
+				var ss monitor.SystemService
+				err := actual.As(&ss)
+				require.NoError(t, err)
+				require.Equal(t, id, ss.ID)
+				require.Equal(t, "Test System Service Monitor", ss.Name)
+				require.Equal(t, "nginx.service", ss.SystemServiceName)
+			},
+			createTypedFunc: func(t *testing.T, base monitor.Monitor) monitor.Monitor {
+				t.Helper()
+				var ss monitor.SystemService
+				err := base.As(&ss)
+				require.NoError(t, err)
+				return &ss
+			},
+			verifyUpdatedFunc: func(t *testing.T, actual monitor.Monitor) {
+				t.Helper()
+				var ss monitor.SystemService
+				err := actual.As(&ss)
+				require.NoError(t, err)
+				require.Equal(t, "Updated System Service Monitor", ss.Name)
+				require.Equal(t, "sshd.service", ss.SystemServiceName)
+			},
+			testPauseResume: true,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## Summary

- Add `SystemService` monitor type (`system-service`) that checks whether a systemd service (Linux) or Windows SCM service is running
- Implement `MarshalJSON`/`UnmarshalJSON` following the existing monitor type pattern; note the upstream API uses snake_case `system_service_name` for this type unlike most other Uptime Kuma fields
- Document the non-empty requirement and allowed character sets (Linux: alphanumeric + `._-@`; Windows: alphanumeric + `._-`) on `SystemServiceDetails.SystemServiceName`
- Qualify error messages in `UnmarshalJSON` and `MarshalJSON` with type context for easier debugging
- Add JSON round-trip unit tests including an empty `system_service_name` case
- Add CRUD integration test case in `monitor_test.go`

## Test plan

- [x] `task fmt` — formatting clean
- [x] `task lint` — 0 lint issues
- [x] `go test ./monitor/...` — unit tests pass
- [x] `task test-e2e` — integration test `TestMonitorCRUD/System_Service` passes

Closes #234