### PR TITLE
feat(monitor): add support for pm2 monitor type

### DIFF
--- a/monitor/monitor_pm2.go
+++ b/monitor/monitor_pm2.go
@@ -1,0 +1,108 @@
+package monitor
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// PM2 represents a pm2 monitor.
+type PM2 struct {
+	Base
+	PM2Details
+}
+
+// Type returns the monitor type.
+func (p PM2) Type() string {
+	return p.PM2Details.Type()
+}
+
+// String returns a string representation of the monitor.
+func (p PM2) String() string {
+	return fmt.Sprintf("%s, %s", formatMonitor(p.Base, false), formatMonitor(p.PM2Details, true))
+}
+
+// UnmarshalJSON unmarshals a JSON byte slice into a monitor.
+func (p *PM2) UnmarshalJSON(data []byte) error {
+	base := Base{}
+	err := json.Unmarshal(data, &base)
+	if err != nil {
+		return fmt.Errorf("unmarshal pm2 monitor base: %w", err)
+	}
+
+	details := PM2Details{}
+	err = json.Unmarshal(data, &details)
+	if err != nil {
+		return fmt.Errorf("unmarshal pm2 monitor details: %w", err)
+	}
+
+	*p = PM2{
+		Base:       base,
+		PM2Details: details,
+	}
+
+	return nil
+}
+
+// MarshalJSON marshals a monitor into a JSON byte slice.
+func (p PM2) MarshalJSON() ([]byte, error) {
+	raw := map[string]any{}
+	raw["id"] = p.ID
+	raw["type"] = "pm2"
+	raw["name"] = p.Name
+	raw["description"] = p.Description
+	// Don't set pathName, server generates it.
+	// raw["pathName"] = p.PathName
+	raw["parent"] = p.Parent
+	raw["interval"] = p.Interval
+	raw["retryInterval"] = p.RetryInterval
+	raw["resendInterval"] = p.ResendInterval
+	raw["maxretries"] = p.MaxRetries
+	raw["upsideDown"] = p.UpsideDown
+	raw["active"] = p.IsActive
+
+	// Update notification IDs.
+	ids := map[string]bool{}
+	for _, id := range p.NotificationIDs {
+		ids[strconv.FormatInt(id, 10)] = true
+	}
+
+	raw["notificationIDList"] = ids
+
+	// Always override with current PM2-specific field values.
+	raw["system_service_name"] = p.SystemServiceName
+
+	// Server expects these fields to be arrays and not null.
+	raw["accepted_statuscodes"] = []string{}
+
+	// Uptime Kuma v2 requires conditions field (empty array by default)
+	raw["conditions"] = []any{}
+
+	data, err := json.Marshal(raw)
+	if err != nil {
+		return nil, fmt.Errorf("marshal pm2 monitor: %w", err)
+	}
+
+	return data, nil
+}
+
+// PM2Details contains pm2-specific monitor configuration.
+//
+// The pm2 monitor shells out to the pm2 CLI on the Uptime Kuma host, so, like
+// the system-service monitor, it only works on non-container installations.
+type PM2Details struct {
+	// SystemServiceName is the name of the PM2 process to check, as reported
+	// by `pm2 jlist`. The server trims the value and requires it to be
+	// non-empty and free of ASCII control characters (U+0000..U+001F, U+007F).
+	// The process name is used instead of the numeric PM2 id, because PM2
+	// reassigns ids after a process is deleted and recreated.
+	// Note: the field is shared with the system-service monitor and the
+	// upstream API uses snake_case for it, unlike most other Uptime Kuma
+	// fields.
+	SystemServiceName string `json:"system_service_name"`
+}
+
+// Type returns the monitor type.
+func (PM2Details) Type() string {
+	return "pm2"
+}

--- a/monitor/monitor_pm2.go
+++ b/monitor/monitor_pm2.go
@@ -2,8 +2,10 @@ package monitor
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 )
 
 // PM2 represents a pm2 monitor.
