### PR TITLE
feat(notification): add GoogleSheets notification support

### DIFF
--- a/notification/notification_googlesheets.go
+++ b/notification/notification_googlesheets.go
@@ -1,0 +1,54 @@
+package notification
+
+import (
+	"fmt"
+)
+
+// GoogleSheets represents a Google Sheets notification provider.
+// Google Sheets logs notifications into a spreadsheet via a deployed
+// Google Apps Script web app.
+type GoogleSheets struct {
+	Base
+	GoogleSheetsDetails
+}
+
+// GoogleSheetsDetails contains the Google Sheets-specific configuration.
+type GoogleSheetsDetails struct {
+	WebhookURL string `json:"googleSheetsWebhookUrl"`
+}
+
+// Type returns the notification type identifier for Google Sheets.
+func (g GoogleSheets) Type() string {
+	return g.GoogleSheetsDetails.Type()
+}
+
+// Type returns the notification type identifier for Google Sheets details.
+func (GoogleSheetsDetails) Type() string {
+	return "GoogleSheets"
+}
+
+// String returns a human-readable representation of the Google Sheets notification.
+func (g GoogleSheets) String() string {
+	return fmt.Sprintf("%s, %s", formatNotification(g.Base, false), formatNotification(g.GoogleSheetsDetails, true))
+}
+
+// UnmarshalJSON deserializes a Google Sheets notification from JSON.
+func (g *GoogleSheets) UnmarshalJSON(data []byte) error {
+	detail := GoogleSheetsDetails{}
+	base, err := unmarshalTo(data, &detail)
+	if err != nil {
+		return err
+	}
+
+	*g = GoogleSheets{
+		Base:                base,
+		GoogleSheetsDetails: detail,
+	}
+
+	return nil
+}
+
+// MarshalJSON serializes a Google Sheets notification to JSON.
+func (g GoogleSheets) MarshalJSON() ([]byte, error) {
+	return marshalJSON(g.Base, g.GoogleSheetsDetails)
+}

