### PR TITLE
feat(notification): add Telnyx notification support

### DIFF
--- a/notification/notification_telnyx.go
+++ b/notification/notification_telnyx.go
@@ -1,0 +1,55 @@
+package notification
+
+import (
+	"fmt"
+)
+
+// Telnyx represents a telnyx notification.
+type Telnyx struct {
+	Base
+	TelnyxDetails
+}
+
+// TelnyxDetails contains telnyx-specific notification configuration.
+type TelnyxDetails struct {
+	APIKey             string `json:"telnyxApiKey"`
+	MessagingProfileID string `json:"telnyxMessagingProfileId"`
+	PhoneNumber        string `json:"telnyxPhoneNumber"`
+	ToNumber           string `json:"telnyxToNumber"`
+}
+
+// Type returns the notification type.
+func (t Telnyx) Type() string {
+	return t.TelnyxDetails.Type()
+}
+
+// Type returns the notification type.
+func (TelnyxDetails) Type() string {
+	return "telnyx"
+}
+
+// String returns a string representation of the notification.
+func (t Telnyx) String() string {
+	return fmt.Sprintf("%s, %s", formatNotification(t.Base, false), formatNotification(t.TelnyxDetails, true))
+}
+
+// UnmarshalJSON unmarshals a JSON byte slice into a notification.
+func (t *Telnyx) UnmarshalJSON(data []byte) error {
+	detail := TelnyxDetails{}
+	base, err := unmarshalTo(data, &detail)
+	if err != nil {
+		return err
+	}
+
+	*t = Telnyx{
+		Base:          base,
+		TelnyxDetails: detail,
+	}
+
+	return nil
+}
+
+// MarshalJSON marshals a notification into a JSON byte slice.
+func (t Telnyx) MarshalJSON() ([]byte, error) {
+	return marshalJSON(t.Base, &t.TelnyxDetails)
+}