@@ -46,6 +48,10 @@ func (p *PM2) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON marshals a monitor into a JSON byte slice.
 func (p PM2) MarshalJSON() ([]byte, error) {
+	if strings.TrimSpace(p.ProcessName) == "" {
+		return nil, errors.New("marshal: process name is required")
+	}
+
 	raw := map[string]any{}
 	raw["id"] = p.ID
 	raw["type"] = "pm2"
@@ -70,7 +76,7 @@ func (p PM2) MarshalJSON() ([]byte, error) {
 	raw["notificationIDList"] = ids
 
 	// Always override with current PM2-specific field values.
-	raw["system_service_name"] = p.SystemServiceName
+	raw["system_service_name"] = p.ProcessName
 
 	// Server expects these fields to be arrays and not null.
 	raw["accepted_statuscodes"] = []string{}
@@ -88,18 +94,27 @@ func (p PM2) MarshalJSON() ([]byte, error) {
 
 // PM2Details contains pm2-specific monitor configuration.
 //
-// The pm2 monitor shells out to the pm2 CLI on the Uptime Kuma host, so, like
-// the system-service monitor, it only works on non-container installations.
+// The behaviour described below was verified against Uptime Kuma 2.5.0.
+//
+// The check runs `pm2 jlist` on the Uptime Kuma host, so the pm2 CLI must be
+// installed there and must see the target PM2 daemon. The official container
+// image does not ship it, but, unlike the system-service monitor, upstream
+// does not otherwise restrict the type in containers.
 type PM2Details struct {
-	// SystemServiceName is the name of the PM2 process to check, as reported
-	// by `pm2 jlist`. The server trims the value and requires it to be
-	// non-empty and free of ASCII control characters (U+0000..U+001F, U+007F).
-	// The process name is used instead of the numeric PM2 id, because PM2
-	// reassigns ids after a process is deleted and recreated.
-	// Note: the field is shared with the system-service monitor and the
+	// ProcessName identifies the PM2 process to check. The server matches it
+	// against both the process name and the stringified numeric PM2 id
+	// reported by `pm2 jlist`, so either form works. Prefer the name, because
+	// PM2 reassigns ids after a process is deleted and recreated.
+	//
+	// The server trims the value and requires it to be non-empty and free of
+	// ASCII control characters (U+0000..U+001F, U+007F). MarshalJSON rejects
+	// an empty (or whitespace-only) value, the remaining rules are enforced
+	// by the server only.
+	//
+	// Note: the wire field is shared with the system-service monitor and the
 	// upstream API uses snake_case for it, unlike most other Uptime Kuma
 	// fields.
-	SystemServiceName string `json:"system_service_name"`
+	ProcessName string `json:"system_service_name"`
 }
 
 // Type returns the monitor type.

--- a/monitor/monitor_pm2_test.go
+++ b/monitor/monitor_pm2_test.go
@@ -42,12 +42,14 @@ func TestMonitorPM2_Unmarshal(t *testing.T) {
 					IsActive:        true,
 				},
 				PM2Details: monitor.PM2Details{
-					SystemServiceName: "api-server",
+					ProcessName: "api-server",
 				},
 			},
 			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":"Test PM2 monitor","id":4,"interval":60,"maxretries":2,"name":"pm2-monitor","notificationIDList":{"1":true,"2":true},"parent":1,"resendInterval":0,"retryInterval":60,"system_service_name":"api-server","type":"pm2","upsideDown":false}`,
 		},
 		{
+			// The "worker 1" fixture contains a space: the system-service
+			// monitor rejects it, pm2 forbids only ASCII control characters.
 			name: "success without parent",
 			data: []byte(
 				`{"id":5,"name":"pm2-monitor-no-parent","description":null,"pathName":"pm2-monitor-no-parent","parent":null,"childrenIDs":[],"url":null,"method":"GET","hostname":null,"port":null,"maxretries":3,"weight":2000,"active":true,"forceInactive":false,"type":"pm2","timeout":null,"interval":120,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":"A","dns_resolve_server":"1.1.1.1","dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{},"tags":[],"maintenance":false,"mqttTopic":"","mqttSuccessMessage":"","databaseQuery":null,"authMethod":null,"grpcUrl":null,"grpcProtobuf":null,"grpcMethod":null,"grpcServiceName":null,"grpcEnableTls":false,"radiusCalledStationId":null,"radiusCallingStationId":null,"game":null,"gamedigGivenPortOnly":true,"httpBodyEncoding":"json","jsonPath":null,"expectedValue":null,"kafkaProducerTopic":null,"kafkaProducerBrokers":[],"kafkaProducerSsl":false,"kafkaProducerAllowAutoTopicCreation":false,"kafkaProducerMessage":null,"screenshot":null,"headers":null,"body":null,"grpcBody":null,"grpcMetadata":null,"basic_auth_user":null,"basic_auth_pass":null,"oauth_client_id":null,"oauth_client_secret":null,"oauth_token_url":null,"oauth_scopes":null,"oauth_auth_method":"client_secret_basic","pushToken":null,"databaseConnectionString":null,"radiusUsername":null,"radiusPassword":null,"radiusSecret":null,"mqttUsername":"","mqttPassword":"","authWorkstation":null,"authDomain":null,"tlsCa":null,"tlsCert":null,"tlsKey":null,"kafkaProducerSaslOptions":{"mechanism":"None"},"system_service_name":"worker 1","includeSensitiveData":true}`,
@@ -67,40 +69,11 @@ func TestMonitorPM2_Unmarshal(t *testing.T) {
 					UpsideDown:     false,
 					IsActive:       true,
 				},
-				// PM2 process names may contain characters the
-				// system-service monitor rejects, only ASCII control
-				// characters are forbidden.
 				PM2Details: monitor.PM2Details{
-					SystemServiceName: "worker 1",
+					ProcessName: "worker 1",
 				},
 			},
 			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":null,"id":5,"interval":120,"maxretries":3,"name":"pm2-monitor-no-parent","notificationIDList":{},"parent":null,"resendInterval":0,"retryInterval":60,"system_service_name":"worker 1","type":"pm2","upsideDown":false}`,
-		},
-		{
-			name: "success with empty process name",
-			data: []byte(
-				`{"id":6,"name":"pm2-empty","description":null,"pathName":"pm2-empty","parent":null,"childrenIDs":[],"url":null,"method":"GET","hostname":null,"port":null,"maxretries":0,"weight":2000,"active":true,"forceInactive":false,"type":"pm2","timeout":null,"interval":60,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":"A","dns_resolve_server":"1.1.1.1","dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{},"tags":[],"maintenance":false,"mqttTopic":"","mqttSuccessMessage":"","databaseQuery":null,"authMethod":null,"grpcUrl":null,"grpcProtobuf":null,"grpcMethod":null,"grpcServiceName":null,"grpcEnableTls":false,"radiusCalledStationId":null,"radiusCallingStationId":null,"game":null,"gamedigGivenPortOnly":true,"httpBodyEncoding":"json","jsonPath":null,"expectedValue":null,"kafkaProducerTopic":null,"kafkaProducerBrokers":[],"kafkaProducerSsl":false,"kafkaProducerAllowAutoTopicCreation":false,"kafkaProducerMessage":null,"screenshot":null,"headers":null,"body":null,"grpcBody":null,"grpcMetadata":null,"basic_auth_user":null,"basic_auth_pass":null,"oauth_client_id":null,"oauth_client_secret":null,"oauth_token_url":null,"oauth_scopes":null,"oauth_auth_method":"client_secret_basic","pushToken":null,"databaseConnectionString":null,"radiusUsername":null,"radiusPassword":null,"radiusSecret":null,"mqttUsername":"","mqttPassword":"","authWorkstation":null,"authDomain":null,"tlsCa":null,"tlsCert":null,"tlsKey":null,"kafkaProducerSaslOptions":{"mechanism":"None"},"system_service_name":"","includeSensitiveData":true}`,
-			),
-
-			want: monitor.PM2{
-				Base: monitor.Base{
-					ID:             6,
-					Name:           "pm2-empty",
-					Description:    nil,
-					PathName:       "pm2-empty",
-					Parent:         nil,
-					Interval:       60,
-					RetryInterval:  60,
-					ResendInterval: 0,
-					MaxRetries:     0,
-					UpsideDown:     false,
-					IsActive:       true,
-				},
-				PM2Details: monitor.PM2Details{
-					SystemServiceName: "",
-				},
-			},
-			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":null,"id":6,"interval":60,"maxretries":0,"name":"pm2-empty","notificationIDList":{},"parent":null,"resendInterval":0,"retryInterval":60,"system_service_name":"","type":"pm2","upsideDown":false}`,
 		},
 	}
 
