### PR TITLE
feat: add support for EgoSMS notifications

### DIFF
--- a/notification/notification_egosms.go
+++ b/notification/notification_egosms.go
@@ -1,0 +1,55 @@
+package notification
+
+import (
+	"fmt"
+)
+
+// EgoSMS represents an EgoSMS notification.
+type EgoSMS struct {
+	Base
+	EgoSMSDetails
+}
+
+// EgoSMSDetails contains EgoSMS-specific notification configuration.
+type EgoSMSDetails struct {
+	Username    string  `json:"egosmsUsername"`
+	Password    string  `json:"egosmsPassword"`
+	Sender      *string `json:"egosmsSender,omitempty"`
+	PhoneNumber string  `json:"egosmsPhoneNumber"`
+}
+
+// Type returns the notification type.
+func (e EgoSMS) Type() string {
+	return e.EgoSMSDetails.Type()
+}
+
+// Type returns the notification type.
+func (EgoSMSDetails) Type() string {
+	return "egosms"
+}
+
+// String returns a string representation of the notification.
+func (e EgoSMS) String() string {
+	return fmt.Sprintf("%s, %s", formatNotification(e.Base, false), formatNotification(e.EgoSMSDetails, true))
+}
+
+// UnmarshalJSON unmarshals a JSON byte slice into a notification.
+func (e *EgoSMS) UnmarshalJSON(data []byte) error {
+	detail := EgoSMSDetails{}
+	base, err := unmarshalTo(data, &detail)
+	if err != nil {
+		return err
+	}
+
+	*e = EgoSMS{
+		Base:          base,
+		EgoSMSDetails: detail,
+	}
+
+	return nil
+}
+
+// MarshalJSON marshals a notification into a JSON byte slice.
+func (e EgoSMS) MarshalJSON() ([]byte, error) {
+	return marshalJSON(e.Base, &e.EgoSMSDetails)
+}