--- a/notification/notification_telnyx.go
+++ b/notification/notification_telnyx.go
@@ -12,10 +12,10 @@ type Telnyx struct {
 
 // TelnyxDetails contains telnyx-specific notification configuration.
 type TelnyxDetails struct {
-	APIKey             string `json:"telnyxApiKey"`
-	MessagingProfileID string `json:"telnyxMessagingProfileId"`
-	PhoneNumber        string `json:"telnyxPhoneNumber"`
-	ToNumber           string `json:"telnyxToNumber"`
+	APIKey             string  `json:"telnyxApiKey"`
+	MessagingProfileID *string `json:"telnyxMessagingProfileId,omitempty"`
+	PhoneNumber        string  `json:"telnyxPhoneNumber"`
+	ToNumber           string  `json:"telnyxToNumber"`
 }
 
 // Type returns the notification type.

--- a/notification/notification_telnyx_test.go
+++ b/notification/notification_telnyx_test.go
@@ -1,0 +1,84 @@
+package notification_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/breml/go-uptime-kuma-client/notification"
+)
+
+func TestNotificationTelnyx_Unmarshal(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+
+		want     notification.Telnyx
+		wantJSON string
+	}{
+		{
+			name: "success",
+			data: []byte(
+				`{"id":1,"name":"My Telnyx Alert","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"My Telnyx Alert\",\"telnyxApiKey\":\"KEYxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\",\"telnyxMessagingProfileId\":\"4001763e-7f7d-4c87-a8b1-1c5a0e5a3f48\",\"telnyxPhoneNumber\":\"+15559876543\",\"telnyxToNumber\":\"+15551234567\",\"type\":\"telnyx\"}"}`,
+			),
+
+			want: notification.Telnyx{
+				Base: notification.Base{
+					ID:            1,
+					Name:          "My Telnyx Alert",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     true,
+					ApplyExisting: true,
+				},
+				TelnyxDetails: notification.TelnyxDetails{
+					APIKey:             "KEYxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+					MessagingProfileID: "4001763e-7f7d-4c87-a8b1-1c5a0e5a3f48",
+					PhoneNumber:        "+15559876543",
+					ToNumber:           "+15551234567",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":true,"id":1,"isDefault":true,"name":"My Telnyx Alert","telnyxApiKey":"KEYxxxxxxxxxxxxxxxxxxxxxxxxxxxxx","telnyxMessagingProfileId":"4001763e-7f7d-4c87-a8b1-1c5a0e5a3f48","telnyxPhoneNumber":"+15559876543","telnyxToNumber":"+15551234567","type":"telnyx","userId":1}`,
+		},
+		{
+			name: "minimal",
+			data: []byte(
+				`{"id":2,"name":"Simple Telnyx","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Simple Telnyx\",\"telnyxApiKey\":\"KEYxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\",\"telnyxPhoneNumber\":\"+15559876543\",\"telnyxToNumber\":\"+15551234567\",\"type\":\"telnyx\"}"}`,
+			),
+
+			want: notification.Telnyx{
+				Base: notification.Base{
+					ID:            2,
+					Name:          "Simple Telnyx",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				TelnyxDetails: notification.TelnyxDetails{
+					APIKey:      "KEYxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+					PhoneNumber: "+15559876543",
+					ToNumber:    "+15551234567",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"id":2,"isDefault":false,"name":"Simple Telnyx","telnyxApiKey":"KEYxxxxxxxxxxxxxxxxxxxxxxxxxxxxx","telnyxMessagingProfileId":"","telnyxPhoneNumber":"+15559876543","telnyxToNumber":"+15551234567","type":"telnyx","userId":1}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			telnyx := notification.Telnyx{}
+
+			err := json.Unmarshal(tc.data, &telnyx)
+			require.NoError(t, err)
+
+			require.EqualExportedValues(t, tc.want, telnyx)
+
+			data, err := json.Marshal(telnyx)
+			require.NoError(t, err)
+
+			require.JSONEq(t, tc.wantJSON, string(data))
+		})
+	}
+}

--- a/notification/notification_telnyx_test.go
+++ b/notification/notification_telnyx_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/breml/go-uptime-kuma-client/internal/ptr"
 	"github.com/breml/go-uptime-kuma-client/notification"
 )
 
@@ -16,6 +17,7 @@ func TestNotificationTelnyx_Unmarshal(t *testing.T) {
 
 		want     notification.Telnyx
 		wantJSON string
+		wantErr  bool
 	}{
 		{
 			name: "success",
@@ -34,7 +36,7 @@ func TestNotificationTelnyx_Unmarshal(t *testing.T) {
 				},
 				TelnyxDetails: notification.TelnyxDetails{
 					APIKey:             "KEYxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-					MessagingProfileID: "4001763e-7f7d-4c87-a8b1-1c5a0e5a3f48",
+					MessagingProfileID: ptr.To("4001763e-7f7d-4c87-a8b1-1c5a0e5a3f48"),
 					PhoneNumber:        "+15559876543",
 					ToNumber:           "+15551234567",
 				},
@@ -62,7 +64,17 @@ func TestNotificationTelnyx_Unmarshal(t *testing.T) {
 					ToNumber:    "+15551234567",
 				},
 			},
-			wantJSON: `{"active":true,"applyExisting":false,"id":2,"isDefault":false,"name":"Simple Telnyx","telnyxApiKey":"KEYxxxxxxxxxxxxxxxxxxxxxxxxxxxxx","telnyxMessagingProfileId":"","telnyxPhoneNumber":"+15559876543","telnyxToNumber":"+15551234567","type":"telnyx","userId":1}`,
+			wantJSON: `{"active":true,"applyExisting":false,"id":2,"isDefault":false,"name":"Simple Telnyx","telnyxApiKey":"KEYxxxxxxxxxxxxxxxxxxxxxxxxxxxxx","telnyxPhoneNumber":"+15559876543","telnyxToNumber":"+15551234567","type":"telnyx","userId":1}`,
+		},
+		{
+			name:    "missing config field",
+			data:    []byte(`{"id":1,"name":"x","active":true,"userId":1,"isDefault":false}`),
+			wantErr: true,
+		},
+		{
+			name:    "invalid config json",
+			data:    []byte(`{"id":1,"name":"x","active":true,"userId":1,"isDefault":false,"config":"not-json"}`),
+			wantErr: true,
 		},
 	}
 
