### PR TITLE
feat(notification): add HaloPSA notification support

### DIFF
--- a/notification/notification_halopsa.go
+++ b/notification/notification_halopsa.go
@@ -1,0 +1,54 @@
+package notification
+
+import (
+	"fmt"
+)
+
+// HaloPSA represents a HaloPSA notification.
+type HaloPSA struct {
+	Base
+	HaloPSADetails
+}
+
+// HaloPSADetails contains HaloPSA-specific notification configuration.
+type HaloPSADetails struct {
+	WebhookURL string `json:"halowebhookurl"`
+	Username   string `json:"haloUsername"`
+	Password   string `json:"haloPassword"`
+}
+
+// Type returns the notification type.
+func (h HaloPSA) Type() string {
+	return h.HaloPSADetails.Type()
+}
+
+// Type returns the notification type.
+func (HaloPSADetails) Type() string {
+	return "HaloPSA"
+}
+
+// String returns a string representation of the notification.
+func (h HaloPSA) String() string {
+	return fmt.Sprintf("%s, %s", formatNotification(h.Base, false), formatNotification(h.HaloPSADetails, true))
+}
+
+// UnmarshalJSON unmarshals a JSON byte slice into a notification.
+func (h *HaloPSA) UnmarshalJSON(data []byte) error {
+	detail := HaloPSADetails{}
+	base, err := unmarshalTo(data, &detail)
+	if err != nil {
+		return err
+	}
+
+	*h = HaloPSA{
+		Base:           base,
+		HaloPSADetails: detail,
+	}
+
+	return nil
+}
+
+// MarshalJSON marshals a notification into a JSON byte slice.
+func (h HaloPSA) MarshalJSON() ([]byte, error) {
+	return marshalJSON(h.Base, &h.HaloPSADetails)
+}