@@ -117,6 +90,35 @@ func TestMonitorPM2_Unmarshal(t *testing.T) {
 			require.NoError(t, err)
 
 			require.JSONEq(t, tc.wantJSON, string(data))
+		})
+	}
+}
+
+func TestMonitorPM2_MarshalRequiresProcessName(t *testing.T) {
+	tests := []struct {
+		name        string
+		processName string
+	}{
+		{
+			name:        "empty",
+			processName: "",
+		},
+		{
+			name:        "whitespace only",
+			processName: "   ",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pm2Monitor := monitor.PM2{
+				Base:       monitor.Base{Name: "pm2-without-process-name"},
+				PM2Details: monitor.PM2Details{ProcessName: tc.processName},
+			}
+
+			_, err := json.Marshal(pm2Monitor)
+			require.Error(t, err)
+			require.ErrorContains(t, err, "process name is required")
 		})
 	}
 }

--- a/monitor/monitor_pm2_test.go
+++ b/monitor/monitor_pm2_test.go
@@ -1,0 +1,122 @@
+package monitor_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/breml/go-uptime-kuma-client/internal/ptr"
+	"github.com/breml/go-uptime-kuma-client/monitor"
+)
+
+func TestMonitorPM2_Unmarshal(t *testing.T) {
+	parent1 := int64(1)
+
+	tests := []struct {
+		name string
+		data []byte
+
+		want     monitor.PM2
+		wantJSON string
+	}{
+		{
+			name: "success",
+			data: []byte(
+				`{"id":4,"name":"pm2-monitor","description":"Test PM2 monitor","pathName":"group / pm2-monitor","parent":1,"childrenIDs":[],"url":null,"method":"GET","hostname":null,"port":null,"maxretries":2,"weight":2000,"active":true,"forceInactive":false,"type":"pm2","timeout":48,"interval":60,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":"A","dns_resolve_server":"1.1.1.1","dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{"1":true,"2":true},"tags":[],"maintenance":false,"mqttTopic":"","mqttSuccessMessage":"","databaseQuery":null,"authMethod":null,"grpcUrl":null,"grpcProtobuf":null,"grpcMethod":null,"grpcServiceName":null,"grpcEnableTls":false,"radiusCalledStationId":null,"radiusCallingStationId":null,"game":null,"gamedigGivenPortOnly":true,"httpBodyEncoding":"json","jsonPath":null,"expectedValue":null,"kafkaProducerTopic":null,"kafkaProducerBrokers":[],"kafkaProducerSsl":false,"kafkaProducerAllowAutoTopicCreation":false,"kafkaProducerMessage":null,"screenshot":null,"headers":null,"body":null,"grpcBody":null,"grpcMetadata":null,"basic_auth_user":null,"basic_auth_pass":null,"oauth_client_id":null,"oauth_client_secret":null,"oauth_token_url":null,"oauth_scopes":null,"oauth_auth_method":"client_secret_basic","pushToken":null,"databaseConnectionString":null,"radiusUsername":null,"radiusPassword":null,"radiusSecret":null,"mqttUsername":"","mqttPassword":"","authWorkstation":null,"authDomain":null,"tlsCa":null,"tlsCert":null,"tlsKey":null,"kafkaProducerSaslOptions":{"mechanism":"None"},"system_service_name":"api-server","includeSensitiveData":true}`,
+			),
+
+			want: monitor.PM2{
+				Base: monitor.Base{
+					ID:              4,
+					Name:            "pm2-monitor",
+					Description:     ptr.To("Test PM2 monitor"),
+					PathName:        "group / pm2-monitor",
+					Parent:          &parent1,
+					Interval:        60,
+					RetryInterval:   60,
+					ResendInterval:  0,
+					MaxRetries:      2,
+					UpsideDown:      false,
+					NotificationIDs: []int64{1, 2},
+					IsActive:        true,
+				},
+				PM2Details: monitor.PM2Details{
+					SystemServiceName: "api-server",
+				},
+			},
+			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":"Test PM2 monitor","id":4,"interval":60,"maxretries":2,"name":"pm2-monitor","notificationIDList":{"1":true,"2":true},"parent":1,"resendInterval":0,"retryInterval":60,"system_service_name":"api-server","type":"pm2","upsideDown":false}`,
+		},
+		{
+			name: "success without parent",
+			data: []byte(
+				`{"id":5,"name":"pm2-monitor-no-parent","description":null,"pathName":"pm2-monitor-no-parent","parent":null,"childrenIDs":[],"url":null,"method":"GET","hostname":null,"port":null,"maxretries":3,"weight":2000,"active":true,"forceInactive":false,"type":"pm2","timeout":null,"interval":120,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":"A","dns_resolve_server":"1.1.1.1","dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{},"tags":[],"maintenance":false,"mqttTopic":"","mqttSuccessMessage":"","databaseQuery":null,"authMethod":null,"grpcUrl":null,"grpcProtobuf":null,"grpcMethod":null,"grpcServiceName":null,"grpcEnableTls":false,"radiusCalledStationId":null,"radiusCallingStationId":null,"game":null,"gamedigGivenPortOnly":true,"httpBodyEncoding":"json","jsonPath":null,"expectedValue":null,"kafkaProducerTopic":null,"kafkaProducerBrokers":[],"kafkaProducerSsl":false,"kafkaProducerAllowAutoTopicCreation":false,"kafkaProducerMessage":null,"screenshot":null,"headers":null,"body":null,"grpcBody":null,"grpcMetadata":null,"basic_auth_user":null,"basic_auth_pass":null,"oauth_client_id":null,"oauth_client_secret":null,"oauth_token_url":null,"oauth_scopes":null,"oauth_auth_method":"client_secret_basic","pushToken":null,"databaseConnectionString":null,"radiusUsername":null,"radiusPassword":null,"radiusSecret":null,"mqttUsername":"","mqttPassword":"","authWorkstation":null,"authDomain":null,"tlsCa":null,"tlsCert":null,"tlsKey":null,"kafkaProducerSaslOptions":{"mechanism":"None"},"system_service_name":"worker 1","includeSensitiveData":true}`,
+			),
+
+			want: monitor.PM2{
+				Base: monitor.Base{
+					ID:             5,
+					Name:           "pm2-monitor-no-parent",
+					Description:    nil,
+					PathName:       "pm2-monitor-no-parent",
+					Parent:         nil,
+					Interval:       120,
+					RetryInterval:  60,
+					ResendInterval: 0,
+					MaxRetries:     3,
+					UpsideDown:     false,
+					IsActive:       true,
+				},
+				// PM2 process names may contain characters the
+				// system-service monitor rejects, only ASCII control
+				// characters are forbidden.
+				PM2Details: monitor.PM2Details{
+					SystemServiceName: "worker 1",
+				},
+			},
+			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":null,"id":5,"interval":120,"maxretries":3,"name":"pm2-monitor-no-parent","notificationIDList":{},"parent":null,"resendInterval":0,"retryInterval":60,"system_service_name":"worker 1","type":"pm2","upsideDown":false}`,
+		},
+		{
+			name: "success with empty process name",
+			data: []byte(
+				`{"id":6,"name":"pm2-empty","description":null,"pathName":"pm2-empty","parent":null,"childrenIDs":[],"url":null,"method":"GET","hostname":null,"port":null,"maxretries":0,"weight":2000,"active":true,"forceInactive":false,"type":"pm2","timeout":null,"interval":60,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":"A","dns_resolve_server":"1.1.1.1","dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{},"tags":[],"maintenance":false,"mqttTopic":"","mqttSuccessMessage":"","databaseQuery":null,"authMethod":null,"grpcUrl":null,"grpcProtobuf":null,"grpcMethod":null,"grpcServiceName":null,"grpcEnableTls":false,"radiusCalledStationId":null,"radiusCallingStationId":null,"game":null,"gamedigGivenPortOnly":true,"httpBodyEncoding":"json","jsonPath":null,"expectedValue":null,"kafkaProducerTopic":null,"kafkaProducerBrokers":[],"kafkaProducerSsl":false,"kafkaProducerAllowAutoTopicCreation":false,"kafkaProducerMessage":null,"screenshot":null,"headers":null,"body":null,"grpcBody":null,"grpcMetadata":null,"basic_auth_user":null,"basic_auth_pass":null,"oauth_client_id":null,"oauth_client_secret":null,"oauth_token_url":null,"oauth_scopes":null,"oauth_auth_method":"client_secret_basic","pushToken":null,"databaseConnectionString":null,"radiusUsername":null,"radiusPassword":null,"radiusSecret":null,"mqttUsername":"","mqttPassword":"","authWorkstation":null,"authDomain":null,"tlsCa":null,"tlsCert":null,"tlsKey":null,"kafkaProducerSaslOptions":{"mechanism":"None"},"system_service_name":"","includeSensitiveData":true}`,
+			),
+
+			want: monitor.PM2{
+				Base: monitor.Base{
+					ID:             6,
+					Name:           "pm2-empty",
+					Description:    nil,
+					PathName:       "pm2-empty",
+					Parent:         nil,
+					Interval:       60,
+					RetryInterval:  60,
+					ResendInterval: 0,
+					MaxRetries:     0,
+					UpsideDown:     false,
+					IsActive:       true,
+				},
+				PM2Details: monitor.PM2Details{
+					SystemServiceName: "",
+				},
+			},
+			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":null,"id":6,"interval":60,"maxretries":0,"name":"pm2-empty","notificationIDList":{},"parent":null,"resendInterval":0,"retryInterval":60,"system_service_name":"","type":"pm2","upsideDown":false}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pm2Monitor := monitor.PM2{}
+
+			err := json.Unmarshal(tc.data, &pm2Monitor)
+			require.NoError(t, err)
+
+			require.EqualExportedValues(t, tc.want, pm2Monitor)
+
+			data, err := json.Marshal(pm2Monitor)
+			require.NoError(t, err)
+
+			require.JSONEq(t, tc.wantJSON, string(data))
+		})
+	}
+}

