### PR TITLE
feat: add support for VKTeams notifications

### DIFF
--- a/notification/notification_vkteams.go
+++ b/notification/notification_vkteams.go
@@ -1,0 +1,57 @@
+package notification
+
+import (
+	"fmt"
+)
+
+// VKTeams represents a VKTeams notification.
+type VKTeams struct {
+	Base
+	VKTeamsDetails
+}
+
+// VKTeamsDetails contains VKTeams-specific notification configuration.
+type VKTeamsDetails struct {
+	BotToken       string `json:"vkteamsBotToken"`
+	ChatID         string `json:"vkteamsChatId"`
+	BaseURL        string `json:"vkteamsBaseUrl"`
+	UseTemplate    bool   `json:"vkteamsUseTemplate"`
+	Template       string `json:"vkteamsTemplate"`
+	TemplateFormat string `json:"vkteamsTemplateFormat"`
+}
+
+// Type returns the notification type.
+func (v VKTeams) Type() string {
+	return v.VKTeamsDetails.Type()
+}
+
+// Type returns the notification type.
+func (VKTeamsDetails) Type() string {
+	return "VKTeams"
+}
+
+// String returns a string representation of the notification.
+func (v VKTeams) String() string {
+	return fmt.Sprintf("%s, %s", formatNotification(v.Base, false), formatNotification(v.VKTeamsDetails, true))
+}
+
+// UnmarshalJSON unmarshals a JSON byte slice into a notification.
+func (v *VKTeams) UnmarshalJSON(data []byte) error {
+	detail := VKTeamsDetails{}
+	base, err := unmarshalTo(data, &detail)
+	if err != nil {
+		return err
+	}
+
+	*v = VKTeams{
+		Base:           base,
+		VKTeamsDetails: detail,
+	}
+
+	return nil
+}
+
+// MarshalJSON marshals a notification into a JSON byte slice.
+func (v VKTeams) MarshalJSON() ([]byte, error) {
+	return marshalJSON(v.Base, &v.VKTeamsDetails)
+}

