### PR TITLE
feat(notification): add Webpush notification type

### DIFF
--- a/notification/notification_webpush.go
+++ b/notification/notification_webpush.go
@@ -1,0 +1,66 @@
+package notification
+
+import (
+	"fmt"
+)
+
+// Webpush represents a Web Push notification.
+// VAPID keys are managed server-side via the webpushPublicVapidKey /
+// webpushPrivateVapidKey settings and are not part of this notification payload.
+type Webpush struct {
+	Base
+	WebpushDetails
+}
+
+// WebpushDetails contains the Web Push-specific notification configuration.
+type WebpushDetails struct {
+	Subscription WebpushSubscription `json:"subscription"`
+}
+
+// WebpushSubscription is a W3C PushSubscription object identifying the push endpoint.
+type WebpushSubscription struct {
+	Endpoint string                  `json:"endpoint"`
+	Keys     WebpushSubscriptionKeys `json:"keys"`
+}
+
+// WebpushSubscriptionKeys holds the encryption keys for a Web Push subscription.
+type WebpushSubscriptionKeys struct {
+	P256dh string `json:"p256dh"`
+	Auth   string `json:"auth"`
+}
+
+// Type returns the notification type.
+func (w Webpush) Type() string {
+	return w.WebpushDetails.Type()
+}
+
+// Type returns the notification type.
+func (WebpushDetails) Type() string {
+	return "Webpush"
+}
+
+// String returns a string representation of the notification.
+func (w Webpush) String() string {
+	return fmt.Sprintf("%s, %s", formatNotification(w.Base, false), formatNotification(w.WebpushDetails, true))
+}
+
+// UnmarshalJSON unmarshals a JSON byte slice into a notification.
+func (w *Webpush) UnmarshalJSON(data []byte) error {
+	detail := WebpushDetails{}
+	base, err := unmarshalTo(data, &detail)
+	if err != nil {
+		return err
+	}
+
+	*w = Webpush{
+		Base:           base,
+		WebpushDetails: detail,
+	}
+
+	return nil
+}
+
+// MarshalJSON marshals a notification into a JSON byte slice.
+func (w Webpush) MarshalJSON() ([]byte, error) {
+	return marshalJSON(w.Base, w.WebpushDetails)
+}