--- a/notification/notification_googlesheets.go
+++ b/notification/notification_googlesheets.go
@@ -14,6 +14,9 @@ type GoogleSheets struct {
 
 // GoogleSheetsDetails contains the Google Sheets-specific configuration.
 type GoogleSheetsDetails struct {
+	// Note: the upstream API uses lowercase "Url" (not "URL") in the JSON key,
+	// unlike the sibling GoogleChat type. Do not "fix" this to maintain wire
+	// compatibility with the Uptime Kuma server.
 	WebhookURL string `json:"googleSheetsWebhookUrl"`
 }
 

--- a/notification/notification_googlesheets_test.go
+++ b/notification/notification_googlesheets_test.go
@@ -16,6 +16,7 @@ func TestNotificationGoogleSheets_Unmarshal(t *testing.T) {
 
 		want     notification.GoogleSheets
 		wantJSON string
+		wantErr  bool
 	}{
 		{
 			name: "success",
@@ -59,6 +60,16 @@ func TestNotificationGoogleSheets_Unmarshal(t *testing.T) {
 			},
 			wantJSON: `{"active":true,"applyExisting":false,"googleSheetsWebhookUrl":"https://script.google.com/macros/s/BBBB/exec","id":2,"isDefault":false,"name":"Simple Google Sheets","type":"GoogleSheets","userId":1}`,
 		},
+		{
+			name:    "missing config field",
+			data:    []byte(`{"id":1,"name":"x","active":true,"userId":1,"isDefault":false}`),
+			wantErr: true,
+		},
+		{
+			name:    "invalid config json",
+			data:    []byte(`{"id":1,"name":"x","active":true,"userId":1,"isDefault":false,"config":"not-json"}`),
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -66,6 +77,12 @@ func TestNotificationGoogleSheets_Unmarshal(t *testing.T) {
 			googleSheets := notification.GoogleSheets{}
 
 			err := json.Unmarshal(tc.data, &googleSheets)
+			if tc.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
 			require.NoError(t, err)
 
 			require.EqualExportedValues(t, tc.want, googleSheets)

--- a/notification/notification_googlesheets_test.go
+++ b/notification/notification_googlesheets_test.go
@@ -1,0 +1,79 @@
+package notification_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/breml/go-uptime-kuma-client/notification"
+)
+
+func TestNotificationGoogleSheets_Unmarshal(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+
+		want     notification.GoogleSheets
+		wantJSON string
+	}{
+		{
+			name: "success",
+			data: []byte(
+				`{"id":1,"name":"My Google Sheets Alert","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"My Google Sheets Alert\",\"googleSheetsWebhookUrl\":\"https://script.google.com/macros/s/AAAA/exec\",\"type\":\"GoogleSheets\"}"}`,
+			),
+
+			want: notification.GoogleSheets{
+				Base: notification.Base{
+					ID:            1,
+					Name:          "My Google Sheets Alert",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     true,
+					ApplyExisting: true,
+				},
+				GoogleSheetsDetails: notification.GoogleSheetsDetails{
+					WebhookURL: "https://script.google.com/macros/s/AAAA/exec",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":true,"googleSheetsWebhookUrl":"https://script.google.com/macros/s/AAAA/exec","id":1,"isDefault":true,"name":"My Google Sheets Alert","type":"GoogleSheets","userId":1}`,
+		},
+		{
+			name: "minimal",
+			data: []byte(
+				`{"id":2,"name":"Simple Google Sheets","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Simple Google Sheets\",\"googleSheetsWebhookUrl\":\"https://script.google.com/macros/s/BBBB/exec\",\"type\":\"GoogleSheets\"}"}`,
+			),
+
+			want: notification.GoogleSheets{
+				Base: notification.Base{
+					ID:            2,
+					Name:          "Simple Google Sheets",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				GoogleSheetsDetails: notification.GoogleSheetsDetails{
+					WebhookURL: "https://script.google.com/macros/s/BBBB/exec",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"googleSheetsWebhookUrl":"https://script.google.com/macros/s/BBBB/exec","id":2,"isDefault":false,"name":"Simple Google Sheets","type":"GoogleSheets","userId":1}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			googleSheets := notification.GoogleSheets{}
+
+			err := json.Unmarshal(tc.data, &googleSheets)
+			require.NoError(t, err)
+
+			require.EqualExportedValues(t, tc.want, googleSheets)
+
+			data, err := json.Marshal(googleSheets)
+			require.NoError(t, err)
+
+			require.JSONEq(t, tc.wantJSON, string(data))
+		})
+	}
+}

--- a/notification_test.go
+++ b/notification_test.go
@@ -1575,6 +1575,57 @@ func TestNotificationCRUD(t *testing.T) {
 			},
 		},
 		{
+			name:         "GoogleSheets",
+			expectedType: "GoogleSheets",
+			create: notification.GoogleSheets{
+				Base: notification.Base{
+					ApplyExisting: true,
+					IsDefault:     false,
+					IsActive:      true,
+					Name:          "Test Google Sheets Created",
+				},
+				GoogleSheetsDetails: notification.GoogleSheetsDetails{
+					WebhookURL: "https://script.google.com/macros/s/AAAA/exec",
+				},
+			},
+			updateFunc: func(n notification.Notification) {
+				googlesheets, ok := n.(*notification.GoogleSheets)
+				if !ok {
+					panic("failed to assert GoogleSheets notification")
+				}
+
+				googlesheets.Name = "Test Google Sheets Updated"
+				googlesheets.WebhookURL = "https://script.google.com/macros/s/BBBB/exec"
+			},
+			verifyCreatedFunc: func(t *testing.T, actual notification.Notification, expected notification.Notification, id int64) {
+				t.Helper()
+				exp, ok := expected.(notification.GoogleSheets)
+				require.True(t, ok)
+				var googlesheets notification.GoogleSheets
+				err := actual.As(&googlesheets)
+				require.NoError(t, err)
+				exp.ID = id
+				exp.UserID = googlesheets.UserID
+				require.EqualExportedValues(t, exp, googlesheets)
+			},
+			createTypedFunc: func(t *testing.T, base notification.Notification) notification.Notification {
+				t.Helper()
+				var googlesheets notification.GoogleSheets
+				err := base.As(&googlesheets)
+				require.NoError(t, err)
+				return &googlesheets
+			},
+			verifyUpdatedFunc: func(t *testing.T, actual notification.Notification, expected notification.Notification) {
+				t.Helper()
+				exp, ok := expected.(*notification.GoogleSheets)
+				require.True(t, ok)
+				var googlesheets notification.GoogleSheets
+				err := actual.As(&googlesheets)
+				require.NoError(t, err)
+				require.EqualExportedValues(t, *exp, googlesheets)
+			},
+		},
+		{
 			name:         "Bark",
 			expectedType: "bark",
 			create: notification.Bark{


### PR DESCRIPTION
## Summary

Add support for the `GoogleSheets` notification provider, which logs incidents into a Google Sheet via a deployed Google Apps Script web app.

The provider is introduced upstream in Uptime Kuma via PR [louislam/uptime-kuma#6777](https://github.com/louislam/uptime-kuma/pull/6777) and is available since Uptime Kuma v2.1.0.

## Changes

- New `GoogleSheets` notification type with the required `googleSheetsWebhookUrl` field, mirroring the single-webhook pattern of `Pumble`.
- Marshal/unmarshal unit tests in [notification/notification_googlesheets_test.go](notification/notification_googlesheets_test.go).
- Integration (CRUD) test entry added to [notification_test.go](notification_test.go).

## Verification

- `task fmt`
- `task lint`
- `task test-e2e` (including the new `TestNotificationCRUD/GoogleSheets` cases for initial state, create, update, delete)

Closes #239