### PR TITLE
feat(core): support configurable User-Agent for HTTP and WebSocket requests

### DIFF
--- a/client.go
+++ b/client.go
@@ -94,6 +94,7 @@ type Client struct {
 	socketioClientConnectTimeout time.Duration
 	socketioLogger               socketio.Logger
 	autosetup                    bool
+	userAgent                    string
 
 	mu      *sync.Mutex
 	updates signals.Signal[string]
@@ -130,12 +131,23 @@ func WithConnectTimeout(timeout time.Duration) Option {
 	}
 }
 
+// WithUserAgent sets the User-Agent header sent with every request made by
+// the client: the entry-page/setup-database HTTP probing during autosetup,
+// the Socket.IO long-polling transport and the WebSocket handshake. When
+// unset, the underlying HTTP and WebSocket libraries' default User-Agent is
+// used.
+func WithUserAgent(userAgent string) Option {
+	return func(c *Client) {
+		c.userAgent = userAgent
+	}
+}
+
 // setupDatabase handles the database setup phase for Uptime Kuma v2.
 // It checks if database setup is needed and configures SQLite if required.
 // The function will wait for the server to restart after database configuration.
 //
 //nolint:revive // Complexity is necessary for complete database setup logic
-func setupDatabase(ctx context.Context, baseURL string) error {
+func setupDatabase(ctx context.Context, baseURL string, userAgent string) error {
 	// Convert socket.io URL to HTTP URL
 	httpURL := strings.Replace(baseURL, "ws://", "http://", 1)
 	httpURL = strings.Replace(httpURL, "wss://", "https://", 1)
@@ -162,6 +174,8 @@ func setupDatabase(ctx context.Context, baseURL string) error {
 	if err != nil {
 		return fmt.Errorf("create entry-page request: %w", err)
 	}
+
+	setUserAgent(req, userAgent)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -211,6 +225,7 @@ func setupDatabase(ctx context.Context, baseURL string) error {
 	}
 
 	req.Header.Set("Content-Type", "application/json")
+	setUserAgent(req, userAgent)
 
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
@@ -260,6 +275,8 @@ func setupDatabase(ctx context.Context, baseURL string) error {
 				pollCancel()
 				continue
 			}
+
+			setUserAgent(pollReq, userAgent)
 
 			pollResp, err := http.DefaultClient.Do(pollReq)
 			if err != nil {
@@ -320,14 +337,19 @@ func New(ctx context.Context, baseURL string, username string, password string, 
 
 	// Handle database setup for Uptime Kuma v2 if autosetup is enabled
 	if c.autosetup {
-		err := setupDatabase(ctxWithConnectTimeout, baseURL)
+		err := setupDatabase(ctxWithConnectTimeout, baseURL, c.userAgent)
 		if err != nil {
 			return nil, fmt.Errorf("database setup: %w", err)
 		}
 	}
 
+	engineIOClientOpt, err := newEngineIOClientOption(baseURL, c.socketioLogger, c.userAgent)
+	if err != nil {
+		return nil, fmt.Errorf("configure transport: %w", err)
+	}
+
 	client, err := socketio.NewClient(
-		socketio.WithRawURL(baseURL),
+		engineIOClientOpt,
 		socketio.WithLogger(c.socketioLogger),
 	)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.2
 require (
 	github.com/maldikhan/go.socket.io v0.1.1
 	github.com/ory/dockertest/v3 v3.12.0
+	golang.org/x/net v0.54.0
 	golang.org/x/sync v0.20.0
 )
 
@@ -374,7 +375,6 @@ require (
 	github.com/maniartech/signals v1.3.1
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/stretchr/testify v1.11.1
-	golang.org/x/net v0.54.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/useragent.go
+++ b/useragent.go
@@ -1,0 +1,173 @@
+package kuma
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	engineioclient "github.com/maldikhan/go.socket.io/engine.io/v4/client"
+	enginepolling "github.com/maldikhan/go.socket.io/engine.io/v4/client/transport/polling"
+	enginews "github.com/maldikhan/go.socket.io/engine.io/v4/client/transport/websocket"
+	socketio "github.com/maldikhan/go.socket.io/socket.io/v5/client"
+
+	"golang.org/x/net/websocket"
+)
+
+// errWebSocketNotConnected mirrors the unexported sentinel error used by the
+// default socket.io WebSocket implementation.
+var errWebSocketNotConnected = errors.New("socket connection is not initialized")
+
+// setUserAgent sets the User-Agent header on req, unless userAgent is empty.
+func setUserAgent(req *http.Request, userAgent string) {
+	if userAgent == "" {
+		return
+	}
+
+	req.Header.Set("User-Agent", userAgent)
+}
+
+// userAgentRoundTripper injects a User-Agent header into every request that
+// does not already carry one.
+type userAgentRoundTripper struct {
+	userAgent string
+}
+
+// RoundTrip implements http.RoundTripper.
+func (rt *userAgentRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Header.Get("User-Agent") == "" {
+		req = req.Clone(req.Context())
+		req.Header.Set("User-Agent", rt.userAgent)
+	}
+
+	resp, err := http.DefaultTransport.RoundTrip(req)
+	if err != nil {
+		return nil, fmt.Errorf("round trip: %w", err)
+	}
+
+	return resp, nil
+}
+
+// userAgentWebSocket wraps golang.org/x/net/websocket to attach a custom
+// User-Agent header during the WebSocket handshake. The socket.io client's
+// default WebSocket implementation (ws_native.WebSocketConnection) does not
+// expose any header configuration, so this type re-implements the same
+// enginews.WebSocket interface with header support.
+type userAgentWebSocket struct {
+	userAgent string
+	conn      *websocket.Conn
+}
+
+// Dial opens the WebSocket connection, attaching the configured User-Agent
+// header to the handshake request.
+func (w *userAgentWebSocket) Dial(ctx context.Context, target *url.URL, origin *url.URL) error {
+	config, err := websocket.NewConfig(target.String(), origin.String())
+	if err != nil {
+		return fmt.Errorf("create websocket config: %w", err)
+	}
+
+	if w.userAgent != "" {
+		config.Header.Set("User-Agent", w.userAgent)
+	}
+
+	conn, err := config.DialContext(ctx)
+	if err != nil {
+		return fmt.Errorf("dial websocket: %w", err)
+	}
+
+	w.conn = conn
+
+	return nil
+}
+
+// Send writes a message frame to the WebSocket connection.
+func (w *userAgentWebSocket) Send(v []byte) error {
+	if w.conn == nil {
+		return errWebSocketNotConnected
+	}
+
+	err := websocket.Message.Send(w.conn, string(v))
+	if err != nil {
+		return fmt.Errorf("send: %w", err)
+	}
+
+	return nil
+}
+
+// Receive reads the next message frame from the WebSocket connection.
+func (w *userAgentWebSocket) Receive(v *[]byte) error {
+	if w.conn == nil {
+		return errWebSocketNotConnected
+	}
+
+	err := websocket.Message.Receive(w.conn, v)
+	if err != nil {
+		return fmt.Errorf("receive: %w", err)
+	}
+
+	return nil
+}
+
+// Close closes the WebSocket connection.
+func (w *userAgentWebSocket) Close() error {
+	if w.conn == nil {
+		return nil
+	}
+
+	err := w.conn.Close()
+	if err != nil {
+		return fmt.Errorf("close: %w", err)
+	}
+
+	return nil
+}
+
+// newEngineIOClientOption builds the socket.io ClientOption used to connect
+// to baseURL. When userAgent is empty, it falls back to the library's
+// default transports (socketio.WithRawURL) unmodified. Otherwise, it builds
+// an Engine.IO client with WebSocket and polling transports that attach
+// userAgent to every request.
+func newEngineIOClientOption(baseURL string, logger socketio.Logger, userAgent string) (socketio.ClientOption, error) {
+	if userAgent == "" {
+		return socketio.WithRawURL(baseURL), nil
+	}
+
+	parsedURL, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse url: %w", err)
+	}
+
+	if parsedURL.Path == "" {
+		parsedURL.Path = "/socket.io/"
+	}
+
+	wsTransport, err := enginews.NewTransport(
+		enginews.WithLogger(logger),
+		enginews.WithWebSocket(&userAgentWebSocket{userAgent: userAgent}),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create websocket transport: %w", err)
+	}
+
+	pollingTransport, err := enginepolling.NewTransport(
+		enginepolling.WithLogger(logger),
+		enginepolling.WithHTTPClient(&http.Client{
+			Transport: &userAgentRoundTripper{userAgent: userAgent},
+		}),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create polling transport: %w", err)
+	}
+
+	engineioClient, err := engineioclient.NewClient(
+		engineioclient.WithURL(parsedURL),
+		engineioclient.WithLogger(logger),
+		engineioclient.WithSupportedTransports([]engineioclient.Transport{wsTransport, pollingTransport}),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create engine.io client: %w", err)
+	}
+
+	return socketio.WithEngineIOClient(engineioClient), nil
+}

--- a/useragent_test.go
+++ b/useragent_test.go
@@ -1,0 +1,216 @@
+package kuma_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	kuma "github.com/breml/go-uptime-kuma-client"
+)
+
+// capturedRequest records the User-Agent header and the "transport" query
+// parameter (e.g. "websocket", or "" for the initial polling handshake) of
+// one captured request.
+type capturedRequest struct {
+	userAgent string
+	transport string
+}
+
+// headerCapturingHandler wraps an http.Handler and records the User-Agent
+// header of every request it sees before delegating to inner.
+type headerCapturingHandler struct {
+	inner http.Handler
+
+	mu       sync.Mutex
+	requests []capturedRequest
+}
+
+func (h *headerCapturingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.mu.Lock()
+	h.requests = append(h.requests, capturedRequest{
+		userAgent: r.Header.Get("User-Agent"),
+		transport: r.URL.Query().Get("transport"),
+	})
+	h.mu.Unlock()
+
+	h.inner.ServeHTTP(w, r)
+}
+
+func (h *headerCapturingHandler) first() string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if len(h.requests) == 0 {
+		return ""
+	}
+
+	return h.requests[0].userAgent
+}
+
+// userAgentFor returns the User-Agent header of the first captured request
+// whose "transport" query parameter matches transport, or "" if none match.
+func (h *headerCapturingHandler) userAgentFor(transport string) string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	for _, req := range h.requests {
+		if req.transport == transport {
+			return req.userAgent
+		}
+	}
+
+	return ""
+}
+
+// TestWithUserAgent_Polling verifies that WithUserAgent attaches the
+// configured User-Agent header to the Socket.IO long-polling transport's
+// HTTP requests (the initial engine.io handshake in this case).
+func TestWithUserAgent_Polling(t *testing.T) {
+	const timeout = 500 * time.Millisecond
+	const userAgent = "terraform-provider-uptimekuma/test"
+
+	capture := &headerCapturingHandler{
+		inner: &fakeSocketIOServer{messages: make(chan []byte, 10)},
+	}
+	server := httptest.NewServer(capture)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*timeout)
+	t.Cleanup(func() {
+		cancel()
+		server.CloseClientConnections()
+		server.Close()
+	})
+
+	// The fake server never emits ready events, so New() always times out.
+	// We only care that the handshake request carried the right header.
+	_, _ = kuma.New(
+		ctx,
+		server.URL,
+		"admin", "admin1",
+		kuma.WithConnectTimeout(timeout),
+		kuma.WithUserAgent(userAgent),
+	)
+
+	require.Equal(t, userAgent, capture.first())
+}
+
+// TestWithUserAgent_PollingDefault verifies that without WithUserAgent, the
+// polling transport falls back to Go's default net/http User-Agent instead
+// of sending no header at all.
+func TestWithUserAgent_PollingDefault(t *testing.T) {
+	const timeout = 500 * time.Millisecond
+
+	capture := &headerCapturingHandler{
+		inner: &fakeSocketIOServer{messages: make(chan []byte, 10)},
+	}
+	server := httptest.NewServer(capture)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*timeout)
+	t.Cleanup(func() {
+		cancel()
+		server.CloseClientConnections()
+		server.Close()
+	})
+
+	_, _ = kuma.New(
+		ctx,
+		server.URL,
+		"admin", "admin1",
+		kuma.WithConnectTimeout(timeout),
+	)
+
+	require.Contains(t, capture.first(), "Go-http-client",
+		"expected the unconfigured default net/http User-Agent, got %q", capture.first())
+}
+
+// TestWithUserAgent_WebSocketHandshake verifies that WithUserAgent attaches
+// the configured User-Agent header to the WebSocket upgrade request.
+func TestWithUserAgent_WebSocketHandshake(t *testing.T) {
+	const timeout = 500 * time.Millisecond
+	const userAgent = "terraform-provider-uptimekuma/test"
+
+	capture := &headerCapturingHandler{
+		inner: &fakeSocketIOServerWithWebSocket{},
+	}
+	server := httptest.NewServer(capture)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*timeout)
+	t.Cleanup(func() {
+		cancel()
+		server.CloseClientConnections()
+		server.Close()
+	})
+
+	_, _ = kuma.New(
+		ctx,
+		server.URL,
+		"admin", "admin1",
+		kuma.WithConnectTimeout(timeout),
+		kuma.WithUserAgent(userAgent),
+	)
+
+	require.Equal(t, userAgent, capture.first(),
+		"the initial polling handshake should carry the configured User-Agent")
+	require.Equal(t, userAgent, capture.userAgentFor("websocket"),
+		"the WebSocket upgrade request should carry the configured User-Agent")
+}
+
+// entryPageHandler serves a minimal /api/entry-page response indicating no
+// database setup is required, so setupDatabase (invoked via WithAutosetup)
+// returns immediately after a single request. Every other path is delegated
+// to a fakeSocketIOServer so the subsequent Socket.IO connection attempt
+// behaves the same way as in TestWithUserAgent_Polling (a clean timeout)
+// instead of hitting an unhandled 404, which the underlying Socket.IO client
+// does not appear to recover from within ConnectTimeout.
+type entryPageHandler struct {
+	socketIO *fakeSocketIOServer
+}
+
+func (h *entryPageHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/api/entry-page" {
+		h.socketIO.ServeHTTP(w, r)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write([]byte(`{"type":"setup"}`))
+}
+
+// TestWithUserAgent_Autosetup verifies that WithUserAgent attaches the
+// configured User-Agent header to the entry-page HTTP request issued during
+// autosetup.
+func TestWithUserAgent_Autosetup(t *testing.T) {
+	const timeout = 500 * time.Millisecond
+	const userAgent = "terraform-provider-uptimekuma/test"
+
+	capture := &headerCapturingHandler{
+		inner: &entryPageHandler{socketIO: &fakeSocketIOServer{messages: make(chan []byte, 10)}},
+	}
+	server := httptest.NewServer(capture)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*timeout)
+	t.Cleanup(func() {
+		cancel()
+		server.CloseClientConnections()
+		server.Close()
+	})
+
+	// The fake server never emits ready events (see fakeSocketIOServer), so
+	// New() always times out after the autosetup phase. We only care that
+	// the entry-page request carried the right header.
+	_, _ = kuma.New(
+		ctx,
+		server.URL,
+		"admin", "admin1",
+		kuma.WithAutosetup(),
+		kuma.WithConnectTimeout(timeout),
+		kuma.WithUserAgent(userAgent),
+	)
+
+	require.Equal(t, userAgent, capture.first())
+}


