### PR TITLE
feat(notification): add support for Resend notifications

### DIFF
--- a/notification/notification_resend.go
+++ b/notification/notification_resend.go
@@ -1,0 +1,62 @@
+package notification
+
+import (
+	"fmt"
+)
+
+// Resend represents a Resend notification provider.
+// Resend is a transactional email API for sending notifications via email.
+type Resend struct {
+	Base
+	ResendDetails
+}
+
+// ResendDetails contains the configuration fields for Resend notifications.
+type ResendDetails struct {
+	// APIKey is the Resend API key for authentication.
+	APIKey string `json:"resendApiKey"`
+	// FromEmail is the sender email address.
+	FromEmail string `json:"resendFromEmail"`
+	// FromName is the sender name.
+	FromName string `json:"resendFromName"`
+	// ToEmail is a comma-separated list of recipient email addresses.
+	ToEmail string `json:"resendToEmail"`
+	// Subject is the email subject line.
+	Subject string `json:"resendSubject"`
+}
+
+// Type returns the notification type identifier for Resend.
+func (r Resend) Type() string {
+	return r.ResendDetails.Type()
+}
+
+// Type returns the notification type identifier for ResendDetails.
+func (ResendDetails) Type() string {
+	return "Resend"
+}
+
+// String returns a string representation of the Resend notification.
+func (r Resend) String() string {
+	return fmt.Sprintf("%s, %s", formatNotification(r.Base, false), formatNotification(r.ResendDetails, true))
+}
+
+// UnmarshalJSON unmarshals JSON data into a Resend notification.
+func (r *Resend) UnmarshalJSON(data []byte) error {
+	detail := ResendDetails{}
+	base, err := unmarshalTo(data, &detail)
+	if err != nil {
+		return err
+	}
+
+	*r = Resend{
+		Base:          base,
+		ResendDetails: detail,
+	}
+
+	return nil
+}
+
+// MarshalJSON marshals the Resend notification into JSON.
+func (r Resend) MarshalJSON() ([]byte, error) {
+	return marshalJSON(r.Base, r.ResendDetails)
+}

--- a/notification/notification_resend.go
+++ b/notification/notification_resend.go
@@ -4,43 +4,38 @@ import (
 	"fmt"
 )
 
-// Resend represents a Resend notification provider.
-// Resend is a transactional email API for sending notifications via email.
+// Resend represents a Resend notification.
 type Resend struct {
 	Base
 	ResendDetails
 }
 
-// ResendDetails contains the configuration fields for Resend notifications.
+// ResendDetails contains Resend-specific notification configuration.
 type ResendDetails struct {
-	// APIKey is the Resend API key for authentication.
-	APIKey string `json:"resendApiKey"`
-	// FromEmail is the sender email address.
+	APIKey    string `json:"resendApiKey"`
 	FromEmail string `json:"resendFromEmail"`
-	// FromName is the sender name.
-	FromName string `json:"resendFromName"`
+	FromName  string `json:"resendFromName,omitempty"`
 	// ToEmail is a comma-separated list of recipient email addresses.
 	ToEmail string `json:"resendToEmail"`
-	// Subject is the email subject line.
-	Subject string `json:"resendSubject"`
+	Subject string `json:"resendSubject,omitempty"`
 }
 
-// Type returns the notification type identifier for Resend.
+// Type returns the notification type.
 func (r Resend) Type() string {
 	return r.ResendDetails.Type()
 }
 
-// Type returns the notification type identifier for ResendDetails.
+// Type returns the notification type.
 func (ResendDetails) Type() string {
 	return "Resend"
 }
 
-// String returns a string representation of the Resend notification.
+// String returns a string representation of the notification.
 func (r Resend) String() string {
 	return fmt.Sprintf("%s, %s", formatNotification(r.Base, false), formatNotification(r.ResendDetails, true))
 }
 
