### PR TITLE
feat(client): tolerate missing ready events and surface transport errors

### DIFF
--- a/client.go
+++ b/client.go
@@ -256,6 +256,12 @@ func WithConnectTimeout(timeout time.Duration) Option {
 // statusPageList; the remaining known events (e.g. maintenanceList, apiKeyList)
 // are best-effort. Use this to widen or narrow the required set for servers or
 // reverse proxies that emit a different subset of events.
+//
+// An optional event that never arrives (server never sends it, or a proxy
+// drops it) leaves the corresponding client state (e.g. GetMaintenances,
+// GetProxyList, GetDockerHostList) populated as empty, indistinguishable from
+// a genuinely empty list on the server. A warning is logged in this case;
+// widen readyEvents to require an event if its state must be trustworthy.
 func WithReadyEvents(events ...string) Option {
 	return func(c *Client) {
 		c.readyEvents = events
@@ -667,6 +673,13 @@ func New(ctx context.Context, baseURL string, username string, password string, 
 	// A non-nil return is the real transport/handshake error (connection
 	// refused, TLS failure, proxy not forwarding the WebSocket upgrade), which
 	// we surface immediately instead of waiting out the timeout.
+	//
+	// This must use ctx, not ctxWithConnectTimeout: the socket.io client
+	// stores the context it receives here and keeps reading from the
+	// connection until that context is done, so it governs the lifetime of
+	// the whole connection, not just the initial dial. ctxWithConnectTimeout
+	// is deferred-canceled as soon as New() returns, which would tear down a
+	// freshly established connection immediately after a successful connect.
 	connectErr := make(chan error, 1)
 	go func() {
 		connectErr <- client.Connect(ctx)
@@ -699,6 +712,24 @@ connectLoop:
 				}
 
 			default:
+				// The dial is still in flight (it uses ctx, so this timeout
+				// does not abort it). Drain connectErr in the background so
+				// a late failure is not silently discarded, and so a late
+				// success (a connection nothing now owns, since New() is
+				// about to return without a *Client) is disconnected rather
+				// than leaked.
+				go func() {
+					dialErr := <-connectErr
+					if dialErr != nil {
+						c.socketioLogger.Warnf("New: dial failed after connect timeout: %s", dialErr)
+						return
+					}
+
+					disconnectErr := c.Disconnect()
+					if disconnectErr != nil {
+						c.socketioLogger.Warnf("New: disconnect orphaned late connection: %s", disconnectErr)
+					}
+				}()
 			}
 
 			return nil, fmt.Errorf("connect to server: %w", ctxWithConnectTimeout.Err())
@@ -757,20 +788,14 @@ connectLoop:
 		select {
 		case <-ready:
 			// All required events received. Give the best-effort optional
-			// events a short grace window to arrive (and populate the state
-			// cache) before returning.
-			if c.readyGracePeriod > 0 {
-				graceTimer := time.NewTimer(c.readyGracePeriod)
-
-				select {
-				case <-optionalReady:
-				case <-graceTimer.C:
-				case <-ctx.Done():
-					graceTimer.Stop()
-					return nil, fmt.Errorf("wait for ready: %w", ctx.Err())
-				}
-
-				graceTimer.Stop()
+			// events their grace window to arrive (and populate the state
+			// cache) before returning, bounded by connectTimeoutDone so it
+			// cannot push New past the caller's WithConnectTimeout budget.
+			err = c.awaitOptionalReadyEvents(
+				ctx, "New", &updateSeenMu, optionalSeen, optionalReady, connectTimeoutDone,
+			)
+			if err != nil {
+				return nil, fmt.Errorf("wait for ready: %w", err)
 			}
 
 			closeOnErr = false
@@ -944,22 +969,12 @@ func (c *Client) Resync(ctx context.Context) error {
 		return fmt.Errorf("resync: %w (missing events: %s)", ctx.Err(), strings.Join(missing, ", "))
 	}
 
-	// The required lists are in. Give the best-effort ones the same short
-	// grace window New grants them, so the cache they feed is refreshed too on
-	// a server that does emit them.
-	if c.readyGracePeriod > 0 {
-		graceTimer := time.NewTimer(c.readyGracePeriod)
-
-		select {
-		case <-optionalDone:
-		case <-graceTimer.C:
-		case <-ctx.Done():
-			graceTimer.Stop()
-
-			return fmt.Errorf("resync: %w", ctx.Err())
-		}
-
-		graceTimer.Stop()
+	// The required lists are in. Give the best-effort ones the same grace
+	// window New grants them, so the cache they feed is refreshed too on a
+	// server that does emit them.
+	err = c.awaitOptionalReadyEvents(ctx, "Resync", &pendingMu, optionalPending, optionalDone, nil)
+	if err != nil {
+		return fmt.Errorf("resync: %w", err)
 	}
 
 	return nil
@@ -994,6 +1009,59 @@ func (c *Client) splitReadyEvents() (required map[string]struct{}, optional map[
 	}
 
 	return required, optional
+}
+
+// awaitOptionalReadyEvents gives the best-effort ready events the ready grace
+// period to arrive, so the state they populate is current when the caller named
+// by caller returns, and warns about the ones that never came. optionalMu
+// guards optional.
+//
+// abort cuts the wait short as a success, which is how New keeps the grace
+// period within the caller's WithConnectTimeout budget; a nil abort never
+// fires. Only the context being done is an error: the required events are
+// already in, so nothing else here can fail the caller.
+func (c *Client) awaitOptionalReadyEvents(
+	ctx context.Context,
+	caller string,
+	optionalMu *sync.Mutex,
+	optional map[string]struct{},
+	optionalReady <-chan struct{},
+	abort <-chan struct{},
+) error {
+	if c.readyGracePeriod > 0 {
+		graceTimer := time.NewTimer(c.readyGracePeriod)
+
+		select {
+		case <-optionalReady:
+		case <-graceTimer.C:
+		case <-abort:
+		case <-ctx.Done():
+			graceTimer.Stop()
+
+			return fmt.Errorf("optional ready events: %w", ctx.Err())
+		}
+
+		graceTimer.Stop()
+	}
+
+	optionalMu.Lock()
+	missing := make([]string, 0, len(optional))
+
+	for event := range optional {
+		missing = append(missing, event)
+	}
+	optionalMu.Unlock()
+
+	if len(missing) > 0 {
+		slices.Sort(missing)
+		c.socketioLogger.Warnf(
+			"%s: optional ready events did not arrive within the grace period: %s",
+			caller,
+			strings.Join(missing, ", "),
+		)
+	}
+
+	return nil
 }
 
 type ackResponse struct {

--- a/client.go
+++ b/client.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"net/http"
 	"slices"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -219,6 +218,10 @@ type Client struct {
 	// sessionToken is the JWT the server handed out at login. It is what
 	// Resync logs in with, see there.
 	sessionToken string
+
+	// readyEventsMissing are the best-effort ready events the server did not
+	// emit while New was connecting, see MissingReadyEvents.
+	readyEventsMissing []string
 }
 
 // Option is a functional option for configuring a Client.
@@ -260,11 +263,16 @@ func WithConnectTimeout(timeout time.Duration) Option {
 // An optional event that never arrives (server never sends it, or a proxy
 // drops it) leaves the corresponding client state (e.g. GetMaintenances,
 // GetProxyList, GetDockerHostList) populated as empty, indistinguishable from
-// a genuinely empty list on the server. A warning is logged in this case;
-// widen readyEvents to require an event if its state must be trustworthy.
+// a genuinely empty list on the server. MissingReadyEvents names those events,
+// and a warning goes to the logger WithLogLevel configures, which is silent by
+// default. Widen readyEvents to require an event if its state must be
+// trustworthy.
+//
+// New rejects an event that is not one of the known ready events, rather than
+// waiting out the connect timeout for something the server never emits.
 func WithReadyEvents(events ...string) Option {
 	return func(c *Client) {
-		c.readyEvents = events
+		c.readyEvents = slices.Clone(events)
 	}
 }
 
@@ -453,6 +461,11 @@ func New(ctx context.Context, baseURL string, username string, password string, 
 		opt(c)
 	}
 
+	unknown := unknownReadyEvents(c.readyEvents)
+	if len(unknown) > 0 {
+		return nil, fmt.Errorf("ready events: unknown: %s", strings.Join(unknown, ", "))
+	}
+
 	ctxWithConnectTimeout := ctx
 
 	// connectTimeoutDone is non-nil only when WithConnectTimeout is
@@ -486,51 +499,10 @@ func New(ctx context.Context, baseURL string, username string, password string, 
 
 	c.socketioClient = client
 
-	// requiredSeen holds the events New must receive before returning. The
-	// remaining known events are optional: they populate optionalSeen and are
-	// waited for only during the ready grace period.
-	updateSeenMu := sync.Mutex{}
-	updateSeenMu.Lock()
-	requiredSeen, optionalSeen := c.splitReadyEvents()
-	updateSeenMu.Unlock()
+	gate := newReadyGate(c.splitReadyEvents())
 
-	ready := make(chan struct{})
-	closeReady := sync.OnceFunc(func() {
-		close(ready)
-	})
-	defer closeReady()
-
-	optionalReady := make(chan struct{})
-	closeOptionalReady := sync.OnceFunc(func() {
-		close(optionalReady)
-	})
-	defer closeOptionalReady()
-
-	// Close the ready gates up front when their event sets are empty, so New
-	// does not block on events it will never receive (e.g. an empty required
-	// set from WithReadyEvents()).
-	if len(requiredSeen) == 0 {
-		closeReady()
-	}
-
-	if len(optionalSeen) == 0 {
-		closeOptionalReady()
-	}
-
-	c.updates.AddListener(func(_ context.Context, s string) {
-		updateSeenMu.Lock()
-		defer updateSeenMu.Unlock()
-
-		delete(requiredSeen, s)
-		delete(optionalSeen, s)
-
-		if len(requiredSeen) == 0 {
-			closeReady()
-		}
-
-		if len(optionalSeen) == 0 {
-			closeOptionalReady()
-		}
+	c.updates.AddListener(func(_ context.Context, event string) {
+		gate.observe(event)
 	}, "connect-ready")
 	defer c.updates.RemoveListener("connect-ready")
 
@@ -668,18 +640,12 @@ func New(ctx context.Context, baseURL string, username string, password string, 
 		}
 	})
 
-	// client.Connect returns nil as soon as the transport is running and the
-	// handshake has been requested; the "connect" event follows asynchronously.
-	// A non-nil return is the real transport/handshake error (connection
-	// refused, TLS failure, proxy not forwarding the WebSocket upgrade), which
-	// we surface immediately instead of waiting out the timeout.
-	//
-	// This must use ctx, not ctxWithConnectTimeout: the socket.io client
-	// stores the context it receives here and keeps reading from the
-	// connection until that context is done, so it governs the lifetime of
-	// the whole connection, not just the initial dial. ctxWithConnectTimeout
-	// is deferred-canceled as soon as New() returns, which would tear down a
-	// freshly established connection immediately after a successful connect.
+	// client.Connect returns as soon as the transport is running and the
+	// handshake has been requested; a non-nil error is the real transport
+	// failure, which is surfaced instead of waiting out the timeout. It gets
+	// ctx and not ctxWithConnectTimeout, because the socket.io client keeps
+	// reading from the connection until that context is done and
+	// ctxWithConnectTimeout is canceled as soon as New returns.
 	connectErr := make(chan error, 1)
 	go func() {
 		connectErr <- client.Connect(ctx)
@@ -696,40 +662,22 @@ connectLoop:
 				return nil, fmt.Errorf("connect to server: %w", err)
 			}
 
-			// Connect succeeded; keep waiting for the connect event. Setting
-			// connectErr to nil makes this case block forever.
+			// The dial returned; keep waiting for the connect event. Setting
+			// connectErr to nil makes this case block forever, and marks the
+			// channel as spent by a transport that is up.
 			connectErr = nil
 
 		case <-ctx.Done():
 			return nil, fmt.Errorf("connect to server: %w", ctx.Err())
 
 		case <-ctxWithConnectTimeout.Done():
-			// Prefer a real transport error if one is already available.
-			select {
-			case err := <-connectErr:
-				if err != nil {
-					return nil, fmt.Errorf("connect to server: %w", err)
+			if connectErr == nil {
+				c.disconnectOrphan()
+			} else {
+				dialErr := c.abandonDial(connectErr)
+				if dialErr != nil {
+					return nil, fmt.Errorf("connect to server: %w", dialErr)
 				}
-
-			default:
-				// The dial is still in flight (it uses ctx, so this timeout
-				// does not abort it). Drain connectErr in the background so
-				// a late failure is not silently discarded, and so a late
-				// success (a connection nothing now owns, since New() is
-				// about to return without a *Client) is disconnected rather
-				// than leaked.
-				go func() {
-					dialErr := <-connectErr
-					if dialErr != nil {
-						c.socketioLogger.Warnf("New: dial failed after connect timeout: %s", dialErr)
-						return
-					}
-
-					disconnectErr := c.Disconnect()
-					if disconnectErr != nil {
-						c.socketioLogger.Warnf("New: disconnect orphaned late connection: %s", disconnectErr)
-					}
-				}()
 			}
 
 			return nil, fmt.Errorf("connect to server: %w", ctxWithConnectTimeout.Err())
@@ -784,82 +732,73 @@ connectLoop:
 		}
 	}
 
+	// Both success paths hand the client over through returnReady, so neither
+	// can skip the grace window the best-effort events get. connectTimeoutDone
+	// keeps that wait inside the caller's WithConnectTimeout budget.
+	returnReady := func() *Client {
+		c.awaitOptionalReadyEvents(ctx, "New", gate, connectTimeoutDone)
+		c.setMissingReadyEvents(gate.missingOptional())
+
+		closeOnErr = false
+
+		return c
+	}
+
 	for {
+		// A server that needs setup says so right after the connect, while a
+		// required set that is empty (see WithReadyEvents) opens the ready gate
+		// before that. Checking setup first keeps it from losing that race and
+		// handing back a client for a server that is not set up.
 		select {
-		case <-ready:
-			// All required events received. Give the best-effort optional
-			// events their grace window to arrive (and populate the state
-			// cache) before returning, bounded by connectTimeoutDone so it
-			// cannot push New past the caller's WithConnectTimeout budget.
-			err = c.awaitOptionalReadyEvents(
-				ctx, "New", &updateSeenMu, optionalSeen, optionalReady, connectTimeoutDone,
-			)
-			if err != nil {
-				return nil, fmt.Errorf("wait for ready: %w", err)
-			}
-
-			closeOnErr = false
-			return c, nil
-
 		case <-setupRequired:
-			setupRequired = nil
+			// Handled below the select.
 
-			if !c.autosetup {
-				return nil, errors.New("server does require setup, but autosetup is disabled")
-			}
-
-			_, err := c.syncEmit(ctxWithConnectTimeout, "setup", username, password)
-			if err != nil {
-				return nil, fmt.Errorf("setup: %w", err)
-			}
-
-			loginResponse, err := c.syncEmit(
-				ctxWithConnectTimeout,
-				"login",
-				map[string]any{"username": username, "password": password, "token": ""},
-			)
-			if err != nil {
-				return nil, fmt.Errorf("login: %w", err)
-			}
-
-			c.setSessionToken(loginResponse.Token)
-
-		case <-ctx.Done():
-			return nil, fmt.Errorf("wait for ready: %w", ctx.Err())
-
-		case <-connectTimeoutDone:
-			// ctxWithConnectTimeout is derived from ctx, so its Done channel
-			// closes whenever the parent ctx is cancelled too. Prefer the
-			// parent's error in that case to avoid a misleading
-			// "missing events" message on an ordinary cancellation.
-			if ctx.Err() != nil {
-				return nil, fmt.Errorf("wait for ready: %w", ctx.Err())
-			}
-
-			// If all ready events arrived at the exact same instant as the
-			// timeout, prefer the success path over the error path.
+		default:
 			select {
-			case <-ready:
-				closeOnErr = false
-				return c, nil
+			case <-gate.requiredDone:
+				return returnReady(), nil
 
-			default:
+			case <-setupRequired:
+				// Handled below the select.
+
+			case <-ctx.Done():
+				return nil, fmt.Errorf("wait for ready: %w", ctx.Err())
+
+			case <-connectTimeoutDone:
+				// ctxWithConnectTimeout is derived from ctx, so its Done
+				// channel closes whenever the parent ctx is cancelled too.
+				// Prefer the parent's error in that case to avoid a misleading
+				// "missing events" message on an ordinary cancellation.
+				if ctx.Err() != nil {
+					return nil, fmt.Errorf("wait for ready: %w", ctx.Err())
+				}
+
+				// If all ready events arrived at the exact same instant as the
+				// timeout, prefer the success path over the error path.
+				select {
+				case <-gate.requiredDone:
+					return returnReady(), nil
+
+				default:
+				}
+
+				return nil, fmt.Errorf(
+					"wait for ready: %w (missing events: %s)",
+					ctxWithConnectTimeout.Err(),
+					strings.Join(gate.missingRequired(), ", "),
+				)
 			}
+		}
 
-			updateSeenMu.Lock()
-			missing := make([]string, 0, len(requiredSeen))
-			for event := range requiredSeen {
-				missing = append(missing, event)
-			}
-			updateSeenMu.Unlock()
+		setupRequired = nil
 
-			sort.Strings(missing)
+		if !c.autosetup {
+			return nil, errors.New("server does require setup, but autosetup is disabled")
+		}
 
-			return nil, fmt.Errorf(
-				"wait for ready: %w (missing events: %s)",
-				ctxWithConnectTimeout.Err(),
-				strings.Join(missing, ", "),
-			)
+		err = c.runSetup(ctxWithConnectTimeout, username, password)
+		if err != nil {
+			return nil, err
 		}
 	}
 }
@@ -888,10 +827,10 @@ func (c *Client) Disconnect() error {
 // created without credentials therefore cannot resync.
 //
 // Which lists Resync waits for follows New: the events configured with
-// WithReadyEvents are required, the remaining known events are best-effort and
-// only awaited for the ready grace period, because a server (or a proxy in
-// front of it) that never emits an event during New does not emit it here
-// either.
+// WithReadyEvents are required and the remaining known events are best-effort,
+// awaited for the ready grace period. The best-effort events New never saw are
+// skipped altogether, because a server (or a proxy in front of it) that does
+// not emit one while connecting does not emit it here either.
 func (c *Client) Resync(ctx context.Context) error {
 	c.mu.Lock()
 	token := c.sessionToken
@@ -901,48 +840,13 @@ func (c *Client) Resync(ctx context.Context) error {
 		return errors.New("resync: no session token, the client was created without credentials")
 	}
 
-	pendingMu := sync.Mutex{}
-	pending, optionalPending := c.splitReadyEvents()
-
-	done := make(chan struct{})
-	closeDone := sync.OnceFunc(func() {
-		close(done)
-	})
-	defer closeDone()
-
-	optionalDone := make(chan struct{})
-	closeOptionalDone := sync.OnceFunc(func() {
-		close(optionalDone)
-	})
-	defer closeOptionalDone()
-
-	// Close the gates up front when their event sets are empty, so Resync does
-	// not block on events it will never receive.
-	if len(pending) == 0 {
-		closeDone()
-	}
-
-	if len(optionalPending) == 0 {
-		closeOptionalDone()
-	}
+	gate := newReadyGate(c.resyncReadyEvents())
 
 	// Registered before the command is emitted, so that no list can arrive
 	// unnoticed between the two.
 	listenerID := uuid.New()
 	c.updates.AddListener(func(_ context.Context, update string) {
-		pendingMu.Lock()
-		defer pendingMu.Unlock()
-
-		delete(pending, update)
-		delete(optionalPending, update)
-
-		if len(pending) == 0 {
-			closeDone()
-		}
-
-		if len(optionalPending) == 0 {
-			closeOptionalDone()
-		}
+		gate.observe(update)
 	}, listenerID.String())
 
 	defer c.updates.RemoveListener(listenerID.String())
@@ -953,31 +857,114 @@ func (c *Client) Resync(ctx context.Context) error {
 	}
 
 	select {
-	case <-done:
+	case <-gate.requiredDone:
 
 	case <-ctx.Done():
-		pendingMu.Lock()
-		missing := make([]string, 0, len(pending))
-
-		for event := range pending {
-			missing = append(missing, event)
-		}
-		pendingMu.Unlock()
-
-		slices.Sort(missing)
-
-		return fmt.Errorf("resync: %w (missing events: %s)", ctx.Err(), strings.Join(missing, ", "))
+		return fmt.Errorf(
+			"resync: %w (missing events: %s)",
+			ctx.Err(),
+			strings.Join(gate.missingRequired(), ", "),
+		)
 	}
 
 	// The required lists are in. Give the best-effort ones the same grace
-	// window New grants them, so the cache they feed is refreshed too on a
-	// server that does emit them.
-	err = c.awaitOptionalReadyEvents(ctx, "Resync", &pendingMu, optionalPending, optionalDone, nil)
-	if err != nil {
-		return fmt.Errorf("resync: %w", err)
+	// window New grants them, so the cache they feed is refreshed too.
+	c.awaitOptionalReadyEvents(ctx, "Resync", gate, nil)
+
+	return nil
+}
+
+// MissingReadyEvents returns the best-effort ready events the server did not
+// emit while New was connecting, sorted.
+//
+// The state such an event carries (maintenances, proxies, Docker hosts, API
+// keys) is empty in the local cache for a reason the getters cannot tell apart
+// from a genuinely empty server, so a caller that depends on one of them can
+// check here — or require the event with WithReadyEvents and have New fail
+// instead.
+func (c *Client) MissingReadyEvents() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return slices.Clone(c.readyEventsMissing)
+}
+
+// abandonDial cleans up the dial New walks away from when the connect timeout
+// fires, and returns the transport error if the dial already failed with one.
+// New returns no *Client on this path, so a connection that was, or still gets,
+// established has no owner: it is disconnected instead of left running until
+// ctx is done.
+func (c *Client) abandonDial(connectErr <-chan error) error {
+	select {
+	case err := <-connectErr:
+		if err != nil {
+			return err
+		}
+
+		c.disconnectOrphan()
+
+	default:
+		// The dial is still in flight (it uses ctx, so this timeout does not
+		// abort it). Drain connectErr in the background so a late failure is
+		// not silently discarded and a late success is not leaked.
+		go func() {
+			err := <-connectErr
+			if err != nil {
+				c.socketioLogger.Warnf("New: dial failed after connect timeout: %s", err)
+
+				return
+			}
+
+			c.disconnectOrphan()
+		}()
 	}
 
 	return nil
+}
+
+// disconnectOrphan closes a connection no caller holds a handle to. The close
+// is best-effort and asynchronous, because Disconnect waits for the transport
+// and the message loop to wind down, which a server that leaves a long poll
+// hanging can stall for as long as it likes — and the caller it would block is
+// on its way out.
+func (c *Client) disconnectOrphan() {
+	go func() {
+		err := c.Disconnect()
+		if err != nil {
+			c.socketioLogger.Warnf("disconnect orphaned connection: %s", err)
+		}
+	}()
+}
+
+// runSetup sets the server up and logs in again afterwards, which is what a
+// server that answers the connect with a setup event asks for.
+func (c *Client) runSetup(ctx context.Context, username string, password string) error {
+	_, err := c.syncEmit(ctx, "setup", username, password)
+	if err != nil {
+		return fmt.Errorf("setup: %w", err)
+	}
+
+	loginResponse, err := c.syncEmit(
+		ctx,
+		"login",
+		map[string]any{"username": username, "password": password, "token": ""},
+	)
+	if err != nil {
+		return fmt.Errorf("login: %w", err)
+	}
+
+	c.setSessionToken(loginResponse.Token)
+
+	return nil
+}
+
+// setMissingReadyEvents records what New waited for in vain, see
+// MissingReadyEvents and resyncReadyEvents.
+func (c *Client) setMissingReadyEvents(missing []string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.readyEventsMissing = missing
 }
 
 // setSessionToken records the JWT a login answered with, see Resync.
@@ -1011,57 +998,160 @@ func (c *Client) splitReadyEvents() (required map[string]struct{}, optional map[
 	return required, optional
 }
 
+// resyncReadyEvents is splitReadyEvents for a resync: the best-effort events
+// the server did not emit while New was connecting are dropped, because it does
+// not emit them here either and waiting them out would cost every resync the
+// full ready grace period for nothing.
+func (c *Client) resyncReadyEvents() (required map[string]struct{}, optional map[string]struct{}) {
+	required, optional = c.splitReadyEvents()
+
+	for _, event := range c.MissingReadyEvents() {
+		delete(optional, event)
+	}
+
+	return required, optional
+}
+
+// unknownReadyEvents returns the events that are not among knownReadyEvents,
+// sorted.
+func unknownReadyEvents(events []string) []string {
+	unknown := make([]string, 0, len(events))
+
+	for _, event := range events {
+		if !slices.Contains(knownReadyEvents, event) {
+			unknown = append(unknown, event)
+		}
+	}
+
+	slices.Sort(unknown)
+
+	return unknown
+}
+
 // awaitOptionalReadyEvents gives the best-effort ready events the ready grace
 // period to arrive, so the state they populate is current when the caller named
-// by caller returns, and warns about the ones that never came. optionalMu
-// guards optional.
+// by caller returns, and warns about the ones that never came. A grace period
+// of zero skips the wait, and with it the warning: the caller asked to return
+// as soon as the required events are in, which is too early to tell an event
+// that is missing from one that is merely late.
 //
-// abort cuts the wait short as a success, which is how New keeps the grace
-// period within the caller's WithConnectTimeout budget; a nil abort never
-// fires. Only the context being done is an error: the required events are
-// already in, so nothing else here can fail the caller.
+// The wait cannot fail the caller: the required events are already in, so every
+// way out of it is a success. Besides the optional events arriving and the
+// grace period elapsing, those are a done context and abort, which is how New
+// keeps the wait within the caller's WithConnectTimeout budget; a nil abort
+// never fires.
 func (c *Client) awaitOptionalReadyEvents(
 	ctx context.Context,
 	caller string,
-	optionalMu *sync.Mutex,
-	optional map[string]struct{},
-	optionalReady <-chan struct{},
+	gate *readyGate,
 	abort <-chan struct{},
-) error {
-	if c.readyGracePeriod > 0 {
-		graceTimer := time.NewTimer(c.readyGracePeriod)
-
-		select {
-		case <-optionalReady:
-		case <-graceTimer.C:
-		case <-abort:
-		case <-ctx.Done():
-			graceTimer.Stop()
-
-			return fmt.Errorf("optional ready events: %w", ctx.Err())
-		}
-
-		graceTimer.Stop()
+) {
+	if c.readyGracePeriod <= 0 {
+		return
 	}
 
-	optionalMu.Lock()
-	missing := make([]string, 0, len(optional))
+	graceTimer := time.NewTimer(c.readyGracePeriod)
+	defer graceTimer.Stop()
 
-	for event := range optional {
-		missing = append(missing, event)
+	select {
+	case <-gate.optionalDone:
+	case <-graceTimer.C:
+	case <-abort:
+	case <-ctx.Done():
 	}
-	optionalMu.Unlock()
 
+	missing := gate.missingOptional()
 	if len(missing) > 0 {
-		slices.Sort(missing)
 		c.socketioLogger.Warnf(
 			"%s: optional ready events did not arrive within the grace period: %s",
 			caller,
 			strings.Join(missing, ", "),
 		)
 	}
+}
 
-	return nil
+// readyGate tracks the initial list events a login answers with, so New and
+// Resync can wait for the required ones and give the best-effort rest a grace
+// period. Events are struck off both sets as they arrive, and a set that runs
+// empty opens its gate.
+type readyGate struct {
+	mu       sync.Mutex
+	required map[string]struct{}
+	optional map[string]struct{}
+
+	requiredDone  chan struct{}
+	optionalDone  chan struct{}
+	closeRequired func()
+	closeOptional func()
+}
+
+func newReadyGate(required map[string]struct{}, optional map[string]struct{}) *readyGate {
+	gate := &readyGate{
+		required:     required,
+		optional:     optional,
+		requiredDone: make(chan struct{}),
+		optionalDone: make(chan struct{}),
+	}
+
+	gate.closeRequired = sync.OnceFunc(func() { close(gate.requiredDone) })
+	gate.closeOptional = sync.OnceFunc(func() { close(gate.optionalDone) })
+
+	// A set that starts out empty has nothing to wait for, e.g. the required
+	// set of a WithReadyEvents() with no events at all. No listener exists yet,
+	// so this needs no lock.
+	gate.openEmptyGates()
+
+	return gate
+}
+
+// observe strikes event off both sets and opens the gates that ran empty.
+func (g *readyGate) observe(event string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	delete(g.required, event)
+	delete(g.optional, event)
+
+	g.openEmptyGates()
+}
+
+// openEmptyGates opens the gate of every set that has nothing left to wait for.
+// Every caller but newReadyGate holds g.mu.
+func (g *readyGate) openEmptyGates() {
+	if len(g.required) == 0 {
+		g.closeRequired()
+	}
+
+	if len(g.optional) == 0 {
+		g.closeOptional()
+	}
+}
+
+// missingRequired returns the required events that have not arrived, sorted.
+func (g *readyGate) missingRequired() []string {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	return sortedEvents(g.required)
+}
+
+// missingOptional returns the best-effort events that have not arrived, sorted.
+func (g *readyGate) missingOptional() []string {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	return sortedEvents(g.optional)
+}
+
+func sortedEvents(events map[string]struct{}) []string {
+	sorted := make([]string, 0, len(events))
+	for event := range events {
+		sorted = append(sorted, event)
+	}
+
+	slices.Sort(sorted)
+
+	return sorted
 }
 
 type ackResponse struct {

--- a/client.go
+++ b/client.go
@@ -19,7 +19,6 @@ import (
 	"github.com/maldikhan/go.socket.io/socket.io/v5/client/emit"
 	"github.com/maldikhan/go.socket.io/utils"
 	"github.com/maniartech/signals"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/breml/go-uptime-kuma-client/dockerhost"
 	"github.com/breml/go-uptime-kuma-client/maintenance"
@@ -145,6 +144,40 @@ func LogLevel(level string) int {
 //nolint:gochecknoglobals // empty is used as a placeholder value in maps to represent set membership.
 var empty = struct{}{}
 
+// knownReadyEvents lists all initial list events an Uptime Kuma server may emit
+// after login. The subset a given server actually emits depends on its version
+// and on any reverse proxy in front of it (older versions and some proxies never
+// emit certain events, e.g. apiKeyList).
+//
+//nolint:gochecknoglobals // package-level constant list of the known ready events.
+var knownReadyEvents = []string{
+	"monitorList",
+	"notificationList",
+	"statusPageList",
+	"maintenanceList",
+	"proxyList",
+	"dockerHostList",
+	"apiKeyList",
+}
+
+// defaultReadyEvents is the set of events New waits for before returning. These
+// are the primary entities this library manages and are emitted by all
+// supported Uptime Kuma versions. The remaining knownReadyEvents are treated as
+// best-effort: they are cached when they arrive, but never block New.
+//
+//nolint:gochecknoglobals // package-level default for the required ready events.
+var defaultReadyEvents = []string{
+	"monitorList",
+	"notificationList",
+	"statusPageList",
+}
+
+// defaultReadyGracePeriod bounds how long New waits for the best-effort
+// (optional) ready events once all required events have been received. On a
+// healthy server all events arrive within milliseconds, so this only elapses
+// when an optional event is genuinely never sent.
+const defaultReadyGracePeriod = 500 * time.Millisecond
+
 type entryPageResponse struct {
 	Type string `json:"type"`
 }
@@ -170,28 +203,14 @@ type state struct {
 	dockerHosts   []dockerhost.DockerHost
 }
 
-// pendingListEvents returns the update events that carry the lists the local
-// state cache is built from, as a set to strike them off as they arrive. The
-// server sends all of them after a login, which is what New waits for and what
-// Resync repeats.
-func pendingListEvents() map[string]struct{} {
-	return map[string]struct{}{
-		"monitorList":      empty,
-		"maintenanceList":  empty,
-		"notificationList": empty,
-		"statusPageList":   empty,
-		"proxyList":        empty,
-		"dockerHostList":   empty,
-		"apiKeyList":       empty,
-	}
-}
-
 // Client represents a connection to an Uptime Kuma server.
 type Client struct {
 	socketioClient               *socketio.Client
 	socketioClientConnectTimeout time.Duration
 	socketioLogger               socketio.Logger
 	autosetup                    bool
+	readyEvents                  []string
+	readyGracePeriod             time.Duration
 
 	mu      *sync.Mutex
 	updates signals.Signal[string]
@@ -229,6 +248,27 @@ func WithLogLevel(level int) Option {
 func WithConnectTimeout(timeout time.Duration) Option {
 	return func(c *Client) {
 		c.socketioClientConnectTimeout = timeout
+	}
+}
+
+// WithReadyEvents overrides the set of initial list events New waits for before
+// returning. By default New waits for monitorList, notificationList and
+// statusPageList; the remaining known events (e.g. maintenanceList, apiKeyList)
+// are best-effort. Use this to widen or narrow the required set for servers or
+// reverse proxies that emit a different subset of events.
+func WithReadyEvents(events ...string) Option {
+	return func(c *Client) {
+		c.readyEvents = events
+	}
+}
+
+// WithReadyGracePeriod sets how long New waits for the best-effort (optional)
+// ready events after all required events have been received. A value of zero
+// makes New return as soon as the required events arrive, without waiting for
+// the optional ones.
+func WithReadyGracePeriod(d time.Duration) Option {
+	return func(c *Client) {
+		c.readyGracePeriod = d
 	}
 }
 
@@ -395,7 +435,9 @@ func setupDatabase(ctx context.Context, baseURL string) error {
 //nolint:revive // Complexity is necessary for complete client initialization and event setup
 func New(ctx context.Context, baseURL string, username string, password string, opts ...Option) (*Client, error) {
 	c := &Client{
-		socketioLogger: &utils.DefaultLogger{Level: utils.NONE},
+		socketioLogger:   &utils.DefaultLogger{Level: utils.NONE},
+		readyEvents:      defaultReadyEvents,
+		readyGracePeriod: defaultReadyGracePeriod,
 
 		mu:      &sync.Mutex{},
 		updates: signals.New[string](),
@@ -438,9 +480,12 @@ func New(ctx context.Context, baseURL string, username string, password string, 
 
 	c.socketioClient = client
 
+	// requiredSeen holds the events New must receive before returning. The
+	// remaining known events are optional: they populate optionalSeen and are
+	// waited for only during the ready grace period.
 	updateSeenMu := sync.Mutex{}
 	updateSeenMu.Lock()
-	updateSeen := pendingListEvents()
+	requiredSeen, optionalSeen := c.splitReadyEvents()
 	updateSeenMu.Unlock()
 
 	ready := make(chan struct{})
@@ -449,14 +494,36 @@ func New(ctx context.Context, baseURL string, username string, password string, 
 	})
 	defer closeReady()
 
+	optionalReady := make(chan struct{})
+	closeOptionalReady := sync.OnceFunc(func() {
+		close(optionalReady)
+	})
+	defer closeOptionalReady()
+
+	// Close the ready gates up front when their event sets are empty, so New
+	// does not block on events it will never receive (e.g. an empty required
+	// set from WithReadyEvents()).
+	if len(requiredSeen) == 0 {
+		closeReady()
+	}
+
+	if len(optionalSeen) == 0 {
+		closeOptionalReady()
+	}
+
 	c.updates.AddListener(func(_ context.Context, s string) {
 		updateSeenMu.Lock()
 		defer updateSeenMu.Unlock()
 
-		delete(updateSeen, s)
+		delete(requiredSeen, s)
+		delete(optionalSeen, s)
 
-		if len(updateSeen) == 0 {
+		if len(requiredSeen) == 0 {
 			closeReady()
+		}
+
+		if len(optionalSeen) == 0 {
+			closeOptionalReady()
 		}
 	}, "connect-ready")
 	defer c.updates.RemoveListener("connect-ready")
@@ -595,23 +662,47 @@ func New(ctx context.Context, baseURL string, username string, password string, 
 		}
 	})
 
-	errgrp := errgroup.Group{}
-	errgrp.Go(func() error {
-		return client.Connect(ctx)
-	})
+	// client.Connect returns nil as soon as the transport is running and the
+	// handshake has been requested; the "connect" event follows asynchronously.
+	// A non-nil return is the real transport/handshake error (connection
+	// refused, TLS failure, proxy not forwarding the WebSocket upgrade), which
+	// we surface immediately instead of waiting out the timeout.
+	connectErr := make(chan error, 1)
+	go func() {
+		connectErr <- client.Connect(ctx)
+	}()
 
-	select {
-	case <-connect:
-	case <-ctx.Done():
-		return nil, fmt.Errorf("connect to server: %w", ctx.Err())
+connectLoop:
+	for {
+		select {
+		case <-connect:
+			break connectLoop
 
-	case <-ctxWithConnectTimeout.Done():
-		return nil, fmt.Errorf("connect to server: %w", ctxWithConnectTimeout.Err())
-	}
+		case err := <-connectErr:
+			if err != nil {
+				return nil, fmt.Errorf("connect to server: %w", err)
+			}
 
-	err = errgrp.Wait()
-	if err != nil {
-		return nil, fmt.Errorf("connect to server: %w", err)
+			// Connect succeeded; keep waiting for the connect event. Setting
+			// connectErr to nil makes this case block forever.
+			connectErr = nil
+
+		case <-ctx.Done():
+			return nil, fmt.Errorf("connect to server: %w", ctx.Err())
+
+		case <-ctxWithConnectTimeout.Done():
+			// Prefer a real transport error if one is already available.
+			select {
+			case err := <-connectErr:
+				if err != nil {
+					return nil, fmt.Errorf("connect to server: %w", err)
+				}
+
+			default:
+			}
+
+			return nil, fmt.Errorf("connect to server: %w", ctxWithConnectTimeout.Err())
+		}
 	}
 
 	// The socket.io client is now connected. On any subsequent error path
@@ -665,6 +756,23 @@ func New(ctx context.Context, baseURL string, username string, password string, 
 	for {
 		select {
 		case <-ready:
+			// All required events received. Give the best-effort optional
+			// events a short grace window to arrive (and populate the state
+			// cache) before returning.
+			if c.readyGracePeriod > 0 {
+				graceTimer := time.NewTimer(c.readyGracePeriod)
+
+				select {
+				case <-optionalReady:
+				case <-graceTimer.C:
+				case <-ctx.Done():
+					graceTimer.Stop()
+					return nil, fmt.Errorf("wait for ready: %w", ctx.Err())
+				}
+
+				graceTimer.Stop()
+			}
+
 			closeOnErr = false
 			return c, nil
 
@@ -714,8 +822,8 @@ func New(ctx context.Context, baseURL string, username string, password string, 
 			}
 
 			updateSeenMu.Lock()
-			missing := make([]string, 0, len(updateSeen))
-			for event := range updateSeen {
+			missing := make([]string, 0, len(requiredSeen))
+			for event := range requiredSeen {
 				missing = append(missing, event)
 			}
 			updateSeenMu.Unlock()
@@ -742,7 +850,7 @@ func (c *Client) Disconnect() error {
 }
 
 // Resync rebuilds the local state cache from the server and returns once the
-// server has resent every list the cache is built from.
+// server has resent the lists the cache is built from.
 //
 // It is the way out of the stale cache an operation that failed with
 // ErrUpdateEventTimeout leaves behind: the getters that serve from the cache do
@@ -753,6 +861,12 @@ func (c *Client) Disconnect() error {
 // a single list. What it does have is a login, which answers with all of them,
 // so Resync logs in again with the token from the login New performed. A client
 // created without credentials therefore cannot resync.
+//
+// Which lists Resync waits for follows New: the events configured with
+// WithReadyEvents are required, the remaining known events are best-effort and
+// only awaited for the ready grace period, because a server (or a proxy in
+// front of it) that never emits an event during New does not emit it here
+// either.
 func (c *Client) Resync(ctx context.Context) error {
 	c.mu.Lock()
 	token := c.sessionToken
@@ -763,13 +877,29 @@ func (c *Client) Resync(ctx context.Context) error {
 	}
 
 	pendingMu := sync.Mutex{}
-	pending := pendingListEvents()
+	pending, optionalPending := c.splitReadyEvents()
 
 	done := make(chan struct{})
 	closeDone := sync.OnceFunc(func() {
 		close(done)
 	})
 	defer closeDone()
+
+	optionalDone := make(chan struct{})
+	closeOptionalDone := sync.OnceFunc(func() {
+		close(optionalDone)
+	})
+	defer closeOptionalDone()
+
+	// Close the gates up front when their event sets are empty, so Resync does
+	// not block on events it will never receive.
+	if len(pending) == 0 {
+		closeDone()
+	}
+
+	if len(optionalPending) == 0 {
+		closeOptionalDone()
+	}
 
 	// Registered before the command is emitted, so that no list can arrive
 	// unnoticed between the two.
@@ -779,9 +909,14 @@ func (c *Client) Resync(ctx context.Context) error {
 		defer pendingMu.Unlock()
 
 		delete(pending, update)
+		delete(optionalPending, update)
 
 		if len(pending) == 0 {
 			closeDone()
+		}
+
+		if len(optionalPending) == 0 {
+			closeOptionalDone()
 		}
 	}, listenerID.String())
 
@@ -794,7 +929,6 @@ func (c *Client) Resync(ctx context.Context) error {
 
 	select {
 	case <-done:
-		return nil
 
 	case <-ctx.Done():
 		pendingMu.Lock()
@@ -809,6 +943,26 @@ func (c *Client) Resync(ctx context.Context) error {
 
 		return fmt.Errorf("resync: %w (missing events: %s)", ctx.Err(), strings.Join(missing, ", "))
 	}
+
+	// The required lists are in. Give the best-effort ones the same short
+	// grace window New grants them, so the cache they feed is refreshed too on
+	// a server that does emit them.
+	if c.readyGracePeriod > 0 {
+		graceTimer := time.NewTimer(c.readyGracePeriod)
+
+		select {
+		case <-optionalDone:
+		case <-graceTimer.C:
+		case <-ctx.Done():
+			graceTimer.Stop()
+
+			return fmt.Errorf("resync: %w", ctx.Err())
+		}
+
+		graceTimer.Stop()
+	}
+
+	return nil
 }
 
 // setSessionToken records the JWT a login answered with, see Resync.
@@ -817,6 +971,29 @@ func (c *Client) setSessionToken(token string) {
 	defer c.mu.Unlock()
 
 	c.sessionToken = token
+}
+
+// splitReadyEvents returns the update events that carry the lists the local
+// state cache is built from, as two sets to strike them off as they arrive:
+// the events the client waits for (its configured readyEvents) and the
+// best-effort rest, which are cached when they arrive but never block. The
+// server sends them after a login, which is what New waits for and what Resync
+// repeats.
+func (c *Client) splitReadyEvents() (required map[string]struct{}, optional map[string]struct{}) {
+	required = make(map[string]struct{}, len(c.readyEvents))
+	for _, event := range c.readyEvents {
+		required[event] = empty
+	}
+
+	optional = make(map[string]struct{}, len(knownReadyEvents))
+
+	for _, event := range knownReadyEvents {
+		if _, isRequired := required[event]; !isRequired {
+			optional[event] = empty
+		}
+	}
+
+	return required, optional
 }
 
 type ackResponse struct {

--- a/client_ack_test.go
+++ b/client_ack_test.go
@@ -18,15 +18,24 @@ import (
 	"github.com/breml/go-uptime-kuma-client/notification"
 )
 
-// readyEvents are the update events kuma.New() waits for before it returns. The
-// payloads only have to unmarshal into the registered handlers' argument types.
+// requiredReadyEvents are the update events kuma.New() and Client.Resync wait
+// for before they return. The payloads only have to unmarshal into the
+// registered handlers' argument types.
 //
 //nolint:gochecknoglobals // fixed table, shared by the fake server below.
-var readyEvents = []string{
+var requiredReadyEvents = []string{
 	`42["monitorList",{}]`,
-	`42["maintenanceList",{}]`,
 	`42["notificationList",[]]`,
 	`42["statusPageList",{}]`,
+}
+
+// optionalReadyEvents are the best-effort update events. A server that never
+// emits them (an older version, or a reverse proxy dropping them) must not
+// block either call, see kuma.WithReadyEvents.
+//
+//nolint:gochecknoglobals // fixed table, shared by the fake server below.
+var optionalReadyEvents = []string{
+	`42["maintenanceList",{}]`,
 	`42["proxyList",[]]`,
 	`42["dockerHostList",[]]`,
 	`42["apiKeyList",[]]`,
@@ -60,6 +69,9 @@ type fakeAckServer struct {
 	// suppressLists answers a loginByToken without resending the lists, which
 	// leaves a Resync waiting.
 	suppressLists bool
+	// suppressOptionalLists resends only the required lists, as a server that
+	// never emits the best-effort ones does.
+	suppressOptionalLists bool
 	// resyncPayload is the last loginByToken frame received.
 	resyncPayload string
 }
@@ -140,6 +152,13 @@ func (s *fakeAckServer) setSuppressLists(suppress bool) {
 	s.suppressLists = suppress
 }
 
+func (s *fakeAckServer) setSuppressOptionalLists(suppress bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.suppressOptionalLists = suppress
+}
+
 func (s *fakeAckServer) recordResync(payload string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -168,7 +187,16 @@ func (s *fakeAckServer) loginAck() string {
 }
 
 func (s *fakeAckServer) sendReadyEvents() {
-	for _, event := range readyEvents {
+	s.mu.Lock()
+	optionalSuppressed := s.suppressOptionalLists
+	s.mu.Unlock()
+
+	events := requiredReadyEvents
+	if !optionalSuppressed {
+		events = append(append([]string{}, requiredReadyEvents...), optionalReadyEvents...)
+	}
+
+	for _, event := range events {
 		s.messages <- []byte(event)
 	}
 }

--- a/client_resync_test.go
+++ b/client_resync_test.go
@@ -68,8 +68,25 @@ func TestResync(t *testing.T) {
 		err := kumaClient.Resync(ctx)
 
 		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.ErrorContains(t, err, "monitorList")
 		require.ErrorContains(t, err, "notificationList")
-		require.ErrorContains(t, err, "proxyList")
+		require.ErrorContains(t, err, "statusPageList")
+		require.NotContains(t, err.Error(), "proxyList",
+			"a best-effort list is not what a resync waits for")
+	})
+
+	t.Run("the_best_effort_lists_do_not_hold_it_up", func(t *testing.T) {
+		fake := &fakeAckServer{messages: make(chan []byte, 32)}
+		kumaClient := newFakeAckClient(t, fake)
+
+		// A server that only ever emits the required lists, as older versions
+		// and some reverse proxies do, has to resync just the same.
+		fake.setSuppressOptionalLists(true)
+
+		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+		defer cancel()
+
+		require.NoError(t, kumaClient.Resync(ctx))
 	})
 
 	t.Run("without_a_session_token_it_reports_that_instead_of_hanging", func(t *testing.T) {

--- a/client_resync_test.go
+++ b/client_resync_test.go
@@ -14,7 +14,7 @@ import (
 
 // newFakeAckClient connects a client to fake and returns it, with the server and
 // the connection torn down when the test ends.
-func newFakeAckClient(t *testing.T, fake *fakeAckServer) *kuma.Client {
+func newFakeAckClient(t *testing.T, fake *fakeAckServer, opts ...kuma.Option) *kuma.Client {
 	t.Helper()
 
 	server := httptest.NewServer(fake)
@@ -30,7 +30,7 @@ func newFakeAckClient(t *testing.T, fake *fakeAckServer) *kuma.Client {
 		ctx,
 		server.URL,
 		"admin", "admin1",
-		kuma.WithConnectTimeout(10*time.Second),
+		append([]kuma.Option{kuma.WithConnectTimeout(10 * time.Second)}, opts...)...,
 	)
 	require.NoError(t, err)
 
@@ -76,14 +76,40 @@ func TestResync(t *testing.T) {
 	})
 
 	t.Run("the_best_effort_lists_do_not_hold_it_up", func(t *testing.T) {
+		// Long enough that a resync waiting it out is unmistakable in the
+		// elapsed time below.
+		const grace = time.Second
+
+		fake := &fakeAckServer{messages: make(chan []byte, 32)}
+
+		// A server that only ever emits the required lists, as older versions
+		// and some reverse proxies do, has to resync just the same — and once
+		// New has learned that it never sends them, without spending the grace
+		// period on them again.
+		fake.setSuppressOptionalLists(true)
+
+		kumaClient := newFakeAckClient(t, fake, kuma.WithReadyGracePeriod(grace))
+
+		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+		defer cancel()
+
+		start := time.Now()
+
+		require.NoError(t, kumaClient.Resync(ctx))
+		require.Less(t, time.Since(start), grace/4,
+			"the resync waited out the grace period for lists this server never sends")
+	})
+
+	t.Run("a_deadline_in_the_grace_window_does_not_fail_a_finished_resync", func(t *testing.T) {
 		fake := &fakeAckServer{messages: make(chan []byte, 32)}
 		kumaClient := newFakeAckClient(t, fake)
 
-		// A server that only ever emits the required lists, as older versions
-		// and some reverse proxies do, has to resync just the same.
 		fake.setSuppressOptionalLists(true)
 
-		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+		// Shorter than the default ready grace period, so the deadline is what
+		// ends the wait for the best-effort lists. By then the required ones
+		// have rebuilt the cache, which is all the caller asked for.
+		ctx, cancel := context.WithTimeout(t.Context(), 300*time.Millisecond)
 		defer cancel()
 
 		require.NoError(t, kumaClient.Resync(ctx))

--- a/client_timeout_test.go
+++ b/client_timeout_test.go
@@ -27,6 +27,10 @@ import (
 // that triggers issue #271.
 type fakeSocketIOServer struct {
 	messages chan []byte
+	// eventsAfterLogin are socket.io EVENT frames enqueued right after the
+	// login ACK, e.g. `42["monitorList",{}]`. This lets a test emit only a
+	// subset of the initial list events to exercise the tolerant ready gate.
+	eventsAfterLogin []string
 }
 
 func (s *fakeSocketIOServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -105,6 +109,11 @@ func (s *fakeSocketIOServer) handleClientMessage(body []byte) {
 		// Enqueue login ACK: engine.io "4" + socket.io "3" (Ack) + ack ID + JSON payload.
 		ack := fmt.Sprintf(`43%s[{"ok":true,"msg":"Logged in successfully."}]`, ackID)
 		s.messages <- []byte(ack)
+
+		// Enqueue any configured post-login list events.
+		for _, event := range s.eventsAfterLogin {
+			s.messages <- []byte(event)
+		}
 
 	default:
 	}
@@ -360,7 +369,8 @@ func TestNewConnectTimeoutDuringReadyWait_WebSocketUpgrade(t *testing.T) {
 	// "connect to server: ...", not "missing events: ...".
 	require.ErrorContains(t, err, "missing events:",
 		"error should report missing events (not a connect-phase hang)")
-	require.ErrorContains(t, err, "apiKeyList")
+	require.ErrorContains(t, err, "monitorList",
+		"a required ready event should appear in the missing events list")
 }
 
 func TestNewConnectTimeoutDuringReadyWait(t *testing.T) {
@@ -402,6 +412,122 @@ func TestNewConnectTimeoutDuringReadyWait(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorIs(t, err, context.DeadlineExceeded, "error should wrap context.DeadlineExceeded, got: %v", err)
 	require.ErrorContains(t, err, "missing events:", "error should list the still-missing ready events")
-	require.ErrorContains(t, err, "apiKeyList", "apiKeyList should appear in the missing events list")
+	require.ErrorContains(t, err, "monitorList", "a required ready event should appear in the missing events list")
 	require.Less(t, elapsed, 2*timeout, "New() should return within 2x timeout, took %s", elapsed)
+}
+
+// TestNewReadyGateTolerant verifies that New() no longer requires the optional
+// list events. The fake server emits only the required core events
+// (monitorList, notificationList, statusPageList) and never sends the optional
+// ones (maintenanceList, proxyList, dockerHostList, apiKeyList). New() must
+// return successfully after the ready grace period, well before the connect
+// timeout — the behavior older Uptime Kuma versions and some reverse proxies
+// need (issue #358).
+func TestNewReadyGateTolerant(t *testing.T) {
+	const (
+		timeout = 2 * time.Second
+		grace   = 200 * time.Millisecond
+	)
+
+	server := httptest.NewServer(&fakeSocketIOServer{
+		messages: make(chan []byte, 10),
+		eventsAfterLogin: []string{
+			`42["monitorList",{}]`,
+			`42["notificationList",[]]`,
+			`42["statusPageList",{}]`,
+		},
+	})
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*timeout)
+	t.Cleanup(func() {
+		cancel()
+		server.CloseClientConnections()
+		server.Close()
+	})
+
+	start := time.Now()
+
+	client, err := kuma.New(
+		ctx,
+		server.URL,
+		"admin", "admin1",
+		kuma.WithConnectTimeout(timeout),
+		kuma.WithReadyGracePeriod(grace),
+	)
+
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	t.Cleanup(func() { _ = client.Disconnect() })
+	require.Less(t, elapsed, timeout, "New() should return after the grace period, not the connect timeout")
+}
+
+// TestNewReadyEventsOption verifies that WithReadyEvents narrows the required
+// ready set: the fake server emits only monitorList, and New() returns as soon
+// as it arrives because monitorList is the sole required event and the grace
+// period is disabled.
+func TestNewReadyEventsOption(t *testing.T) {
+	const timeout = 2 * time.Second
+
+	server := httptest.NewServer(&fakeSocketIOServer{
+		messages:         make(chan []byte, 10),
+		eventsAfterLogin: []string{`42["monitorList",{}]`},
+	})
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*timeout)
+	t.Cleanup(func() {
+		cancel()
+		server.CloseClientConnections()
+		server.Close()
+	})
+
+	client, err := kuma.New(
+		ctx,
+		server.URL,
+		"admin", "admin1",
+		kuma.WithConnectTimeout(timeout),
+		kuma.WithReadyEvents("monitorList"),
+		kuma.WithReadyGracePeriod(0),
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	t.Cleanup(func() { _ = client.Disconnect() })
+}
+
+// TestNewTransportErrorSurfaced verifies that a real transport/handshake failure
+// is surfaced immediately instead of being masked by the connect timeout. The
+// endpoint points at a closed port (connection refused), so New() must return
+// the underlying error well before the generous connect timeout and must not
+// wrap context.DeadlineExceeded.
+func TestNewTransportErrorSurfaced(t *testing.T) {
+	// Reserve a port, then close the listener so nothing is listening.
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	addr := listener.Addr().String()
+	require.NoError(t, listener.Close())
+
+	const timeout = 10 * time.Second
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*timeout)
+	t.Cleanup(cancel)
+
+	start := time.Now()
+
+	_, err = kuma.New(
+		ctx,
+		"http://"+addr,
+		"admin", "admin1",
+		kuma.WithConnectTimeout(timeout),
+	)
+
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "connect to server:")
+	require.NotErrorIs(t, err, context.DeadlineExceeded,
+		"a real transport error should be surfaced, not a context deadline")
+	require.Less(t, elapsed, timeout, "New() should fail fast, not wait out the connect timeout")
 }

--- a/client_timeout_test.go
+++ b/client_timeout_test.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -31,6 +32,11 @@ type fakeSocketIOServer struct {
 	// login ACK, e.g. `42["monitorList",{}]`. This lets a test emit only a
 	// subset of the initial list events to exercise the tolerant ready gate.
 	eventsAfterLogin []string
+	// noConnectACK leaves the socket.io CONNECT unanswered, the way a reverse
+	// proxy that forwards the engine.io handshake but nothing beyond it does.
+	// The transport comes up, so the dial succeeds, but the connect event
+	// never arrives.
+	noConnectACK bool
 }
 
 func (s *fakeSocketIOServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -73,9 +79,24 @@ func (s *fakeSocketIOServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case r.Method == http.MethodGet && sid != "":
 		// Long-poll: deliver the next queued message or block until the
 		// client disconnects (simulating a server that never emits ready events).
+		var idle <-chan time.Time
+
+		if s.noConnectACK {
+			// End an idle poll with an engine.io NOOP instead of holding it
+			// open forever. Nothing else would ever end this poll, and a
+			// client shutting down waits for the one in flight.
+			timer := time.NewTimer(50 * time.Millisecond)
+			defer timer.Stop()
+
+			idle = timer.C
+		}
+
 		select {
 		case msg := <-s.messages:
 			_, _ = w.Write(msg)
+
+		case <-idle:
+			_, _ = w.Write([]byte("6"))
 
 		case <-r.Context().Done():
 		}
@@ -95,6 +116,10 @@ func (s *fakeSocketIOServer) handleClientMessage(body []byte) {
 
 	switch socketIOData[0] {
 	case '0': // socket.io CONNECT
+		if s.noConnectACK {
+			return
+		}
+
 		// Enqueue CONNECT ACK: engine.io "4" (Message) + socket.io "0" (Connect).
 		s.messages <- []byte("40")
 
@@ -460,7 +485,34 @@ func TestNewReadyGateTolerant(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, client)
 	t.Cleanup(func() { _ = client.Disconnect() })
-	require.Less(t, elapsed, timeout, "New() should return after the grace period, not the connect timeout")
+	require.Less(t, elapsed, 5*grace, "New() should return after the grace period, not the connect timeout")
+	require.Equal(t,
+		[]string{"apiKeyList", "dockerHostList", "maintenanceList", "proxyList"},
+		client.MissingReadyEvents(),
+		"the caller has to be able to tell a cache left empty from an empty server")
+}
+
+// TestNewRejectsUnknownReadyEvent covers a typo in WithReadyEvents. Waiting for
+// an event no server ever emits can only end in the connect timeout, so New
+// says so up front, before it even dials.
+func TestNewRejectsUnknownReadyEvent(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	start := time.Now()
+
+	_, err := kuma.New(
+		ctx,
+		// Unreachable on purpose: the check has to come before the dial.
+		"http://127.0.0.1:1",
+		"admin", "admin1",
+		kuma.WithReadyEvents("monitorlist"),
+		kuma.WithConnectTimeout(5*time.Second),
+	)
+
+	require.ErrorContains(t, err, "unknown")
+	require.ErrorContains(t, err, "monitorlist")
+	require.Less(t, time.Since(start), time.Second, "New() should not have dialed at all")
 }
 
 // TestNewReadyEventsOption verifies that WithReadyEvents narrows the required
@@ -493,6 +545,126 @@ func TestNewReadyEventsOption(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, client)
+	t.Cleanup(func() { _ = client.Disconnect() })
+}
+
+// TestNewConnectTimeoutDoesNotLeakTheDial covers the connect timeout firing
+// after client.Connect has already returned successfully — it only brings the
+// transport up, so it returns long before the socket.io CONNECT this server
+// never answers. New hands back the timeout error without a *Client, so nobody
+// can disconnect the transport afterwards and New has to do it itself.
+func TestNewConnectTimeoutDoesNotLeakTheDial(t *testing.T) {
+	const timeout = 500 * time.Millisecond
+
+	server := httptest.NewServer(&fakeSocketIOServer{
+		messages:     make(chan []byte, 10),
+		noConnectACK: true,
+	})
+
+	// Deliberately without a deadline: the context governs the lifetime of the
+	// connection, so an abandoned one lives on until the caller happens to
+	// cancel it.
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(func() {
+		cancel()
+		server.CloseClientConnections()
+		server.Close()
+	})
+
+	// The rest of the suite keeps clients of its own connected, so only the
+	// growth over this baseline is this test's.
+	before, _ := goroutinesIn(socketIOPackage)
+
+	_, err := kuma.New(
+		ctx,
+		server.URL,
+		"admin", "admin1",
+		kuma.WithConnectTimeout(timeout),
+	)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	// The connection has to wind down on its own: the context that governs it
+	// is still alive and the caller was handed no *Client to disconnect.
+	running, stack := before+1, ""
+
+	for range 100 {
+		running, stack = goroutinesIn(socketIOPackage)
+		if running <= before {
+			break
+		}
+
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	require.NotContains(t, stack, "chan receive (nil chan)",
+		"draining the spent connectErr channel blocks forever")
+	require.LessOrEqual(t, running, before,
+		"the abandoned connection kept its goroutines running:\n%s", stack)
+}
+
+// socketIOPackage appears in the stack of every goroutine the socket.io client
+// runs, which is what goroutinesIn counts to tell a wound-down connection from
+// a leaked one.
+const socketIOPackage = "go.socket.io"
+
+// goroutinesIn counts the running goroutines whose stack mentions pkg and
+// returns the dump they were counted in.
+func goroutinesIn(pkg string) (count int, dump string) {
+	buf := make([]byte, 1<<16)
+	for {
+		n := runtime.Stack(buf, true)
+		if n < len(buf) {
+			buf = buf[:n]
+
+			break
+		}
+
+		buf = make([]byte, 2*len(buf))
+	}
+
+	dump = string(buf)
+
+	for goroutine := range strings.SplitSeq(dump, "\n\n") {
+		if strings.Contains(goroutine, pkg) {
+			count++
+		}
+	}
+
+	return count, dump
+}
+
+// TestNewReadyGraceWithinCallerDeadline covers the caller that bounds New with
+// a context deadline instead of WithConnectTimeout, against a server that never
+// emits the optional lists. The required events arrive well within the
+// deadline, so the deadline running out during the best-effort grace window has
+// to hand the client over, not throw it away.
+func TestNewReadyGraceWithinCallerDeadline(t *testing.T) {
+	server := httptest.NewServer(&fakeSocketIOServer{
+		messages: make(chan []byte, 10),
+		eventsAfterLogin: []string{
+			`42["monitorList",{}]`,
+			`42["notificationList",[]]`,
+			`42["statusPageList",{}]`,
+		},
+	})
+
+	t.Cleanup(func() {
+		server.CloseClientConnections()
+		server.Close()
+	})
+
+	// Shorter than the default ready grace period, and no WithConnectTimeout,
+	// so nothing but this deadline ends the grace window.
+	ctx, cancel := context.WithTimeout(t.Context(), 300*time.Millisecond)
+	defer cancel()
+
+	client, err := kuma.New(ctx, server.URL, "admin", "admin1")
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
 	t.Cleanup(func() { _ = client.Disconnect() })
 }
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.25.2
 require (
 	github.com/maldikhan/go.socket.io v0.1.1
 	github.com/ory/dockertest/v3 v3.12.0
-	golang.org/x/sync v0.22.0
 )
 
 require (
@@ -348,6 +347,7 @@ require (
 	golang.org/x/exp/typeparams v0.0.0-20260529124908-c761662dc8c9 // indirect
 	golang.org/x/mod v0.36.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
+	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/term v0.43.0 // indirect
 	golang.org/x/text v0.37.0 // indirect


### PR DESCRIPTION
## Summary

Improves the robustness and diagnostics of `client.New()` for the connection failures reported against reverse-proxied and older Uptime Kuma servers (motivated by [breml/terraform-provider-uptime-kuma#358](https://github.com/breml/terraform-provider-uptime-kuma/issues/358)).

Two independent shortcomings in `New()` are addressed:

### 1. Relax the over-strict "ready gate"

Previously `New()` blocked until **all seven** initial list events arrived (`monitorList, notificationList, statusPageList, maintenanceList, proxyList, dockerHostList, apiKeyList`). Older Uptime Kuma versions and some reverse proxies never emit certain events (notably `apiKeyList` / `maintenanceList` / `dockerHostList`), so `New()` hung until the connect timeout and then failed with a misleading `wait for ready: ... (missing events: apiKeyList)`.

Now `New()` waits only for a **required core set** — `monitorList`, `notificationList`, `statusPageList` (the primary entities this library manages, emitted by all supported versions) — and treats the rest as **best-effort**: they are cached when they arrive within a short grace period, but never block. On a healthy server all events still arrive within milliseconds, so there is no added latency in the common case.

Two new functional options allow overriding the defaults:

- `WithReadyEvents(events ...string)` — override the required core set.
- `WithReadyGracePeriod(d time.Duration)` — override the optional-event grace window (default 500ms; `0` returns as soon as the required events arrive).

### 2. Surface the real transport/handshake error

The error from `client.Connect()` was captured in a goroutine that the connect `select` never observed, so a fast handshake failure (connection refused, TLS error, proxy not forwarding the WebSocket upgrade) was masked as `connect to server: context deadline exceeded` only after the full timeout elapsed. The connect goroutine's result is now selected on directly, so the real error is returned immediately.

## Note on version-derivation

I investigated deriving the expected event set from the server version and rejected it: the version is only available post-login via the `info` event (emitted concurrently with the list events, no ordering guarantee, and not currently consumed), there is no unauthenticated version endpoint, a version→event table would be brittle across 1.x/2.x, and — most importantly — it would not help the actual reported failure mode where a reverse proxy drops events while the server still reports a modern version. The tolerant core+optional+grace approach handles all of these out of the box.

## Testing

- `task fmt` — no changes
- `task lint` — passes
- `task test` — passes (adds `TestNewReadyGateTolerant`, `TestNewReadyEventsOption`, `TestNewTransportErrorSurfaced`; existing `apiKeyList` regression assertions updated to a still-required core event)
- `task test-e2e` — passes against a real Uptime Kuma via dockertest, confirming the relaxed gate + grace period still returns fully-populated state