### PR TITLE
feat(notification): add VK notification support

### DIFF
--- a/notification/notification_vk.go
+++ b/notification/notification_vk.go
@@ -1,0 +1,55 @@
+package notification
+
+import (
+	"fmt"
+)
+
+// VK represents a VK notification.
+type VK struct {
+	Base
+	VKDetails
+}
+
+// VKDetails contains VK-specific notification configuration.
+type VKDetails struct {
+	AccessToken    string `json:"vkAccessToken"`
+	PeerID         string `json:"vkPeerId"`
+	APIVersion     string `json:"vkApiVersion"`
+	DontParseLinks bool   `json:"vkDontParseLinks"`
+}
+
+// Type returns the notification type.
+func (v VK) Type() string {
+	return v.VKDetails.Type()
+}
+
+// Type returns the notification type.
+func (VKDetails) Type() string {
+	return "VK"
+}
+
+// String returns a string representation of the notification.
+func (v VK) String() string {
+	return fmt.Sprintf("%s, %s", formatNotification(v.Base, false), formatNotification(v.VKDetails, true))
+}
+
+// UnmarshalJSON unmarshals a JSON byte slice into a notification.
+func (v *VK) UnmarshalJSON(data []byte) error {
+	detail := VKDetails{}
+	base, err := unmarshalTo(data, &detail)
+	if err != nil {
+		return err
+	}
+
+	*v = VK{
+		Base:      base,
+		VKDetails: detail,
+	}
+
+	return nil
+}
+
+// MarshalJSON marshals a notification into a JSON byte slice.
+func (v VK) MarshalJSON() ([]byte, error) {
+	return marshalJSON(v.Base, &v.VKDetails)
+}

