### PR TITLE
feat(notification): add support for Teltonika RUTxxx SMS gateway

### DIFF
--- a/notification/notification_teltonika.go
+++ b/notification/notification_teltonika.go
@@ -1,0 +1,68 @@
+package notification
+
+import (
+	"fmt"
+)
+
+// Teltonika represents a Teltonika notification provider.
+// Teltonika uses a Teltonika RUTxxx series router as an SMS gateway over its HTTP API
+// (https://developers.teltonika-networks.com/reference/rut241/7.19.4/v1.11.1/messages).
+// This provider is only compatible with Teltonika RutOS >= 7.14.0 devices.
+type Teltonika struct {
+	Base
+	TeltonikaDetails
+}
+
+// TeltonikaDetails contains the configuration fields for Teltonika notifications.
+type TeltonikaDetails struct {
+	// URL is the Teltonika router base URL (e.g., https://192.168.100.1 or http://teltonika.example.com:8080).
+	URL string `json:"teltonikaUrl"`
+	// Username is the router user used to authenticate against the Teltonika HTTP API.
+	Username string `json:"teltonikaUsername"`
+	// Password is the password for the router user.
+	Password string `json:"teltonikaPassword"`
+	// Modem is the modem identifier on the router (e.g., "1-1").
+	Modem string `json:"teltonikaModem"`
+	// PhoneNumber is the recipient phone number (e.g., "+336xxxxxxxx").
+	// Multiple recipients can be provided as a comma-separated list.
+	PhoneNumber string `json:"teltonikaPhoneNumber"`
+	// UnsafeTLS disables TLS certificate validation when communicating with the router.
+	// This is useful for routers using a self-signed certificate.
+	UnsafeTLS bool `json:"teltonikaUnsafeTls"`
+}
+
+// Type returns the notification type identifier for Teltonika.
+func (t Teltonika) Type() string {
+	return t.TeltonikaDetails.Type()
+}
+
+// Type returns the notification type identifier for TeltonikaDetails.
+func (TeltonikaDetails) Type() string {
+	return "Teltonika"
+}
+
+// String returns a string representation of the Teltonika notification.
+func (t Teltonika) String() string {
+	return fmt.Sprintf("%s, %s", formatNotification(t.Base, false), formatNotification(t.TeltonikaDetails, true))
+}
+
+// UnmarshalJSON unmarshals JSON data into a Teltonika notification.
+func (t *Teltonika) UnmarshalJSON(data []byte) error {
+	detail := TeltonikaDetails{}
+	base, err := unmarshalTo(data, &detail)
+	if err != nil {
+		return err
+	}
+
+	*t = Teltonika{
+		Base:             base,
+		TeltonikaDetails: detail,
+	}
+
+	return nil
+}
+
+// MarshalJSON marshals the Teltonika notification into JSON.
+func (t Teltonika) MarshalJSON() ([]byte, error) {
+	return marshalJSON(t.Base, t.TeltonikaDetails)
+}

--- a/notification/notification_teltonika.go
+++ b/notification/notification_teltonika.go
@@ -5,8 +5,7 @@ import (
 )
 
 // Teltonika represents a Teltonika notification provider.
