### PR TITLE
feat(notification): add SMS.ir notification support

### DIFF
--- a/notification/notification_smsir.go
+++ b/notification/notification_smsir.go
@@ -1,0 +1,58 @@
+package notification
+
+import (
+	"fmt"
+)
+
+// SMSIR represents an SMS.ir notification provider.
+// SMS.ir is an Iranian SMS gateway for sending text message notifications.
+type SMSIR struct {
+	Base
+	SMSIRDetails
+}
+
+// SMSIRDetails contains the configuration fields for SMS.ir notifications.
+type SMSIRDetails struct {
+	// APIKey is the SMS.ir API key for authentication.
+	APIKey string `json:"smsirApiKey"`
+	// Number is the comma separated list of recipient phone numbers.
+	Number string `json:"smsirNumber"`
+	// Template is the pre-approved template ID used for sending the message.
+	Template string `json:"smsirTemplate"`
+}
+
+// Type returns the notification type identifier for SMSIR.
+func (s SMSIR) Type() string {
+	return s.SMSIRDetails.Type()
+}
+
+// Type returns the notification type identifier for SMSIRDetails.
+func (SMSIRDetails) Type() string {
+	return "smsir"
+}
+
+// String returns a string representation of the SMSIR notification.
+func (s SMSIR) String() string {
+	return fmt.Sprintf("%s, %s", formatNotification(s.Base, false), formatNotification(s.SMSIRDetails, true))
+}
+
+// UnmarshalJSON unmarshals JSON data into an SMSIR notification.
+func (s *SMSIR) UnmarshalJSON(data []byte) error {
+	detail := SMSIRDetails{}
+	base, err := unmarshalTo(data, &detail)
+	if err != nil {
+		return err
+	}
+
+	*s = SMSIR{
+		Base:         base,
+		SMSIRDetails: detail,
+	}
+
+	return nil
+}
+
+// MarshalJSON marshals the SMSIR notification into JSON.
+func (s SMSIR) MarshalJSON() ([]byte, error) {
+	return marshalJSON(s.Base, s.SMSIRDetails)
+}