-// UnmarshalJSON unmarshals JSON data into a Resend notification.
+// UnmarshalJSON unmarshals a JSON byte slice into a notification.
 func (r *Resend) UnmarshalJSON(data []byte) error {
 	detail := ResendDetails{}
 	base, err := unmarshalTo(data, &detail)
@@ -56,7 +51,7 @@ func (r *Resend) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// MarshalJSON marshals the Resend notification into JSON.
+// MarshalJSON marshals a notification into a JSON byte slice.
 func (r Resend) MarshalJSON() ([]byte, error) {
-	return marshalJSON(r.Base, r.ResendDetails)
+	return marshalJSON(r.Base, &r.ResendDetails)
 }

--- a/notification/notification_resend_test.go
+++ b/notification/notification_resend_test.go
@@ -1,0 +1,110 @@
+package notification_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/breml/go-uptime-kuma-client/notification"
+)
+
+func TestNotificationResend_Unmarshal(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+
+		want     notification.Resend
+		wantJSON string
+	}{
+		{
+			name: "success with all fields",
+			data: []byte(
+				`{"id":1,"name":"My Resend Alert","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"My Resend Alert\",\"resendApiKey\":\"re_xxxxxxxxxxxxxxxx\",\"resendFromEmail\":\"noreply@example.com\",\"resendFromName\":\"Uptime Kuma\",\"resendToEmail\":\"alerts@example.com\",\"resendSubject\":\"Uptime Alert\",\"type\":\"Resend\"}"}`,
+			),
+
+			want: notification.Resend{
+				Base: notification.Base{
+					ID:            1,
+					Name:          "My Resend Alert",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     true,
+					ApplyExisting: true,
+				},
+				ResendDetails: notification.ResendDetails{
+					APIKey:    "re_xxxxxxxxxxxxxxxx",
+					FromEmail: "noreply@example.com",
+					FromName:  "Uptime Kuma",
+					ToEmail:   "alerts@example.com",
+					Subject:   "Uptime Alert",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":true,"id":1,"isDefault":true,"name":"My Resend Alert","resendApiKey":"re_xxxxxxxxxxxxxxxx","resendFromEmail":"noreply@example.com","resendFromName":"Uptime Kuma","resendSubject":"Uptime Alert","resendToEmail":"alerts@example.com","type":"Resend","userId":1}`,
+		},
+		{
+			name: "minimal configuration",
+			data: []byte(
+				`{"id":2,"name":"Simple Resend","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Simple Resend\",\"resendApiKey\":\"re_yyyyyyyyyyyyyyyy\",\"resendFromEmail\":\"sender@example.com\",\"resendToEmail\":\"user@example.com\",\"type\":\"Resend\"}"}`,
+			),
+
+			want: notification.Resend{
+				Base: notification.Base{
+					ID:            2,
+					Name:          "Simple Resend",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				ResendDetails: notification.ResendDetails{
+					APIKey:    "re_yyyyyyyyyyyyyyyy",
+					FromEmail: "sender@example.com",
+					ToEmail:   "user@example.com",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"id":2,"isDefault":false,"name":"Simple Resend","resendApiKey":"re_yyyyyyyyyyyyyyyy","resendFromEmail":"sender@example.com","resendFromName":"","resendSubject":"","resendToEmail":"user@example.com","type":"Resend","userId":1}`,
+		},
+		{
+			name: "with multiple recipients",
+			data: []byte(
+				`{"id":3,"name":"Resend Multi To","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Resend Multi To\",\"resendApiKey\":\"re_zzzzzzzzzzzzzzzz\",\"resendFromEmail\":\"sender@example.com\",\"resendFromName\":\"Alert System\",\"resendToEmail\":\"to1@example.com, to2@example.com\",\"resendSubject\":\"System Alert\",\"type\":\"Resend\"}"}`,
+			),
+
+			want: notification.Resend{
+				Base: notification.Base{
+					ID:            3,
+					Name:          "Resend Multi To",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				ResendDetails: notification.ResendDetails{
+					APIKey:    "re_zzzzzzzzzzzzzzzz",
+					FromEmail: "sender@example.com",
+					FromName:  "Alert System",
+					ToEmail:   "to1@example.com, to2@example.com",
+					Subject:   "System Alert",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"id":3,"isDefault":false,"name":"Resend Multi To","resendApiKey":"re_zzzzzzzzzzzzzzzz","resendFromEmail":"sender@example.com","resendFromName":"Alert System","resendSubject":"System Alert","resendToEmail":"to1@example.com, to2@example.com","type":"Resend","userId":1}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resend := notification.Resend{}
+
+			err := json.Unmarshal(tc.data, &resend)
+			require.NoError(t, err)
+
+			require.EqualExportedValues(t, tc.want, resend)
+
+			data, err := json.Marshal(resend)
+			require.NoError(t, err)
+
+			require.JSONEq(t, tc.wantJSON, string(data))
+		})
+	}
+}

--- a/notification/notification_resend_test.go
+++ b/notification/notification_resend_test.go
@@ -16,6 +16,7 @@ func TestNotificationResend_Unmarshal(t *testing.T) {
 
 		want     notification.Resend
 		wantJSON string
+		wantErr  bool
 	}{
 		{
 			name: "success with all fields",
@@ -63,7 +64,7 @@ func TestNotificationResend_Unmarshal(t *testing.T) {
 					ToEmail:   "user@example.com",
 				},
 			},
-			wantJSON: `{"active":true,"applyExisting":false,"id":2,"isDefault":false,"name":"Simple Resend","resendApiKey":"re_yyyyyyyyyyyyyyyy","resendFromEmail":"sender@example.com","resendFromName":"","resendSubject":"","resendToEmail":"user@example.com","type":"Resend","userId":1}`,
+			wantJSON: `{"active":true,"applyExisting":false,"id":2,"isDefault":false,"name":"Simple Resend","resendApiKey":"re_yyyyyyyyyyyyyyyy","resendFromEmail":"sender@example.com","resendToEmail":"user@example.com","type":"Resend","userId":1}`,
 		},
 		{
 			name: "with multiple recipients",
@@ -90,6 +91,16 @@ func TestNotificationResend_Unmarshal(t *testing.T) {
 			},
 			wantJSON: `{"active":true,"applyExisting":false,"id":3,"isDefault":false,"name":"Resend Multi To","resendApiKey":"re_zzzzzzzzzzzzzzzz","resendFromEmail":"sender@example.com","resendFromName":"Alert System","resendSubject":"System Alert","resendToEmail":"to1@example.com, to2@example.com","type":"Resend","userId":1}`,
 		},
+		{
+			name:    "missing config field",
+			data:    []byte(`{"id":1,"name":"x","active":true,"userId":1,"isDefault":false}`),
+			wantErr: true,
+		},
+		{
+			name:    "invalid config json",
+			data:    []byte(`{"id":1,"name":"x","active":true,"userId":1,"isDefault":false,"config":"not-json"}`),
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -97,6 +108,12 @@ func TestNotificationResend_Unmarshal(t *testing.T) {
 			resend := notification.Resend{}
 
 			err := json.Unmarshal(tc.data, &resend)
+			if tc.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
 			require.NoError(t, err)
 
 			require.EqualExportedValues(t, tc.want, resend)
@@ -107,4 +124,9 @@ func TestNotificationResend_Unmarshal(t *testing.T) {
 			require.JSONEq(t, tc.wantJSON, string(data))
 		})
 	}
+}
+
+func TestNotificationResend_Type(t *testing.T) {
+	require.Equal(t, "Resend", notification.Resend{}.Type())
+	require.Equal(t, "Resend", notification.ResendDetails{}.Type())
 }

--- a/notification_test.go
+++ b/notification_test.go
@@ -3309,6 +3309,64 @@ func TestNotificationCRUD(t *testing.T) {
 			},
 		},
 		{
+			name:         "Resend",
+			expectedType: "Resend",
+			create: notification.Resend{
+				Base: notification.Base{
+					ApplyExisting: true,
+					IsDefault:     false,
+					IsActive:      true,
+					Name:          "Test Resend Created",
+				},
+				ResendDetails: notification.ResendDetails{
+					APIKey:    "re_test_api_key_xxxxx",
+					FromEmail: "sender@example.com",
+					FromName:  "Uptime Kuma",
+					ToEmail:   "alerts@example.com",
+					Subject:   "Test Subject",
+				},
+			},
+			updateFunc: func(n notification.Notification) {
+				resend, ok := n.(*notification.Resend)
+				if !ok {
+					panic("failed to assert Resend notification")
+				}
+
+				resend.Name = "Test Resend Updated"
+				resend.APIKey = "re_updated_api_key_yyyyy"
+				resend.ToEmail = "updated@example.com, second@example.com"
+				resend.FromName = "Updated System"
+				resend.Subject = "Updated Subject"
+			},
+			verifyCreatedFunc: func(t *testing.T, actual notification.Notification, expected notification.Notification, id int64) {
+				t.Helper()
+				exp, ok := expected.(notification.Resend)
+				require.True(t, ok)
+				var resend notification.Resend
+				err := actual.As(&resend)
+				require.NoError(t, err)
+				exp.ID = id
+				exp.UserID = resend.UserID
+				require.EqualExportedValues(t, exp, resend)
+			},
+			createTypedFunc: func(t *testing.T, base notification.Notification) notification.Notification {
+				t.Helper()
+				var resend notification.Resend
+				err := base.As(&resend)
+				require.NoError(t, err)
+				return &resend
+			},
+			verifyUpdatedFunc: func(t *testing.T, actual notification.Notification, expected notification.Notification) {
+				t.Helper()
+				exp, ok := expected.(*notification.Resend)
+				require.True(t, ok)
+				var resend notification.Resend
+				err := actual.As(&resend)
+				require.NoError(t, err)
+				require.EqualExportedValues(t, *exp, resend)
+			},
+		},
+		{
 			name:         "SendGrid",
 			expectedType: "SendGrid",
 			create: notification.SendGrid{


### PR DESCRIPTION
Add the `Resend` notification provider — a transactional email API.

## Changes

- Add `notification.Resend` struct with the required fields (`resendApiKey`,
  `resendFromEmail`, `resendFromName`, `resendToEmail`, `resendSubject`),
  modeled after the existing `Brevo` / `SendGrid` providers.
- Implement `Type()`, `String()`, `MarshalJSON` / `UnmarshalJSON` mirroring the
  shared notification pattern.
- Add unit tests for marshal/unmarshal round-trip in
  `notification/notification_resend_test.go` (all fields, minimal config,
  multiple recipients).
- Add an end-to-end CRUD test case (`TestNotificationCRUD/Resend`) covering
  create, read, update, delete and typed conversion via `As()`.

## Validation

- `task fmt` — clean
- `task lint` — 0 issues
- `task test-e2e` — all packages pass

Closes #243