--- a/monitor_test.go
+++ b/monitor_test.go
@@ -1865,7 +1865,7 @@ func TestMonitorCRUD(t *testing.T) {
 					IsActive:       true,
 				},
 				PM2Details: monitor.PM2Details{
-					SystemServiceName: "api-server",
+					ProcessName: "api-server",
 				},
 			},
 			updateFunc: func(m monitor.Monitor) {
@@ -1875,16 +1875,20 @@ func TestMonitorCRUD(t *testing.T) {
 				}
 
 				pm2.Name = "Updated PM2 Monitor"
-				pm2.SystemServiceName = "worker 1"
+				// The space in "worker 1" is deliberate: the server rejects it
+				// for system-service monitors but allows it for pm2, so the
+				// update fails if the client ever sends the wrong type.
+				pm2.ProcessName = "worker 1"
 			},
 			verifyCreatedFunc: func(t *testing.T, actual monitor.Monitor, id int64) {
 				t.Helper()
 				var pm2 monitor.PM2
 				err := actual.As(&pm2)
 				require.NoError(t, err)
+				require.Equal(t, "pm2", pm2.Type())
 				require.Equal(t, id, pm2.ID)
 				require.Equal(t, "Test PM2 Monitor", pm2.Name)
-				require.Equal(t, "api-server", pm2.SystemServiceName)
+				require.Equal(t, "api-server", pm2.ProcessName)
 			},
 			createTypedFunc: func(t *testing.T, base monitor.Monitor) monitor.Monitor {
 				t.Helper()
@@ -1898,8 +1902,9 @@ func TestMonitorCRUD(t *testing.T) {
 				var pm2 monitor.PM2
 				err := actual.As(&pm2)
 				require.NoError(t, err)
+				require.Equal(t, "pm2", pm2.Type())
 				require.Equal(t, "Updated PM2 Monitor", pm2.Name)
-				require.Equal(t, "worker 1", pm2.SystemServiceName)
+				require.Equal(t, "worker 1", pm2.ProcessName)
 			},
 			testPauseResume: true,
 		},