### PR DESCRIPTION
## Summary

- Adds `kuma.WithUserAgent(userAgent string) Option` to set the `User-Agent` header on every request the client makes: the autosetup `entry-page`/`setup-database` HTTP probing, the Socket.IO long-polling transport, and the WebSocket handshake.
- Previously none of these set an explicit User-Agent, falling back to Go's default (`Go-http-client/1.1`) or no header at all on the WebSocket handshake. Some WAFs/reverse proxies reject this.
- When `WithUserAgent` is not set, behavior is unchanged (falls back to the library's default transports untouched).
- Implemented without forking `maldikhan/go.socket.io`: the polling transport's `HttpClient` interface and the WebSocket transport's `WebSocket` interface are both small enough to satisfy with custom wrappers that inject the header.

## Test plan

- [x] `task fmt` — no changes
- [x] `go vet ./...` — clean
- [x] `bin/golangci-lint run ./...` — 0 issues
- [x] `task test` (full suite incl. Docker-backed e2e tests) — all pass
- [x] New tests in `useragent_test.go`:
  - `TestWithUserAgent_Polling` — polling transport carries the configured UA
  - `TestWithUserAgent_PollingDefault` — falls back to Go's default UA when unset
  - `TestWithUserAgent_WebSocketHandshake` — WebSocket upgrade request carries the configured UA
  - `TestWithUserAgent_Autosetup` — autosetup entry-page request carries the configured UA

Closes #330