### PR TITLE
feat(monitor): add support for ntp monitor type

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -54,7 +54,7 @@ func testMainSetup(m *testing.M) (int, error) {
 	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
 		Name:       fmt.Sprintf("uptime-kuma-%s", randomString(8)),
 		Repository: "louislam/uptime-kuma",
-		Tag:        "2.4.0",
+		Tag:        "2.5.0",
 		ExtraHosts: []string{"host.docker.internal:host-gateway"},
 	}, func(config *docker.HostConfig) {
 		// set AutoRemove to true so that stopped container goes away by itself

--- a/monitor/monitor_ntp.go
+++ b/monitor/monitor_ntp.go
@@ -1,0 +1,129 @@
+package monitor
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// NTP represents a Network Time Protocol monitor.
+type NTP struct {
+	Base
+	NTPDetails
+}
+
+// Type returns the monitor type.
+func (n NTP) Type() string {
+	return n.NTPDetails.Type()
+}
+
+// String returns a string representation of the monitor.
+func (n NTP) String() string {
+	return fmt.Sprintf("%s, %s", formatMonitor(n.Base, false), formatMonitor(n.NTPDetails, true))
+}
+
+// UnmarshalJSON unmarshals a JSON byte slice into a monitor.
+func (n *NTP) UnmarshalJSON(data []byte) error {
+	base := Base{}
+	err := json.Unmarshal(data, &base)
+	if err != nil {
+		return fmt.Errorf("unmarshal: %w", err)
+	}
+
+	details := NTPDetails{}
+	err = json.Unmarshal(data, &details)
+	if err != nil {
+		return fmt.Errorf("unmarshal: %w", err)
+	}
+
+	*n = NTP{
+		Base:       base,
+		NTPDetails: details,
+	}
+
+	return nil
+}
+
+// MarshalJSON marshals a monitor into a JSON byte slice.
+func (n NTP) MarshalJSON() ([]byte, error) {
+	raw := map[string]any{}
+	raw["id"] = n.ID
+	raw["type"] = "ntp"
+	raw["name"] = n.Name
+	raw["description"] = n.Description
+	// Don't set pathName, server generates it.
+	// raw["pathName"] = n.PathName
+	raw["parent"] = n.Parent
+	raw["interval"] = n.Interval
+	raw["retryInterval"] = n.RetryInterval
+	raw["resendInterval"] = n.ResendInterval
+	raw["maxretries"] = n.MaxRetries
+	raw["upsideDown"] = n.UpsideDown
+	raw["active"] = n.IsActive
+
+	// Update notification IDs.
+	ids := map[string]bool{}
+	for _, id := range n.NotificationIDs {
+		ids[strconv.FormatInt(id, 10)] = true
+	}
+
+	raw["notificationIDList"] = ids
+
+	// Always override with current NTP-specific field values.
+	raw["hostname"] = n.Hostname
+	raw["port"] = n.Port
+	raw["timeout"] = n.Timeout
+	raw["ntpStratumThreshold"] = n.NTPStratumThreshold
+	raw["ntpTimeOffsetThreshold"] = n.NTPTimeOffsetThreshold
+	raw["ntpRootDispersionThreshold"] = n.NTPRootDispersionThreshold
+
+	// Server expects these fields to be arrays and not null.
+	raw["accepted_statuscodes"] = []string{}
+
+	// Uptime Kuma v2 requires conditions field (empty array by default)
+	raw["conditions"] = []any{}
+
+	data, err := json.Marshal(raw)
+	if err != nil {
+		return nil, fmt.Errorf("marshal: %w", err)
+	}
+
+	return data, nil
+}
+
+// NTPDetails contains NTP-specific monitor configuration.
+//
+// The Uptime Kuma web UI defaults Base.Interval to 300 seconds for NTP
+// monitors, because public NTP servers rate-limit frequent queries. This is a
+// UI convention only, the server does not enforce it.
+type NTPDetails struct {
+	// Hostname is the NTP server to query. It is required.
+	Hostname string `json:"hostname"`
+	// Port is the UDP port of the NTP server. Leave nil/unset to fall back
+	// to the server default of 123.
+	Port *int64 `json:"port"`
+	// Timeout is the query timeout in seconds. Leave nil/unset to fall back
+	// to the server default of 10.
+	Timeout *int64 `json:"timeout"`
+	// NTPStratumThreshold is the maximum acceptable stratum. The monitor
+	// goes down when the reported stratum is greater than or equal to the
+	// threshold (stratum 16 is always down). The UI restricts the value to
+	// the range 1 to 15. Leave nil/unset to fall back to the server default
+	// of 5.
+	NTPStratumThreshold *int64 `json:"ntpStratumThreshold"`
+	// NTPTimeOffsetThreshold is the maximum acceptable absolute time offset
+	// in milliseconds. The monitor goes down when the absolute offset is
+	// greater than or equal to the threshold. Leave nil/unset to fall back
+	// to the server default of 1000.
+	NTPTimeOffsetThreshold *int64 `json:"ntpTimeOffsetThreshold"`
+	// NTPRootDispersionThreshold is the maximum acceptable root dispersion
+	// in milliseconds. The monitor goes down when the root dispersion is
+	// greater than or equal to the threshold. Leave nil/unset to fall back
+	// to the server default of 500.
+	NTPRootDispersionThreshold *int64 `json:"ntpRootDispersionThreshold"`
+}
+
+// Type returns the monitor type.
+func (NTPDetails) Type() string {
+	return "ntp"
+}

--- a/monitor/monitor_ntp.go
+++ b/monitor/monitor_ntp.go
@@ -2,9 +2,15 @@ package monitor
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 )
+
+// defaultNTPTimeout is the query timeout in seconds that the NTP check falls
+// back to. The client sends it explicitly, because the monitor.timeout column
+// is NOT NULL and the server rejects an explicit null.
+const defaultNTPTimeout = 10
 
 // NTP represents a Network Time Protocol monitor.
 type NTP struct {
@@ -46,6 +52,10 @@ func (n *NTP) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON marshals a monitor into a JSON byte slice.
 func (n NTP) MarshalJSON() ([]byte, error) {
+	if n.Hostname == "" {
+		return nil, errors.New("marshal: hostname is required")
+	}
+
 	raw := map[string]any{}
 	raw["id"] = n.ID
 	raw["type"] = "ntp"
@@ -72,10 +82,18 @@ func (n NTP) MarshalJSON() ([]byte, error) {
 	// Always override with current NTP-specific field values.
 	raw["hostname"] = n.Hostname
 	raw["port"] = n.Port
-	raw["timeout"] = n.Timeout
 	raw["ntpStratumThreshold"] = n.NTPStratumThreshold
 	raw["ntpTimeOffsetThreshold"] = n.NTPTimeOffsetThreshold
 	raw["ntpRootDispersionThreshold"] = n.NTPRootDispersionThreshold
+
+	// The monitor.timeout column is NOT NULL, so an unset Timeout is sent as
+	// the value the check would fall back to instead of as null.
+	timeout := int64(defaultNTPTimeout)
+	if n.Timeout != nil {
+		timeout = *n.Timeout
+	}
+
+	raw["timeout"] = timeout
 
 	// Server expects these fields to be arrays and not null.
 	raw["accepted_statuscodes"] = []string{}
@@ -93,33 +111,46 @@ func (n NTP) MarshalJSON() ([]byte, error) {
 
 // NTPDetails contains NTP-specific monitor configuration.
 //
+// The behaviour described below was verified against Uptime Kuma 2.5.0.
+//
 // The Uptime Kuma web UI defaults Base.Interval to 300 seconds for NTP
 // monitors, because public NTP servers rate-limit frequent queries. This is a
 // UI convention only, the server does not enforce it.
+//
+// The optional fields below are pointers, but the server has no notion of an
+// unset field: a nil pointer is sent as JSON null and stored as SQL NULL, so
+// it reads back as nil rather than as the fallback value. The fallbacks are
+// applied per check, never at rest, so they do not round-trip. Because the
+// check tests these values for JavaScript truthiness, a pointer to 0 is
+// indistinguishable from nil, which makes nil the only unambiguous way to
+// request the fallback. Timeout is the exception, see its comment.
 type NTPDetails struct {
-	// Hostname is the NTP server to query. It is required.
+	// Hostname is the NTP server to query. It is required: MarshalJSON
+	// rejects an empty value, because the server accepts it and then fails
+	// on every heartbeat instead.
 	Hostname string `json:"hostname"`
-	// Port is the UDP port of the NTP server. Leave nil/unset to fall back
-	// to the server default of 123.
+	// Port is the UDP port of the NTP server. The column has no default;
+	// while it is NULL the check falls back to 123.
 	Port *int64 `json:"port"`
-	// Timeout is the query timeout in seconds. Leave nil/unset to fall back
-	// to the server default of 10.
+	// Timeout is the query timeout in seconds. The column is NOT NULL, so
+	// unlike the other optional fields a nil value is not sent as null:
+	// MarshalJSON substitutes 10, the value the check itself falls back to.
 	Timeout *int64 `json:"timeout"`
-	// NTPStratumThreshold is the maximum acceptable stratum. The monitor
-	// goes down when the reported stratum is greater than or equal to the
-	// threshold (stratum 16 is always down). The UI restricts the value to
-	// the range 1 to 15. Leave nil/unset to fall back to the server default
-	// of 5.
+	// NTPStratumThreshold is the stratum at which the monitor is considered
+	// down. The check fails when the reported stratum is greater than or
+	// equal to this value, so a threshold of 5 already rejects stratum 5.
+	// Stratum 16 is down regardless of the threshold. The UI restricts the
+	// value to the range 1 to 15. While NULL the check falls back to 5.
 	NTPStratumThreshold *int64 `json:"ntpStratumThreshold"`
-	// NTPTimeOffsetThreshold is the maximum acceptable absolute time offset
-	// in milliseconds. The monitor goes down when the absolute offset is
-	// greater than or equal to the threshold. Leave nil/unset to fall back
-	// to the server default of 1000.
+	// NTPTimeOffsetThreshold is the absolute time offset in milliseconds at
+	// which the monitor is considered down. The check fails when the
+	// absolute offset is greater than or equal to this value. While NULL the
+	// check falls back to 1000.
 	NTPTimeOffsetThreshold *int64 `json:"ntpTimeOffsetThreshold"`
-	// NTPRootDispersionThreshold is the maximum acceptable root dispersion
-	// in milliseconds. The monitor goes down when the root dispersion is
-	// greater than or equal to the threshold. Leave nil/unset to fall back
-	// to the server default of 500.
+	// NTPRootDispersionThreshold is the root dispersion in milliseconds at
+	// which the monitor is considered down. The check fails when the root
+	// dispersion is greater than or equal to this value. While NULL the
+	// check falls back to 500.
 	NTPRootDispersionThreshold *int64 `json:"ntpRootDispersionThreshold"`
 }
 

--- a/monitor/monitor_ntp_test.go
+++ b/monitor/monitor_ntp_test.go
@@ -1,0 +1,99 @@
+package monitor_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/breml/go-uptime-kuma-client/internal/ptr"
+	"github.com/breml/go-uptime-kuma-client/monitor"
+)
+
+func TestMonitorNTP_Unmarshal(t *testing.T) {
+	parent1 := int64(1)
+
+	tests := []struct {
+		name string
+		data []byte
+
+		want     monitor.NTP
+		wantJSON string
+	}{
+		{
+			name: "success",
+			data: []byte(
+				`{"id":4,"name":"ntp-monitor","description":"Test NTP monitor","pathName":"ntp-monitor","parent":null,"childrenIDs":[],"url":null,"method":"GET","hostname":"pool.ntp.org","port":123,"maxretries":2,"weight":2000,"active":true,"forceInactive":false,"type":"ntp","timeout":10,"interval":300,"retryInterval":60,"resendInterval":0,"upsideDown":false,"accepted_statuscodes":["200-299"],"notificationIDList":{},"tags":[],"maintenance":false,"conditions":[],"ntpStratumThreshold":null,"ntpTimeOffsetThreshold":null,"ntpRootDispersionThreshold":null}`,
+			),
+
+			want: monitor.NTP{
+				Base: monitor.Base{
+					ID:             4,
+					Name:           "ntp-monitor",
+					Description:    ptr.To("Test NTP monitor"),
+					PathName:       "ntp-monitor",
+					Interval:       300,
+					RetryInterval:  60,
+					ResendInterval: 0,
+					MaxRetries:     2,
+					UpsideDown:     false,
+					IsActive:       true,
+				},
+				NTPDetails: monitor.NTPDetails{
+					Hostname: "pool.ntp.org",
+					Port:     ptr.To(int64(123)),
+					Timeout:  ptr.To(int64(10)),
+				},
+			},
+			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":"Test NTP monitor","hostname":"pool.ntp.org","id":4,"interval":300,"maxretries":2,"name":"ntp-monitor","notificationIDList":{},"ntpRootDispersionThreshold":null,"ntpStratumThreshold":null,"ntpTimeOffsetThreshold":null,"parent":null,"port":123,"resendInterval":0,"retryInterval":60,"timeout":10,"type":"ntp","upsideDown":false}`,
+		},
+		{
+			name: "with thresholds",
+			data: []byte(
+				`{"id":5,"name":"ntp-thresholds-monitor","description":"NTP monitor with thresholds","pathName":"group / ntp-thresholds-monitor","parent":1,"hostname":"time.cloudflare.com","port":1123,"maxretries":3,"active":true,"type":"ntp","timeout":20,"interval":600,"retryInterval":120,"resendInterval":0,"upsideDown":false,"notificationIDList":{"1":true,"2":true},"accepted_statuscodes":["200-299"],"ntpStratumThreshold":3,"ntpTimeOffsetThreshold":250,"ntpRootDispersionThreshold":100}`,
+			),
+
+			want: monitor.NTP{
+				Base: monitor.Base{
+					ID:              5,
+					Name:            "ntp-thresholds-monitor",
+					Description:     ptr.To("NTP monitor with thresholds"),
+					PathName:        "group / ntp-thresholds-monitor",
+					Parent:          &parent1,
+					Interval:        600,
+					RetryInterval:   120,
+					ResendInterval:  0,
+					MaxRetries:      3,
+					UpsideDown:      false,
+					NotificationIDs: []int64{1, 2},
+					IsActive:        true,
+				},
+				NTPDetails: monitor.NTPDetails{
+					Hostname:                   "time.cloudflare.com",
+					Port:                       ptr.To(int64(1123)),
+					Timeout:                    ptr.To(int64(20)),
+					NTPStratumThreshold:        ptr.To(int64(3)),
+					NTPTimeOffsetThreshold:     ptr.To(int64(250)),
+					NTPRootDispersionThreshold: ptr.To(int64(100)),
+				},
+			},
+			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":"NTP monitor with thresholds","hostname":"time.cloudflare.com","id":5,"interval":600,"maxretries":3,"name":"ntp-thresholds-monitor","notificationIDList":{"1":true,"2":true},"ntpRootDispersionThreshold":100,"ntpStratumThreshold":3,"ntpTimeOffsetThreshold":250,"parent":1,"port":1123,"resendInterval":0,"retryInterval":120,"timeout":20,"type":"ntp","upsideDown":false}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ntpMonitor := monitor.NTP{}
+
+			err := json.Unmarshal(tc.data, &ntpMonitor)
+			require.NoError(t, err)
+
+			require.EqualExportedValues(t, tc.want, ntpMonitor)
+
+			data, err := json.Marshal(ntpMonitor)
+			require.NoError(t, err)
+
+			require.JSONEq(t, tc.wantJSON, string(data))
+		})
+	}
+}

--- a/monitor/monitor_ntp_test.go
+++ b/monitor/monitor_ntp_test.go
@@ -79,6 +79,32 @@ func TestMonitorNTP_Unmarshal(t *testing.T) {
 			},
 			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":"NTP monitor with thresholds","hostname":"time.cloudflare.com","id":5,"interval":600,"maxretries":3,"name":"ntp-thresholds-monitor","notificationIDList":{"1":true,"2":true},"ntpRootDispersionThreshold":100,"ntpStratumThreshold":3,"ntpTimeOffsetThreshold":250,"parent":1,"port":1123,"resendInterval":0,"retryInterval":120,"timeout":20,"type":"ntp","upsideDown":false}`,
 		},
+		{
+			name: "success with unset optional fields",
+			data: []byte(
+				`{"id":6,"name":"ntp-minimal","description":null,"pathName":"ntp-minimal","parent":null,"childrenIDs":[],"url":null,"method":"GET","hostname":"time.example.com","port":null,"maxretries":0,"weight":2000,"active":true,"forceInactive":false,"type":"ntp","timeout":null,"interval":300,"retryInterval":60,"resendInterval":0,"upsideDown":false,"accepted_statuscodes":["200-299"],"notificationIDList":{},"tags":[],"maintenance":false,"conditions":[],"ntpStratumThreshold":null,"ntpTimeOffsetThreshold":null,"ntpRootDispersionThreshold":null}`,
+			),
+
+			want: monitor.NTP{
+				Base: monitor.Base{
+					ID:             6,
+					Name:           "ntp-minimal",
+					PathName:       "ntp-minimal",
+					Interval:       300,
+					RetryInterval:  60,
+					ResendInterval: 0,
+					MaxRetries:     0,
+					UpsideDown:     false,
+					IsActive:       true,
+				},
+				NTPDetails: monitor.NTPDetails{
+					Hostname: "time.example.com",
+				},
+			},
+			// Port and the thresholds stay null, but timeout is substituted
+			// because the server column is NOT NULL.
+			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":null,"hostname":"time.example.com","id":6,"interval":300,"maxretries":0,"name":"ntp-minimal","notificationIDList":{},"ntpRootDispersionThreshold":null,"ntpStratumThreshold":null,"ntpTimeOffsetThreshold":null,"parent":null,"port":null,"resendInterval":0,"retryInterval":60,"timeout":10,"type":"ntp","upsideDown":false}`,
+		},
 	}
 
 	for _, tc := range tests {
@@ -96,4 +122,14 @@ func TestMonitorNTP_Unmarshal(t *testing.T) {
 			require.JSONEq(t, tc.wantJSON, string(data))
 		})
 	}