--- a/notification/notification_vkteams_test.go
+++ b/notification/notification_vkteams_test.go
@@ -1,0 +1,85 @@
+package notification_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/breml/go-uptime-kuma-client/notification"
+)
+
+func TestNotificationVKTeams_Unmarshal(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+
+		want     notification.VKTeams
+		wantJSON string
+	}{
+		{
+			name: "success",
+			data: []byte(
+				`{"id":1,"name":"My VKTeams Alert","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"My VKTeams Alert\",\"vkteamsBotToken\":\"001.1234567890.abcdefgh:1000000001\",\"vkteamsChatId\":\"*****@chat.agent\",\"vkteamsBaseUrl\":\"https://myteam.mail.ru\",\"vkteamsUseTemplate\":true,\"vkteamsTemplate\":\"Monitor: {monitor.name}\\nStatus: {monitor.status}\",\"vkteamsTemplateFormat\":\"MarkdownV2\",\"type\":\"VKTeams\"}"}`,
+			),
+
+			want: notification.VKTeams{
+				Base: notification.Base{
+					ID:            1,
+					Name:          "My VKTeams Alert",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     true,
+					ApplyExisting: true,
+				},
+				VKTeamsDetails: notification.VKTeamsDetails{
+					BotToken:       "001.1234567890.abcdefgh:1000000001",
+					ChatID:         "*****@chat.agent",
+					BaseURL:        "https://myteam.mail.ru",
+					UseTemplate:    true,
+					Template:       "Monitor: {monitor.name}\nStatus: {monitor.status}",
+					TemplateFormat: "MarkdownV2",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":true,"id":1,"isDefault":true,"name":"My VKTeams Alert","vkteamsBotToken":"001.1234567890.abcdefgh:1000000001","vkteamsChatId":"*****@chat.agent","vkteamsBaseUrl":"https://myteam.mail.ru","vkteamsUseTemplate":true,"vkteamsTemplate":"Monitor: {monitor.name}\nStatus: {monitor.status}","vkteamsTemplateFormat":"MarkdownV2","type":"VKTeams","userId":1}`,
+		},
+		{
+			name: "minimal",
+			data: []byte(
+				`{"id":2,"name":"Simple VKTeams","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Simple VKTeams\",\"vkteamsBotToken\":\"001.1234567890.abcdefgh:1000000001\",\"vkteamsChatId\":\"*****@chat.agent\",\"type\":\"VKTeams\"}"}`,
+			),
+
+			want: notification.VKTeams{
+				Base: notification.Base{
+					ID:            2,
+					Name:          "Simple VKTeams",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				VKTeamsDetails: notification.VKTeamsDetails{
+					BotToken: "001.1234567890.abcdefgh:1000000001",
+					ChatID:   "*****@chat.agent",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"id":2,"isDefault":false,"name":"Simple VKTeams","vkteamsBotToken":"001.1234567890.abcdefgh:1000000001","vkteamsChatId":"*****@chat.agent","vkteamsBaseUrl":"","vkteamsUseTemplate":false,"vkteamsTemplate":"","vkteamsTemplateFormat":"","type":"VKTeams","userId":1}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			vkteams := notification.VKTeams{}
+
+			err := json.Unmarshal(tc.data, &vkteams)
+			require.NoError(t, err)
+
+			require.EqualExportedValues(t, tc.want, vkteams)
+
+			data, err := json.Marshal(vkteams)
+			require.NoError(t, err)
+
+			require.JSONEq(t, tc.wantJSON, string(data))
+		})
+	}
+}

--- a/notification_test.go
+++ b/notification_test.go
@@ -4834,6 +4834,62 @@ func TestNotificationCRUD(t *testing.T) {
 			},
 		},
 		{
+			name:         "VKTeams",
+			expectedType: "VKTeams",
+			create: notification.VKTeams{
+				Base: notification.Base{
+					ApplyExisting: true,
+					IsDefault:     false,
+					IsActive:      true,
+					Name:          "Test VKTeams Created",
+				},
+				VKTeamsDetails: notification.VKTeamsDetails{
+					BotToken:       "001.1234567890.abcdefgh:1000000001",
+					ChatID:         "*****@chat.agent",
+					BaseURL:        "https://myteam.mail.ru",
+					UseTemplate:    true,
+					Template:       "Monitor: {monitor.name}\nStatus: {monitor.status}",
+					TemplateFormat: "MarkdownV2",
+				},
+			},
+			updateFunc: func(n notification.Notification) {
+				vkteams, ok := n.(*notification.VKTeams)
+				if !ok {
+					panic("failed to assert VKTeams notification")
+				}
+
+				vkteams.Name = "Test VKTeams Updated"
+				vkteams.ChatID = "*****@updated.agent"
+			},
+			verifyCreatedFunc: func(t *testing.T, actual notification.Notification, expected notification.Notification, id int64) {
+				t.Helper()
+				exp, ok := expected.(notification.VKTeams)
+				require.True(t, ok)
+				var vkteams notification.VKTeams
+				err := actual.As(&vkteams)
+				require.NoError(t, err)
+				exp.ID = id
+				exp.UserID = vkteams.UserID
+				require.EqualExportedValues(t, exp, vkteams)
+			},
+			createTypedFunc: func(t *testing.T, base notification.Notification) notification.Notification {
+				t.Helper()
+				var vkteams notification.VKTeams
+				err := base.As(&vkteams)
+				require.NoError(t, err)
+				return &vkteams
+			},
+			verifyUpdatedFunc: func(t *testing.T, actual notification.Notification, expected notification.Notification) {
+				t.Helper()
+				exp, ok := expected.(*notification.VKTeams)
+				require.True(t, ok)
+				var vkteams notification.VKTeams
+				err := actual.As(&vkteams)
+				require.NoError(t, err)
+				require.EqualExportedValues(t, *exp, vkteams)
+			},
+		},
+		{
 			name:         "ZohoCliq",
 			expectedType: "ZohoCliq",
 			create: notification.ZohoCliq{


### PR DESCRIPTION
## Summary
- Add the `VKTeams` notification provider, introduced upstream in Uptime Kuma v2.4.0 (louislam/uptime-kuma#7365)
- VKTeams sends bot messages via the VK Teams (Myteam) bot API and supports custom message templates (modeled on the `Telegram` provider's `UseTemplate`/`Template`/`TemplateParseMode` pattern)
- `Type()` returns `"VKTeams"` (PascalCase), matching the registration name in `server/notification.js`

## Test plan
- [x] `task fmt` — no changes
- [x] `task lint` — 0 issues
- [x] `task test-e2e` — full suite passes, including new `TestNotificationVKTeams_Unmarshal` unit test and `TestNotificationCRUD/VKTeams` integration CRUD test

Closes #317