-// Teltonika uses a Teltonika RUTxxx series router as an SMS gateway over its HTTP API
-// (https://developers.teltonika-networks.com/reference/rut241/7.19.4/v1.11.1/messages).
+// Teltonika uses a Teltonika RUTxxx series router as an SMS gateway over its HTTP API.
 // This provider is only compatible with Teltonika RutOS >= 7.14.0 devices.
 type Teltonika struct {
 	Base

--- a/notification/notification_teltonika_test.go
+++ b/notification/notification_teltonika_test.go
@@ -1,0 +1,89 @@
+package notification_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/breml/go-uptime-kuma-client/notification"
+)
+
+func TestNotificationTeltonika_Unmarshal(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+
+		want     notification.Teltonika
+		wantJSON string
+	}{
+		{
+			name: "single phone number with TLS validation",
+			data: []byte(
+				`{"id":1,"name":"My Teltonika Alert","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"My Teltonika Alert\",\"teltonikaUrl\":\"https://192.168.100.1\",\"teltonikaUsername\":\"admin\",\"teltonikaPassword\":\"secret-password\",\"teltonikaModem\":\"1-1\",\"teltonikaPhoneNumber\":\"+336xxxxxxxx\",\"teltonikaUnsafeTls\":false,\"type\":\"Teltonika\"}"}`,
+			),
+
+			want: notification.Teltonika{
+				Base: notification.Base{
+					ID:            1,
+					Name:          "My Teltonika Alert",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     true,
+					ApplyExisting: true,
+				},
+				TeltonikaDetails: notification.TeltonikaDetails{
+					URL:         "https://192.168.100.1",
+					Username:    "admin",
+					Password:    "secret-password",
+					Modem:       "1-1",
+					PhoneNumber: "+336xxxxxxxx",
+					UnsafeTLS:   false,
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":true,"id":1,"isDefault":true,"name":"My Teltonika Alert","teltonikaModem":"1-1","teltonikaPassword":"secret-password","teltonikaPhoneNumber":"+336xxxxxxxx","teltonikaUnsafeTls":false,"teltonikaUrl":"https://192.168.100.1","teltonikaUsername":"admin","type":"Teltonika","userId":1}`,
+		},
+		{
+			name: "multiple recipients with unsafe TLS",
+			data: []byte(
+				`{"id":2,"name":"Teltonika Self-Signed","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Teltonika Self-Signed\",\"teltonikaUrl\":\"http://teltonika.example.com:8080\",\"teltonikaUsername\":\"opsuser\",\"teltonikaPassword\":\"another-secret\",\"teltonikaModem\":\"2-1\",\"teltonikaPhoneNumber\":\"+336xxxxxxxx,+496xxxxxxxx\",\"teltonikaUnsafeTls\":true,\"type\":\"Teltonika\"}"}`,
+			),
+
+			want: notification.Teltonika{
+				Base: notification.Base{
+					ID:            2,
+					Name:          "Teltonika Self-Signed",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				TeltonikaDetails: notification.TeltonikaDetails{
+					URL:         "http://teltonika.example.com:8080",
+					Username:    "opsuser",
+					Password:    "another-secret",
+					Modem:       "2-1",
+					PhoneNumber: "+336xxxxxxxx,+496xxxxxxxx",
+					UnsafeTLS:   true,
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"id":2,"isDefault":false,"name":"Teltonika Self-Signed","teltonikaModem":"2-1","teltonikaPassword":"another-secret","teltonikaPhoneNumber":"+336xxxxxxxx,+496xxxxxxxx","teltonikaUnsafeTls":true,"teltonikaUrl":"http://teltonika.example.com:8080","teltonikaUsername":"opsuser","type":"Teltonika","userId":1}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			teltonika := notification.Teltonika{}
+
+			err := json.Unmarshal(tc.data, &teltonika)
+			require.NoError(t, err)
+
+			require.EqualExportedValues(t, tc.want, teltonika)
+
+			data, err := json.Marshal(teltonika)
+			require.NoError(t, err)
+
+			require.JSONEq(t, tc.wantJSON, string(data))
+		})
+	}
+}

--- a/notification_test.go
+++ b/notification_test.go
@@ -4120,6 +4120,63 @@ func TestNotificationCRUD(t *testing.T) {
 			},
 		},
 		{
+			name:         "Teltonika",
+			expectedType: "Teltonika",
+			create: notification.Teltonika{
+				Base: notification.Base{
+					ApplyExisting: true,
+					IsDefault:     false,
+					IsActive:      true,
+					Name:          "Test Teltonika Created",
+				},
+				TeltonikaDetails: notification.TeltonikaDetails{
+					URL:         "https://192.168.100.1",
+					Username:    "admin",
+					Password:    "secret-password",
+					Modem:       "1-1",
+					PhoneNumber: "+336xxxxxxxx",
+					UnsafeTLS:   false,
+				},
+			},
+			updateFunc: func(n notification.Notification) {
+				teltonika, ok := n.(*notification.Teltonika)
+				if !ok {
+					panic("failed to assert Teltonika notification")
+				}
+
+				teltonika.Name = "Test Teltonika Updated"
+				teltonika.PhoneNumber = "+496xxxxxxxx"
+				teltonika.UnsafeTLS = true
+			},
+			verifyCreatedFunc: func(t *testing.T, actual notification.Notification, expected notification.Notification, id int64) {
+				t.Helper()
+				exp, ok := expected.(notification.Teltonika)
+				require.True(t, ok)
+				var teltonika notification.Teltonika
+				err := actual.As(&teltonika)
+				require.NoError(t, err)
+				exp.ID = id
+				exp.UserID = teltonika.UserID
+				require.EqualExportedValues(t, exp, teltonika)
+			},
+			createTypedFunc: func(t *testing.T, base notification.Notification) notification.Notification {
+				t.Helper()
+				var teltonika notification.Teltonika
+				err := base.As(&teltonika)
+				require.NoError(t, err)
+				return &teltonika
+			},
+			verifyUpdatedFunc: func(t *testing.T, actual notification.Notification, expected notification.Notification) {
+				t.Helper()
+				exp, ok := expected.(*notification.Teltonika)
+				require.True(t, ok)
+				var teltonika notification.Teltonika
+				err := actual.As(&teltonika)
+				require.NoError(t, err)
+				require.EqualExportedValues(t, *exp, teltonika)
+			},
+		},
+		{
 			name:         "Threema",
 			expectedType: "threema",
 			create: notification.Threema{


### PR DESCRIPTION
Add the `Teltonika` notification provider that uses a Teltonika RUTxxx series router as an SMS gateway over its HTTP API.

## Fields

- `teltonikaUrl` — router base URL (e.g. `https://192.168.100.1`)
- `teltonikaUsername` / `teltonikaPassword` — router credentials
- `teltonikaModem` — modem identifier on the router (e.g. `1-1`)
- `teltonikaPhoneNumber` — recipient phone number(s)
- `teltonikaUnsafeTls` — disable TLS certificate validation (for self-signed certs)

Mirrors the existing pattern (e.g. `SMSEagle`): `Teltonika` struct embedding `Base` + `TeltonikaDetails`, with `Type`, `String`, `UnmarshalJSON`, and `MarshalJSON` implementations.

## Tests

- `notification/notification_teltonika_test.go` — marshal/unmarshal unit tests covering both TLS-validated and self-signed (`teltonikaUnsafeTls: true`) configurations with single and multiple recipients.
- `notification_test.go` — integration test case added to `TestNotificationCRUD` covering initial state, create, update, and delete against a live Uptime Kuma instance.

Verified locally:

- `task fmt` — clean
- `task lint` — 0 issues
- `task test-e2e` — all tests pass, including `TestNotificationCRUD/Teltonika`

Closes #246