--- a/notification/notification_vk.go
+++ b/notification/notification_vk.go
@@ -12,8 +12,12 @@ type VK struct {
 
 // VKDetails contains VK-specific notification configuration.
 type VKDetails struct {
-	AccessToken    string `json:"vkAccessToken"`
-	PeerID         string `json:"vkPeerId"`
+	// AccessToken is the VK API user or service access token.
+	AccessToken string `json:"vkAccessToken"`
+	// PeerID is the recipient. Must be a numeric string: positive for user
+	// IDs, negative for community IDs, or 2000000000+chat_id for group chats.
+	PeerID string `json:"vkPeerId"`
+	// APIVersion is the VK API version string (e.g., "5.199").
 	APIVersion     string `json:"vkApiVersion"`
 	DontParseLinks bool   `json:"vkDontParseLinks"`
 }

--- a/notification/notification_vk_test.go
+++ b/notification/notification_vk_test.go
@@ -16,6 +16,7 @@ func TestNotificationVK_Unmarshal(t *testing.T) {
 
 		want     notification.VK
 		wantJSON string
+		wantErr  bool
 	}{
 		{
 			name: "success",
@@ -64,6 +65,16 @@ func TestNotificationVK_Unmarshal(t *testing.T) {
 			},
 			wantJSON: `{"active":true,"applyExisting":false,"id":2,"isDefault":false,"name":"Simple VK","vkAccessToken":"vk1.a.token","vkPeerId":"12345","vkApiVersion":"5.199","vkDontParseLinks":false,"type":"VK","userId":1}`,
 		},
+		{
+			name:    "missing config field",
+			data:    []byte(`{"id":1,"name":"x","active":true,"userId":1,"isDefault":false}`),
+			wantErr: true,
+		},
+		{
+			name:    "invalid config json",
+			data:    []byte(`{"id":1,"name":"x","active":true,"userId":1,"isDefault":false,"config":"not-json"}`),
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -71,6 +82,12 @@ func TestNotificationVK_Unmarshal(t *testing.T) {
 			vk := notification.VK{}
 
 			err := json.Unmarshal(tc.data, &vk)
+			if tc.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
 			require.NoError(t, err)
 
 			require.EqualExportedValues(t, tc.want, vk)

--- a/notification/notification_vk_test.go
+++ b/notification/notification_vk_test.go
@@ -1,0 +1,84 @@
+package notification_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/breml/go-uptime-kuma-client/notification"
+)
+
+func TestNotificationVK_Unmarshal(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+
+		want     notification.VK
+		wantJSON string
+	}{
+		{
+			name: "success",
+			data: []byte(
+				`{"id":1,"name":"My VK Alert","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"My VK Alert\",\"vkAccessToken\":\"vk1.a.abcdefghijklmnopqrstuvwxyz\",\"vkPeerId\":\"2000000001\",\"vkApiVersion\":\"5.199\",\"vkDontParseLinks\":true,\"type\":\"VK\"}"}`,
+			),
+
+			want: notification.VK{
+				Base: notification.Base{
+					ID:            1,
+					Name:          "My VK Alert",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     true,
+					ApplyExisting: true,
+				},
+				VKDetails: notification.VKDetails{
+					AccessToken:    "vk1.a.abcdefghijklmnopqrstuvwxyz",
+					PeerID:         "2000000001",
+					APIVersion:     "5.199",
+					DontParseLinks: true,
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":true,"id":1,"isDefault":true,"name":"My VK Alert","vkAccessToken":"vk1.a.abcdefghijklmnopqrstuvwxyz","vkPeerId":"2000000001","vkApiVersion":"5.199","vkDontParseLinks":true,"type":"VK","userId":1}`,
+		},
+		{
+			name: "minimal",
+			data: []byte(
+				`{"id":2,"name":"Simple VK","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Simple VK\",\"vkAccessToken\":\"vk1.a.token\",\"vkPeerId\":\"12345\",\"vkApiVersion\":\"5.199\",\"type\":\"VK\"}"}`,
+			),
+
+			want: notification.VK{
+				Base: notification.Base{
+					ID:            2,
+					Name:          "Simple VK",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				VKDetails: notification.VKDetails{
+					AccessToken: "vk1.a.token",
+					PeerID:      "12345",
+					APIVersion:  "5.199",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"id":2,"isDefault":false,"name":"Simple VK","vkAccessToken":"vk1.a.token","vkPeerId":"12345","vkApiVersion":"5.199","vkDontParseLinks":false,"type":"VK","userId":1}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			vk := notification.VK{}
+
+			err := json.Unmarshal(tc.data, &vk)
+			require.NoError(t, err)
+
+			require.EqualExportedValues(t, tc.want, vk)
+
+			data, err := json.Marshal(vk)
+			require.NoError(t, err)
+
+			require.JSONEq(t, tc.wantJSON, string(data))
+		})
+	}
+}

--- a/notification_test.go
+++ b/notification_test.go
@@ -4387,6 +4387,60 @@ func TestNotificationCRUD(t *testing.T) {
 			},
 		},
 		{
+			name:         "VK",
+			expectedType: "VK",
+			create: notification.VK{
+				Base: notification.Base{
+					ApplyExisting: true,
+					IsDefault:     false,
+					IsActive:      true,
+					Name:          "Test VK Created",
+				},
+				VKDetails: notification.VKDetails{
+					AccessToken: "vk1.a.abcdefghijklmnopqrstuvwxyz",
+					PeerID:      "2000000001",
+					APIVersion:  "5.199",
+				},
+			},
+			updateFunc: func(n notification.Notification) {
+				vk, ok := n.(*notification.VK)
+				if !ok {
+					panic("failed to assert VK notification")
+				}
+
+				vk.Name = "Test VK Updated"
+				vk.PeerID = "2000000002"
+				vk.DontParseLinks = true
+			},
+			verifyCreatedFunc: func(t *testing.T, actual notification.Notification, expected notification.Notification, id int64) {
+				t.Helper()
+				exp, ok := expected.(notification.VK)
+				require.True(t, ok)
+				var vk notification.VK
+				err := actual.As(&vk)
+				require.NoError(t, err)
+				exp.ID = id
+				exp.UserID = vk.UserID
+				require.EqualExportedValues(t, exp, vk)
+			},
+			createTypedFunc: func(t *testing.T, base notification.Notification) notification.Notification {
+				t.Helper()
+				var vk notification.VK
+				err := base.As(&vk)
+				require.NoError(t, err)
+				return &vk
+			},
+			verifyUpdatedFunc: func(t *testing.T, actual notification.Notification, expected notification.Notification) {
+				t.Helper()
+				exp, ok := expected.(*notification.VK)
+				require.True(t, ok)
+				var vk notification.VK
+				err := actual.As(&vk)
+				require.NoError(t, err)
+				require.EqualExportedValues(t, *exp, vk)
+			},
+		},
+		{
 			name:         "ZohoCliq",
 			expectedType: "ZohoCliq",
 			create: notification.ZohoCliq{


### PR DESCRIPTION
Add support for the VK notification provider — VK is a Russian social network with a messaging API.

The configuration exposes the access token, peer ID, API version and a flag to disable VK link previews, matching the upstream Uptime Kuma provider name `VK` (introduced upstream in louislam/uptime-kuma#7182).

Closes #247