--- a/notification/notification_smsir_test.go
+++ b/notification/notification_smsir_test.go
@@ -15,6 +15,7 @@ func TestNotificationSMSIR_Unmarshal(t *testing.T) {
 		data     []byte
 		want     notification.SMSIR
 		wantJSON string
+		wantErr  bool
 	}{
 		{
 			name: "success with all fields",
@@ -85,6 +86,16 @@ func TestNotificationSMSIR_Unmarshal(t *testing.T) {
 			},
 			wantJSON: `{"active":false,"applyExisting":false,"id":3,"isDefault":false,"name":"SMSIR Multi","smsirApiKey":"api-key-multi","smsirNumber":"9123456789,09987654321","smsirTemplate":"99999","type":"smsir","userId":1}`,
 		},
+		{
+			name:    "missing config field",
+			data:    []byte(`{"id":1,"name":"x","active":true,"userId":1,"isDefault":false}`),
+			wantErr: true,
+		},
+		{
+			name:    "invalid config json",
+			data:    []byte(`{"id":1,"name":"x","active":true,"userId":1,"isDefault":false,"config":"not-json"}`),
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -92,6 +103,12 @@ func TestNotificationSMSIR_Unmarshal(t *testing.T) {
 			smsir := notification.SMSIR{}
 
 			err := json.Unmarshal(tc.data, &smsir)
+			if tc.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
 			require.NoError(t, err)
 
 			require.EqualExportedValues(t, tc.want, smsir)

--- a/notification/notification_smsir_test.go
+++ b/notification/notification_smsir_test.go
@@ -1,0 +1,105 @@
+package notification_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/breml/go-uptime-kuma-client/notification"
+)
+
+func TestNotificationSMSIR_Unmarshal(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     []byte
+		want     notification.SMSIR
+		wantJSON string
+	}{
+		{
+			name: "success with all fields",
+			data: []byte(
+				`{"id":1,"name":"My SMSIR Alert","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"My SMSIR Alert\",\"smsirApiKey\":\"test-api-key\",\"smsirNumber\":\"9123456789\",\"smsirTemplate\":\"12345\",\"type\":\"smsir\"}"}`,
+			),
+
+			want: notification.SMSIR{
+				Base: notification.Base{
+					ID:            1,
+					Name:          "My SMSIR Alert",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     true,
+					ApplyExisting: true,
+				},
+				SMSIRDetails: notification.SMSIRDetails{
+					APIKey:   "test-api-key",
+					Number:   "9123456789",
+					Template: "12345",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":true,"id":1,"isDefault":true,"name":"My SMSIR Alert","smsirApiKey":"test-api-key","smsirNumber":"9123456789","smsirTemplate":"12345","type":"smsir","userId":1}`,
+		},
+		{
+			name: "minimal configuration",
+			data: []byte(
+				`{"id":2,"name":"Simple SMSIR","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Simple SMSIR\",\"smsirApiKey\":\"minimal-key\",\"smsirNumber\":\"09123456789\",\"smsirTemplate\":\"54321\",\"type\":\"smsir\"}"}`,
+			),
+
+			want: notification.SMSIR{
+				Base: notification.Base{
+					ID:            2,
+					Name:          "Simple SMSIR",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				SMSIRDetails: notification.SMSIRDetails{
+					APIKey:   "minimal-key",
+					Number:   "09123456789",
+					Template: "54321",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"id":2,"isDefault":false,"name":"Simple SMSIR","smsirApiKey":"minimal-key","smsirNumber":"09123456789","smsirTemplate":"54321","type":"smsir","userId":1}`,
+		},
+		{
+			name: "multiple recipients",
+			data: []byte(
+				`{"id":3,"name":"SMSIR Multi","active":false,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"SMSIR Multi\",\"smsirApiKey\":\"api-key-multi\",\"smsirNumber\":\"9123456789,09987654321\",\"smsirTemplate\":\"99999\",\"type\":\"smsir\"}"}`,
+			),
+
+			want: notification.SMSIR{
+				Base: notification.Base{
+					ID:            3,
+					Name:          "SMSIR Multi",
+					IsActive:      false,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				SMSIRDetails: notification.SMSIRDetails{
+					APIKey:   "api-key-multi",
+					Number:   "9123456789,09987654321",
+					Template: "99999",
+				},
+			},
+			wantJSON: `{"active":false,"applyExisting":false,"id":3,"isDefault":false,"name":"SMSIR Multi","smsirApiKey":"api-key-multi","smsirNumber":"9123456789,09987654321","smsirTemplate":"99999","type":"smsir","userId":1}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			smsir := notification.SMSIR{}
+
+			err := json.Unmarshal(tc.data, &smsir)
+			require.NoError(t, err)
+
+			require.EqualExportedValues(t, tc.want, smsir)
+
+			data, err := json.Marshal(smsir)
+			require.NoError(t, err)
+
+			require.JSONEq(t, tc.wantJSON, string(data))
+		})
+	}
+}

--- a/notification_test.go
+++ b/notification_test.go
@@ -3693,6 +3693,60 @@ func TestNotificationCRUD(t *testing.T) {
 			},
 		},
 		{
+			name:         "SMSIR",
+			expectedType: "smsir",
+			create: notification.SMSIR{
+				Base: notification.Base{
+					ApplyExisting: true,
+					IsDefault:     false,
+					IsActive:      true,
+					Name:          "Test SMSIR Created",
+				},
+				SMSIRDetails: notification.SMSIRDetails{
+					APIKey:   "test-api-key",
+					Number:   "9123456789",
+					Template: "12345",
+				},
+			},
+			updateFunc: func(n notification.Notification) {
+				smsir, ok := n.(*notification.SMSIR)
+				if !ok {
+					panic("failed to assert SMSIR notification")
+				}
+
+				smsir.Name = "Test SMSIR Updated"
+				smsir.Number = "9123456789,09987654321"
+				smsir.Template = "54321"
+			},
+			verifyCreatedFunc: func(t *testing.T, actual notification.Notification, expected notification.Notification, id int64) {
+				t.Helper()
+				exp, ok := expected.(notification.SMSIR)
+				require.True(t, ok)
+				var smsir notification.SMSIR
+				err := actual.As(&smsir)
+				require.NoError(t, err)
+				exp.ID = id
+				exp.UserID = smsir.UserID
+				require.EqualExportedValues(t, exp, smsir)
+			},
+			createTypedFunc: func(t *testing.T, base notification.Notification) notification.Notification {
+				t.Helper()
+				var smsir notification.SMSIR
+				err := base.As(&smsir)
+				require.NoError(t, err)
+				return &smsir
+			},
+			verifyUpdatedFunc: func(t *testing.T, actual notification.Notification, expected notification.Notification) {
+				t.Helper()
+				exp, ok := expected.(*notification.SMSIR)
+				require.True(t, ok)
+				var smsir notification.SMSIR
+				err := actual.As(&smsir)
+				require.NoError(t, err)
+				require.EqualExportedValues(t, *exp, smsir)
+			},
+		},
+		{
 			name:         "SMSManager",
 			expectedType: "SMSManager",
 			create: notification.SMSManager{


### PR DESCRIPTION
Adds support for the `smsir` notification provider in the Go Uptime Kuma
client. SMS.ir is an Iranian SMS gateway used by Uptime Kuma to send
notifications based on a pre-approved SMS template.

## Changes

- New `notification.SMSIR` / `notification.SMSIRDetails` types in
  `notification/notification_smsir.go`, mirroring the existing
  `SMSPartner` implementation.
- `Type()` returns `"smsir"` (lowercase), matching the upstream
  Uptime Kuma provider name (`name = "smsir"` in
  `server/notification-providers/smsir.js`).
- JSON fields exposed: `smsirApiKey`, `smsirNumber`, `smsirTemplate`.
- Unit tests in `notification/notification_smsir_test.go` cover
  unmarshal + remarshal of the `Base` config payload with full,
  minimal, and multi-recipient configurations.
- End-to-end CRUD test entry added to `TestNotificationCRUD` in
  `notification_test.go`, covering initial state, create, update
  and delete against a real Uptime Kuma instance.

## Verification

- `task fmt` ✓
- `task lint` ✓
- `task test-e2e` ✓ (including the new
  `TestNotificationCRUD/SMSIR` and `TestNotificationSMSIR_Unmarshal`)

Closes #244