### PR TITLE
feat(statuspage): support custom url for status page monitors

### DIFF
--- a/statuspage.go
+++ b/statuspage.go
@@ -87,6 +87,10 @@ func (c *Client) SaveStatusPage(ctx context.Context, sp *statuspage.StatusPage) 
 				monitorData["sendUrl"] = *monitor.SendURL
 			}
 
+			if monitor.URL != nil {
+				monitorData["url"] = *monitor.URL
+			}
+
 			monitorList[j] = monitorData
 		}
 

--- a/statuspage/statuspage.go
+++ b/statuspage/statuspage.go
@@ -33,4 +33,8 @@ type PublicGroup struct {
 type PublicMonitor struct {
 	ID      int64 `json:"id"`
 	SendURL *bool `json:"sendUrl,omitempty"`
+	// URL overrides the link shown for this monitor on the status page.
+	// It corresponds to Uptime Kuma's "Custom URL" status page monitor
+	// setting (server-side stored as monitor_group.custom_url).
+	URL *string `json:"url,omitempty"`
 }

--- a/statuspage/statuspage_test.go
+++ b/statuspage/statuspage_test.go
@@ -43,7 +43,7 @@ func TestStatusPage_MarshalUnmarshal(t *testing.T) {
 						Name:   "Web Services",
 						Weight: 1,
 						MonitorList: []statuspage.PublicMonitor{
-							{ID: 100, SendURL: &sendURLTrue},
+							{ID: 100, SendURL: &sendURLTrue, URL: ptr.To("https://example.com/")},
 							{ID: 101, SendURL: &sendURLFalse},
 						},
 					},
@@ -95,7 +95,7 @@ func TestPublicGroup_MarshalUnmarshal(t *testing.T) {
 				Name:   "Test Group",
 				Weight: 5,
 				MonitorList: []statuspage.PublicMonitor{
-					{ID: 10, SendURL: &sendURL},
+					{ID: 10, SendURL: &sendURL, URL: ptr.To("https://example.com/")},
 					{ID: 20, SendURL: nil},
 				},
 			},
@@ -141,6 +141,14 @@ func TestPublicMonitor_MarshalUnmarshal(t *testing.T) {
 		{
 			name:    "monitor without sendUrl",
 			monitor: statuspage.PublicMonitor{ID: 3, SendURL: nil},
+		},
+		{
+			name:    "monitor with custom url",
+			monitor: statuspage.PublicMonitor{ID: 4, SendURL: &sendURLTrue, URL: ptr.To("https://example.com/")},
+		},
+		{
+			name:    "monitor without custom url",
+			monitor: statuspage.PublicMonitor{ID: 5, SendURL: &sendURLTrue, URL: nil},
 		},
 	}
 

--- a/statuspage_test.go
+++ b/statuspage_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/breml/go-uptime-kuma-client/internal/ptr"
 	"github.com/breml/go-uptime-kuma-client/monitor"
 	"github.com/breml/go-uptime-kuma-client/statuspage"
 )
@@ -164,7 +165,7 @@ func TestClient_StatusPageWithMonitors(t *testing.T) {
 				Name:   "Web Services",
 				Weight: 1,
 				MonitorList: []statuspage.PublicMonitor{
-					{ID: monitor1ID, SendURL: &sendURLTrue},
+					{ID: monitor1ID, SendURL: &sendURLTrue, URL: ptr.To("https://example.com/")},
 					{ID: monitor2ID, SendURL: &sendURLFalse},
 				},
 			},


### PR DESCRIPTION
## Summary

- Add a `URL *string` field (`json:"url,omitempty"`) to `statuspage.PublicMonitor`, letting a status page entry override the clickable link shown for a monitor independently of the monitor's own check URL
- Wire the new field through `SaveStatusPage`, mirroring the existing `SendURL` handling

Requested in breml/terraform-provider-uptimekuma#384. Note: the issue calls the attribute `custom_url` (matching the Uptime Kuma UI label), but the actual Uptime Kuma wire protocol field is `url` (paired with `sendUrl`), which is what this PR follows.

## Test plan

- [x] `task fmt`
- [x] `task lint`
- [x] `task test-e2e`