--- a/monitor_test.go
+++ b/monitor_test.go
@@ -1853,6 +1853,57 @@ func TestMonitorCRUD(t *testing.T) {
 			testPauseResume: true,
 		},
 		{
+			name: "PM2",
+			create: &monitor.PM2{
+				Base: monitor.Base{
+					Name:           "Test PM2 Monitor",
+					Interval:       60,
+					RetryInterval:  60,
+					ResendInterval: 0,
+					MaxRetries:     3,
+					UpsideDown:     false,
+					IsActive:       true,
+				},
+				PM2Details: monitor.PM2Details{
+					SystemServiceName: "api-server",
+				},
+			},
+			updateFunc: func(m monitor.Monitor) {
+				pm2, ok := m.(*monitor.PM2)
+				if !ok {
+					panic("failed to assert PM2 monitor")
+				}
+
+				pm2.Name = "Updated PM2 Monitor"
+				pm2.SystemServiceName = "worker 1"
+			},
+			verifyCreatedFunc: func(t *testing.T, actual monitor.Monitor, id int64) {
+				t.Helper()
+				var pm2 monitor.PM2
+				err := actual.As(&pm2)
+				require.NoError(t, err)
+				require.Equal(t, id, pm2.ID)
+				require.Equal(t, "Test PM2 Monitor", pm2.Name)
+				require.Equal(t, "api-server", pm2.SystemServiceName)
+			},
+			createTypedFunc: func(t *testing.T, base monitor.Monitor) monitor.Monitor {
+				t.Helper()
+				var pm2 monitor.PM2
+				err := base.As(&pm2)
+				require.NoError(t, err)
+				return &pm2
+			},
+			verifyUpdatedFunc: func(t *testing.T, actual monitor.Monitor) {
+				t.Helper()
+				var pm2 monitor.PM2
+				err := actual.As(&pm2)
+				require.NoError(t, err)
+				require.Equal(t, "Updated PM2 Monitor", pm2.Name)
+				require.Equal(t, "worker 1", pm2.SystemServiceName)
+			},
+			testPauseResume: true,
+		},
+		{
 			name: "NTP",
 			create: &monitor.NTP{
 				Base: monitor.Base{


### PR DESCRIPTION
## Summary

Adds `monitor.PM2` and `monitor.PM2Details` for the `pm2` monitor type introduced in Uptime Kuma 2.5.0 (louislam/uptime-kuma#7114). The monitor reports up while the named PM2 process is `online`.

The type reuses the `system_service_name` field of the `system-service` monitor, so the field shape is identical to `monitor.SystemService` and only the wire `type` differs. The value is a PM2 process *name* rather than the numeric PM2 id, because PM2 reassigns ids after a process is deleted and recreated. Server-side validation trims the value and requires it to be non-empty and free of ASCII control characters (U+0000..U+001F, U+007F) — both documented on the field.

Like `system-service`, the check shells out to a CLI on the Uptime Kuma host, so it only works on non-container installations.

## Out of scope

The `getPM2ProcessList` socket event upstream added alongside the monitor type is intentionally not wrapped, in line with the other UI-only helper events (gamedig's game list, `testChrome`).

## Testing

- `monitor/monitor_pm2_test.go`: JSON round-trip coverage (with parent and notifications, without parent, empty process name).
- `monitor_test.go`: `TestMonitorCRUD/PM2` integration coverage including pause/resume.
- `task lint`, `task fmt` and `task test-e2e` pass.

Closes #336