--- a/notification/notification_egosms_test.go
+++ b/notification/notification_egosms_test.go
@@ -1,0 +1,102 @@
+package notification_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/breml/go-uptime-kuma-client/internal/ptr"
+	"github.com/breml/go-uptime-kuma-client/notification"
+)
+
+func TestNotificationEgoSMS_Unmarshal(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+
+		want     notification.EgoSMS
+		wantJSON string
+		wantErr  bool
+	}{
+		{
+			name: "full with custom sender",
+			data: []byte(
+				`{"id":1,"name":"My EgoSMS Alert","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"My EgoSMS Alert\",\"egosmsUsername\":\"myuser\",\"egosmsPassword\":\"mypassword\",\"egosmsSender\":\"MYAPP\",\"egosmsPhoneNumber\":\"2567XXXXXXXX\",\"type\":\"egosms\"}"}`,
+			),
+
+			want: notification.EgoSMS{
+				Base: notification.Base{
+					ID:            1,
+					Name:          "My EgoSMS Alert",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     true,
+					ApplyExisting: true,
+				},
+				EgoSMSDetails: notification.EgoSMSDetails{
+					Username:    "myuser",
+					Password:    "mypassword",
+					Sender:      ptr.To("MYAPP"),
+					PhoneNumber: "2567XXXXXXXX",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":true,"egosmsPassword":"mypassword","egosmsPhoneNumber":"2567XXXXXXXX","egosmsSender":"MYAPP","egosmsUsername":"myuser","id":1,"isDefault":true,"name":"My EgoSMS Alert","type":"egosms","userId":1}`,
+		},
+		{
+			name: "minimal without sender",
+			data: []byte(
+				`{"id":2,"name":"Simple EgoSMS","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Simple EgoSMS\",\"egosmsUsername\":\"myuser\",\"egosmsPassword\":\"mypassword\",\"egosmsPhoneNumber\":\"2567XXXXXXXX\",\"type\":\"egosms\"}"}`,
+			),
+
+			want: notification.EgoSMS{
+				Base: notification.Base{
+					ID:            2,
+					Name:          "Simple EgoSMS",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				EgoSMSDetails: notification.EgoSMSDetails{
+					Username:    "myuser",
+					Password:    "mypassword",
+					PhoneNumber: "2567XXXXXXXX",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"egosmsPassword":"mypassword","egosmsPhoneNumber":"2567XXXXXXXX","egosmsUsername":"myuser","id":2,"isDefault":false,"name":"Simple EgoSMS","type":"egosms","userId":1}`,
+		},
+		{
+			name:    "missing config field",
+			data:    []byte(`{"id":1,"name":"x","active":true,"userId":1,"isDefault":false}`),
+			wantErr: true,
+		},
+		{
+			name:    "invalid config json",
+			data:    []byte(`{"id":1,"name":"x","active":true,"userId":1,"isDefault":false,"config":"not-json"}`),
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			egosms := notification.EgoSMS{}
+
+			err := json.Unmarshal(tc.data, &egosms)
+			if tc.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+
+			require.EqualExportedValues(t, tc.want, egosms)
+
+			data, err := json.Marshal(egosms)
+			require.NoError(t, err)
+
+			require.JSONEq(t, tc.wantJSON, string(data))
+		})
+	}
+}

--- a/notification_test.go
+++ b/notification_test.go
@@ -1035,6 +1035,60 @@ func TestNotificationCRUD(t *testing.T) {
 			},
 		},
 		{
+			name:         "EgoSMS",
+			expectedType: "egosms",
+			create: notification.EgoSMS{
+				Base: notification.Base{
+					ApplyExisting: true,
+					IsDefault:     false,
+					IsActive:      true,
+					Name:          "Test EgoSMS Created",
+				},
+				EgoSMSDetails: notification.EgoSMSDetails{
+					Username:    "myuser",
+					Password:    "mypassword",
+					Sender:      ptr.To("TESTSENDER"),
+					PhoneNumber: "+41791234567",
+				},
+			},
+			updateFunc: func(n notification.Notification) {
+				egosms, ok := n.(*notification.EgoSMS)
+				if !ok {
+					panic("failed to assert EgoSMS notification")
+				}
+
+				egosms.Name = "Test EgoSMS Updated"
+				egosms.PhoneNumber = "+41797654321"
+			},
+			verifyCreatedFunc: func(t *testing.T, actual notification.Notification, expected notification.Notification, id int64) {
+				t.Helper()
+				exp, ok := expected.(notification.EgoSMS)
+				require.True(t, ok)
+				var egosms notification.EgoSMS
+				err := actual.As(&egosms)
+				require.NoError(t, err)
+				exp.ID = id
+				exp.UserID = egosms.UserID
+				require.EqualExportedValues(t, exp, egosms)
+			},
+			createTypedFunc: func(t *testing.T, base notification.Notification) notification.Notification {
+				t.Helper()
+				var egosms notification.EgoSMS
+				err := base.As(&egosms)
+				require.NoError(t, err)
+				return &egosms
+			},
+			verifyUpdatedFunc: func(t *testing.T, actual notification.Notification, expected notification.Notification) {
+				t.Helper()
+				exp, ok := expected.(*notification.EgoSMS)
+				require.True(t, ok)
+				var egosms notification.EgoSMS
+				err := actual.As(&egosms)
+				require.NoError(t, err)
+				require.EqualExportedValues(t, *exp, egosms)
+			},
+		},
+		{
 			name:         "Mattermost",
 			expectedType: "mattermost",
 			create: notification.Mattermost{


### PR DESCRIPTION
## Summary

- Add `EgoSMS` notification provider (`egosms`) introduced upstream in Uptime Kuma v2.4.0
- Implements `EgoSMS` struct with `EgoSMSDetails` (username, password, optional sender, phone number)
- Adds marshal/unmarshal support following existing notification provider patterns

## Test plan

- [x] Unit tests for marshal/unmarshal with full config (custom sender)
- [x] Unit tests for marshal/unmarshal with minimal config (no sender)
- [x] Error cases: missing config field, invalid config JSON
- [x] Integration CRUD test in `TestNotificationCRUD` (create, update, delete round-trip)
- [x] All tests pass (`task test`)
- [x] Linting passes (`task lint`)
- [x] Formatting checked (`task fmt`)

Closes #316