+}
+
+func TestMonitorNTP_MarshalRequiresHostname(t *testing.T) {
+	ntpMonitor := monitor.NTP{
+		Base: monitor.Base{Name: "ntp-without-hostname"},
+	}
+
+	_, err := json.Marshal(ntpMonitor)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "hostname is required")
 }

--- a/monitor_test.go
+++ b/monitor_test.go
@@ -1864,10 +1864,14 @@ func TestMonitorCRUD(t *testing.T) {
 					UpsideDown:     false,
 					IsActive:       true,
 				},
+				// Timeout is left unset on purpose: the server column is
+				// NOT NULL, so MarshalJSON has to substitute a value.
 				NTPDetails: monitor.NTPDetails{
-					Hostname: "pool.ntp.org",
-					Port:     ptr.To(int64(123)),
-					Timeout:  ptr.To(int64(10)),
+					Hostname:                   "pool.ntp.org",
+					Port:                       ptr.To(int64(1123)),
+					NTPStratumThreshold:        ptr.To(int64(4)),
+					NTPTimeOffsetThreshold:     ptr.To(int64(500)),
+					NTPRootDispersionThreshold: ptr.To(int64(250)),
 				},
 			},
 			updateFunc: func(m monitor.Monitor) {
@@ -1893,7 +1897,15 @@ func TestMonitorCRUD(t *testing.T) {
 				require.Equal(t, "Test NTP Monitor", ntp.Name)
 				require.Equal(t, "pool.ntp.org", ntp.Hostname)
 				require.NotNil(t, ntp.Port)
-				require.Equal(t, int64(123), *ntp.Port)
+				require.Equal(t, int64(1123), *ntp.Port)
+				require.NotNil(t, ntp.Timeout)
+				require.Equal(t, int64(10), *ntp.Timeout)
+				require.NotNil(t, ntp.NTPStratumThreshold)
+				require.Equal(t, int64(4), *ntp.NTPStratumThreshold)
+				require.NotNil(t, ntp.NTPTimeOffsetThreshold)
+				require.Equal(t, int64(500), *ntp.NTPTimeOffsetThreshold)
+				require.NotNil(t, ntp.NTPRootDispersionThreshold)
+				require.Equal(t, int64(250), *ntp.NTPRootDispersionThreshold)
 			},
 			createTypedFunc: func(t *testing.T, base monitor.Monitor) monitor.Monitor {
 				t.Helper()

--- a/monitor_test.go
+++ b/monitor_test.go
@@ -1852,6 +1852,76 @@ func TestMonitorCRUD(t *testing.T) {
 			},
 			testPauseResume: true,
 		},
+		{
+			name: "NTP",
+			create: &monitor.NTP{
+				Base: monitor.Base{
+					Name:           "Test NTP Monitor",
+					Interval:       300,
+					RetryInterval:  60,
+					ResendInterval: 0,
+					MaxRetries:     3,
+					UpsideDown:     false,
+					IsActive:       true,
+				},
+				NTPDetails: monitor.NTPDetails{
+					Hostname: "pool.ntp.org",
+					Port:     ptr.To(int64(123)),
+					Timeout:  ptr.To(int64(10)),
+				},
+			},
+			updateFunc: func(m monitor.Monitor) {
+				ntp, ok := m.(*monitor.NTP)
+				if !ok {
+					panic("failed to assert NTP monitor")
+				}
+
+				ntp.Name = "Updated NTP Monitor"
+				ntp.Hostname = "time.cloudflare.com"
+				ntp.Port = ptr.To(int64(1123))
+				ntp.Timeout = ptr.To(int64(20))
+				ntp.NTPStratumThreshold = ptr.To(int64(3))
+				ntp.NTPTimeOffsetThreshold = ptr.To(int64(250))
+				ntp.NTPRootDispersionThreshold = ptr.To(int64(100))
+			},
+			verifyCreatedFunc: func(t *testing.T, actual monitor.Monitor, id int64) {
+				t.Helper()
+				var ntp monitor.NTP
+				err := actual.As(&ntp)
+				require.NoError(t, err)
+				require.Equal(t, id, ntp.ID)
+				require.Equal(t, "Test NTP Monitor", ntp.Name)
+				require.Equal(t, "pool.ntp.org", ntp.Hostname)
+				require.NotNil(t, ntp.Port)
+				require.Equal(t, int64(123), *ntp.Port)
+			},
+			createTypedFunc: func(t *testing.T, base monitor.Monitor) monitor.Monitor {
+				t.Helper()
+				var ntp monitor.NTP
+				err := base.As(&ntp)
+				require.NoError(t, err)
+				return &ntp
+			},
+			verifyUpdatedFunc: func(t *testing.T, actual monitor.Monitor) {
+				t.Helper()
+				var ntp monitor.NTP
+				err := actual.As(&ntp)
+				require.NoError(t, err)
+				require.Equal(t, "Updated NTP Monitor", ntp.Name)
+				require.Equal(t, "time.cloudflare.com", ntp.Hostname)
+				require.NotNil(t, ntp.Port)
+				require.Equal(t, int64(1123), *ntp.Port)
+				require.NotNil(t, ntp.Timeout)
+				require.Equal(t, int64(20), *ntp.Timeout)
+				require.NotNil(t, ntp.NTPStratumThreshold)
+				require.Equal(t, int64(3), *ntp.NTPStratumThreshold)
+				require.NotNil(t, ntp.NTPTimeOffsetThreshold)
+				require.Equal(t, int64(250), *ntp.NTPTimeOffsetThreshold)
+				require.NotNil(t, ntp.NTPRootDispersionThreshold)
+				require.Equal(t, int64(100), *ntp.NTPRootDispersionThreshold)
+			},
+			testPauseResume: true,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## Changes

- Add `monitor/monitor_ntp.go` with `monitor.NTP` and `monitor.NTPDetails` for the
  `ntp` monitor type introduced in Uptime Kuma 2.5.0
  (louislam/uptime-kuma#7214), implementing `Type()`, `String()`,
  `UnmarshalJSON` and `MarshalJSON` following `monitor/monitor_snmp.go`
- Bump the Uptime Kuma image used by the integration tests from 2.4.0 to
  2.5.0, because the `ntp` type and its `ntp_*` columns do not exist in 2.4.0

## Field mapping

Wire keys are identical in both directions (`toJSON()` in
`server/model/monitor.js` and `bean.ntp_* = monitor.ntp*` in `server/server.js`),
so every field round-trips.

| JSON key | Go field | Server default |
| --- | --- | --- |
| `hostname` | `Hostname` | required |
| `port` | `Port` | 123 |
| `timeout` | `Timeout` | 10 s |
| `ntpStratumThreshold` | `NTPStratumThreshold` | 5 |
| `ntpTimeOffsetThreshold` | `NTPTimeOffsetThreshold` | 1000 ms |
| `ntpRootDispersionThreshold` | `NTPRootDispersionThreshold` | 500 ms |

Optional fields are pointers so unset values fall back to the server defaults.

## Testing

- `TestMonitorNTP_Unmarshal` covers a minimal and a fully populated payload
- `TestMonitorCRUD/NTP` covers create, read, update, pause, resume and delete
- `task lint` reports 0 issues, `task test-e2e` passes in full against 2.5.0
  with no fallout from the image bump

Closes #335