--- a/notification/notification_halopsa_test.go
+++ b/notification/notification_halopsa_test.go
@@ -1,0 +1,81 @@
+package notification_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/breml/go-uptime-kuma-client/notification"
+)
+
+func TestNotificationHaloPSA_Unmarshal(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+
+		want     notification.HaloPSA
+		wantJSON string
+	}{
+		{
+			name: "success",
+			data: []byte(
+				`{"id":1,"name":"My HaloPSA Alert","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"My HaloPSA Alert\",\"halowebhookurl\":\"https://example.halopsa.com/api/v1/webhook\",\"haloUsername\":\"admin\",\"haloPassword\":\"secret\",\"type\":\"HaloPSA\"}"}`,
+			),
+
+			want: notification.HaloPSA{
+				Base: notification.Base{
+					ID:            1,
+					Name:          "My HaloPSA Alert",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     true,
+					ApplyExisting: true,
+				},
+				HaloPSADetails: notification.HaloPSADetails{
+					WebhookURL: "https://example.halopsa.com/api/v1/webhook",
+					Username:   "admin",
+					Password:   "secret",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":true,"haloPassword":"secret","haloUsername":"admin","halowebhookurl":"https://example.halopsa.com/api/v1/webhook","id":1,"isDefault":true,"name":"My HaloPSA Alert","type":"HaloPSA","userId":1}`,
+		},
+		{
+			name: "minimal",
+			data: []byte(
+				`{"id":2,"name":"Simple HaloPSA","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Simple HaloPSA\",\"halowebhookurl\":\"https://halopsa.example.com/webhook\",\"haloUsername\":\"\",\"haloPassword\":\"\",\"type\":\"HaloPSA\"}"}`,
+			),
+
+			want: notification.HaloPSA{
+				Base: notification.Base{
+					ID:            2,
+					Name:          "Simple HaloPSA",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				HaloPSADetails: notification.HaloPSADetails{
+					WebhookURL: "https://halopsa.example.com/webhook",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"haloPassword":"","haloUsername":"","halowebhookurl":"https://halopsa.example.com/webhook","id":2,"isDefault":false,"name":"Simple HaloPSA","type":"HaloPSA","userId":1}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			halopsa := notification.HaloPSA{}
+
+			err := json.Unmarshal(tc.data, &halopsa)
+			require.NoError(t, err)
+
+			require.EqualExportedValues(t, tc.want, halopsa)
+
+			data, err := json.Marshal(halopsa)
+			require.NoError(t, err)
+
+			require.JSONEq(t, tc.wantJSON, string(data))
+		})
+	}
+}

--- a/notification_test.go
+++ b/notification_test.go
@@ -1363,6 +1363,61 @@ func TestNotificationCRUD(t *testing.T) {
 			},
 		},
 		{
+			name:         "HaloPSA",
+			expectedType: "HaloPSA",
+			create: notification.HaloPSA{
+				Base: notification.Base{
+					ApplyExisting: true,
+					IsDefault:     false,
+					IsActive:      true,
+					Name:          "Test HaloPSA Created",
+				},
+				HaloPSADetails: notification.HaloPSADetails{
+					WebhookURL: "https://example.halopsa.com/api/v1/webhook",
+					Username:   "admin",
+					Password:   "secret",
+				},
+			},
+			updateFunc: func(n notification.Notification) {
+				halopsa, ok := n.(*notification.HaloPSA)
+				if !ok {
+					panic("failed to assert HaloPSA notification")
+				}
+
+				halopsa.Name = "Test HaloPSA Updated"
+				halopsa.WebhookURL = "https://example.halopsa.com/api/v1/webhook/updated"
+				halopsa.Username = "updated-user"
+				halopsa.Password = "updated-secret"
+			},
+			verifyCreatedFunc: func(t *testing.T, actual notification.Notification, expected notification.Notification, id int64) {
+				t.Helper()
+				exp, ok := expected.(notification.HaloPSA)
+				require.True(t, ok)
+				var halopsa notification.HaloPSA
+				err := actual.As(&halopsa)
+				require.NoError(t, err)
+				exp.ID = id
+				exp.UserID = halopsa.UserID
+				require.EqualExportedValues(t, exp, halopsa)
+			},
+			createTypedFunc: func(t *testing.T, base notification.Notification) notification.Notification {
+				t.Helper()
+				var halopsa notification.HaloPSA
+				err := base.As(&halopsa)
+				require.NoError(t, err)
+				return &halopsa
+			},
+			verifyUpdatedFunc: func(t *testing.T, actual notification.Notification, expected notification.Notification) {
+				t.Helper()
+				exp, ok := expected.(*notification.HaloPSA)
+				require.True(t, ok)
+				var halopsa notification.HaloPSA
+				err := actual.As(&halopsa)
+				require.NoError(t, err)
+				require.EqualExportedValues(t, *exp, halopsa)
+			},
+		},
+		{
 			name:         "AlertNow",
 			expectedType: "AlertNow",
 			create: notification.AlertNow{


### PR DESCRIPTION
## Summary

Add support for the `HaloPSA` notification provider introduced upstream in Uptime Kuma v2.x (louislam/uptime-kuma#6560, with `monitor_id` support added in louislam/uptime-kuma#6849).

HaloPSA is an IT service-management / PSA platform. Notifications are delivered via a webhook URL with optional HTTP Basic Auth credentials.

## Changes

- New `notification.HaloPSA` type with `HaloPSADetails` (webhook URL, username, password)
- JSON tags match the upstream payload keys exactly: `halowebhookurl`, `haloUsername`, `haloPassword` (not normalized, per upstream)
- Type discriminator preserves upstream casing: `HaloPSA`
- Marshal/Unmarshal round-trip tests in `notification/notification_halopsa_test.go`
- CRUD integration test case added to `TestNotificationCRUD`

## Verification

- `task fmt` ✔
- `task lint` ✔
- `task test-e2e` ✔ (all tests pass, including new `TestNotificationCRUD/HaloPSA` and `TestNotificationHaloPSA_Unmarshal`)

Closes #240