@@ -71,6 +83,12 @@ func TestNotificationTelnyx_Unmarshal(t *testing.T) {
 			telnyx := notification.Telnyx{}
 
 			err := json.Unmarshal(tc.data, &telnyx)
+			if tc.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
 			require.NoError(t, err)
 
 			require.EqualExportedValues(t, tc.want, telnyx)

--- a/notification_test.go
+++ b/notification_test.go
@@ -937,7 +937,7 @@ func TestNotificationCRUD(t *testing.T) {
 				},
 				TelnyxDetails: notification.TelnyxDetails{
 					APIKey:             "KEYxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-					MessagingProfileID: "4001763e-7f7d-4c87-a8b1-1c5a0e5a3f48",
+					MessagingProfileID: ptr.To("4001763e-7f7d-4c87-a8b1-1c5a0e5a3f48"),
 					PhoneNumber:        "+15559876543",
 					ToNumber:           "+15551234567",
 				},

--- a/notification_test.go
+++ b/notification_test.go
@@ -926,6 +926,60 @@ func TestNotificationCRUD(t *testing.T) {
 			},
 		},
 		{
+			name:         "Telnyx",
+			expectedType: "telnyx",
+			create: notification.Telnyx{
+				Base: notification.Base{
+					ApplyExisting: true,
+					IsDefault:     false,
+					IsActive:      true,
+					Name:          "Test Telnyx Created",
+				},
+				TelnyxDetails: notification.TelnyxDetails{
+					APIKey:             "KEYxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+					MessagingProfileID: "4001763e-7f7d-4c87-a8b1-1c5a0e5a3f48",
+					PhoneNumber:        "+15559876543",
+					ToNumber:           "+15551234567",
+				},
+			},
+			updateFunc: func(n notification.Notification) {
+				telnyx, ok := n.(*notification.Telnyx)
+				if !ok {
+					panic("failed to assert Telnyx notification")
+				}
+
+				telnyx.Name = "Test Telnyx Updated"
+				telnyx.ToNumber = "+15559999999"
+			},
+			verifyCreatedFunc: func(t *testing.T, actual notification.Notification, expected notification.Notification, id int64) {
+				t.Helper()
+				exp, ok := expected.(notification.Telnyx)
+				require.True(t, ok)
+				var telnyx notification.Telnyx
+				err := actual.As(&telnyx)
+				require.NoError(t, err)
+				exp.ID = id
+				exp.UserID = telnyx.UserID
+				require.EqualExportedValues(t, exp, telnyx)
+			},
+			createTypedFunc: func(t *testing.T, base notification.Notification) notification.Notification {
+				t.Helper()
+				var telnyx notification.Telnyx
+				err := base.As(&telnyx)
+				require.NoError(t, err)
+				return &telnyx
+			},
+			verifyUpdatedFunc: func(t *testing.T, actual notification.Notification, expected notification.Notification) {
+				t.Helper()
+				exp, ok := expected.(*notification.Telnyx)
+				require.True(t, ok)
+				var telnyx notification.Telnyx
+				err := actual.As(&telnyx)
+				require.NoError(t, err)
+				require.EqualExportedValues(t, *exp, telnyx)
+			},
+		},
+		{
 			name:         "Mattermost",
 			expectedType: "mattermost",
 			create: notification.Mattermost{


### PR DESCRIPTION
## Summary

Add support for the `telnyx` notification provider, introduced upstream
in Uptime Kuma v2.x (louislam/uptime-kuma#7201).

## Changes

- `notification/notification_telnyx.go`: new `Telnyx` notification type
  with `TelnyxDetails` (`telnyxApiKey`, `telnyxMessagingProfileId`,
  `telnyxPhoneNumber`, `telnyxToNumber`), mirroring the existing Twilio
  provider implementation.
- `notification/notification_telnyx_test.go`: marshal / unmarshal unit
  tests (success and minimal variants).
- `notification_test.go`: end-to-end CRUD test case for Telnyx
  (create / update / delete against a live Uptime Kuma instance).

## Validation

- ` task fmt`
- ` task lint`
- ` task test-e2e`

Closes #245