--- a/notification/notification_webpush_test.go
+++ b/notification/notification_webpush_test.go
@@ -1,0 +1,108 @@
+package notification_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/breml/go-uptime-kuma-client/notification"
+)
+
+func TestNotificationWebpush_Unmarshal(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+
+		want     notification.Webpush
+		wantJSON string
+		wantErr  bool
+	}{
+		{
+			name: "success",
+			data: []byte(
+				`{"id":1,"name":"My Webpush Alert","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"My Webpush Alert\",\"subscription\":{\"endpoint\":\"https://push.example.com/abc123\",\"keys\":{\"p256dh\":\"BGxi5eHcCn...\",\"auth\":\"abc\"}},\"type\":\"Webpush\"}"}`,
+			),
+
+			want: notification.Webpush{
+				Base: notification.Base{
+					ID:            1,
+					Name:          "My Webpush Alert",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     true,
+					ApplyExisting: true,
+				},
+				WebpushDetails: notification.WebpushDetails{
+					Subscription: notification.WebpushSubscription{
+						Endpoint: "https://push.example.com/abc123",
+						Keys: notification.WebpushSubscriptionKeys{
+							P256dh: "BGxi5eHcCn...",
+							Auth:   "abc",
+						},
+					},
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":true,"id":1,"isDefault":true,"name":"My Webpush Alert","subscription":{"endpoint":"https://push.example.com/abc123","keys":{"p256dh":"BGxi5eHcCn...","auth":"abc"}},"type":"Webpush","userId":1}`,
+		},
+		{
+			name: "minimal",
+			data: []byte(
+				`{"id":2,"name":"Simple Webpush","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Simple Webpush\",\"subscription\":{\"endpoint\":\"https://fcm.googleapis.com/fcm/send/xyz\",\"keys\":{\"p256dh\":\"BNc...\",\"auth\":\"xyz\"}},\"type\":\"Webpush\"}"}`,
+			),
+
+			want: notification.Webpush{
+				Base: notification.Base{
+					ID:            2,
+					Name:          "Simple Webpush",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				WebpushDetails: notification.WebpushDetails{
+					Subscription: notification.WebpushSubscription{
+						Endpoint: "https://fcm.googleapis.com/fcm/send/xyz",
+						Keys: notification.WebpushSubscriptionKeys{
+							P256dh: "BNc...",
+							Auth:   "xyz",
+						},
+					},
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"id":2,"isDefault":false,"name":"Simple Webpush","subscription":{"endpoint":"https://fcm.googleapis.com/fcm/send/xyz","keys":{"p256dh":"BNc...","auth":"xyz"}},"type":"Webpush","userId":1}`,
+		},
+		{
+			name:    "missing config field",
+			data:    []byte(`{"id":1,"name":"x","active":true,"userId":1,"isDefault":false}`),
+			wantErr: true,
+		},
+		{
+			name:    "invalid config json",
+			data:    []byte(`{"id":1,"name":"x","active":true,"userId":1,"isDefault":false,"config":"not-json"}`),
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			webpush := notification.Webpush{}
+
+			err := json.Unmarshal(tc.data, &webpush)
+			if tc.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+
+			require.EqualExportedValues(t, tc.want, webpush)
+
+			data, err := json.Marshal(webpush)
+			require.NoError(t, err)
+
+			require.JSONEq(t, tc.wantJSON, string(data))
+		})
+	}
+}

--- a/notification/notification_webpush_test.go
+++ b/notification/notification_webpush_test.go
@@ -106,3 +106,37 @@ func TestNotificationWebpush_Unmarshal(t *testing.T) {
 		})
 	}
 }
+
+func TestNotificationWebpush_Type(t *testing.T) {
+	webpush := notification.Webpush{}
+	require.Equal(t, "Webpush", webpush.Type())
+
+	details := notification.WebpushDetails{}
+	require.Equal(t, "Webpush", details.Type())
+}
+
+func TestNotificationWebpush_String(t *testing.T) {
+	webpush := notification.Webpush{
+		Base: notification.Base{
+			ID:       1,
+			Name:     "Test Webpush",
+			IsActive: true,
+			UserID:   1,
+		},
+		WebpushDetails: notification.WebpushDetails{
+			Subscription: notification.WebpushSubscription{
+				Endpoint: "https://push.example.com/abc123",
+				Keys: notification.WebpushSubscriptionKeys{
+					P256dh: "BGxi5eHcCn...",
+					Auth:   "abc",
+				},
+			},
+		},
+	}
+
+	str := webpush.String()
+	require.Contains(t, str, "Test Webpush")
+	require.Contains(t, str, "Webpush")
+	require.Contains(t, str, "https://push.example.com/abc123")
+	require.NotContains(t, str, "0x")
+}

--- a/notification_test.go
+++ b/notification_test.go
@@ -4283,6 +4283,63 @@ func TestNotificationCRUD(t *testing.T) {
 			},
 		},
 		{
+			name:         "Webpush",
+			expectedType: "Webpush",
+			create: notification.Webpush{
+				Base: notification.Base{
+					ApplyExisting: true,
+					IsDefault:     false,
+					IsActive:      true,
+					Name:          "Test Webpush Created",
+				},
+				WebpushDetails: notification.WebpushDetails{
+					Subscription: notification.WebpushSubscription{
+						Endpoint: "https://push.example.com/abc123",
+						Keys: notification.WebpushSubscriptionKeys{
+							P256dh: "BGxi5eHcCnxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+							Auth:   "abc123auth",
+						},
+					},
+				},
+			},
+			updateFunc: func(n notification.Notification) {
+				webpush, ok := n.(*notification.Webpush)
+				if !ok {
+					panic("failed to assert Webpush notification")
+				}
+
+				webpush.Name = "Test Webpush Updated"
+				webpush.Subscription.Endpoint = "https://push.example.com/xyz789"
+			},
+			verifyCreatedFunc: func(t *testing.T, actual notification.Notification, expected notification.Notification, id int64) {
+				t.Helper()
+				exp, ok := expected.(notification.Webpush)
+				require.True(t, ok)
+				var webpush notification.Webpush
+				err := actual.As(&webpush)
+				require.NoError(t, err)
+				exp.ID = id
+				exp.UserID = webpush.UserID
+				require.EqualExportedValues(t, exp, webpush)
+			},
+			createTypedFunc: func(t *testing.T, base notification.Notification) notification.Notification {
+				t.Helper()
+				var webpush notification.Webpush
+				err := base.As(&webpush)
+				require.NoError(t, err)
+				return &webpush
+			},
+			verifyUpdatedFunc: func(t *testing.T, actual notification.Notification, expected notification.Notification) {
+				t.Helper()
+				exp, ok := expected.(*notification.Webpush)
+				require.True(t, ok)
+				var webpush notification.Webpush
+				err := actual.As(&webpush)
+				require.NoError(t, err)
+				require.EqualExportedValues(t, *exp, webpush)
+			},
+		},
+		{
 			name:         "WPush",
 			expectedType: "WPush",
 			create: notification.WPush{


### PR DESCRIPTION
## Summary

- Add `Webpush` notification type with typed `WebpushSubscription` struct
  modelling the W3C PushSubscription object (`endpoint`, `keys.p256dh`,
  `keys.auth`)
- Follow existing notification provider patterns (`GoogleSheets`, `Ntfy`, etc.)
- Add unit tests covering success, minimal, missing config, and invalid config
  cases; plus `Type()` and `String()` assertions
- Add Webpush entry to the integration test table (`TestNotificationCRUD`)

## Notes

VAPID keys are server-side settings (`webpushPublicVapidKey` /
`webpushPrivateVapidKey`) and are not part of the notification payload.

## Test plan

- [ ] `task fmt` — no changes
- [ ] `task lint` — 0 issues
- [ ] `task test` — all pass
- [ ] `task test-e2e` — all pass

Closes #248