### PR TITLE
feat(notification): add support for Plivo notifications

### DIFF
--- a/notification/notification_plivo.go
+++ b/notification/notification_plivo.go
@@ -17,11 +17,13 @@ type PlivoDetails struct {
 	FromNumber string `json:"plivoFromNumber"`
 	ToNumber   string `json:"plivoToNumber"`
 	// MessageType selects whether the alert is delivered as an SMS or as a
-	// voice call.
-	MessageType PlivoMessageType `json:"plivoMessageType"`
-	// AnswerURL returns the Plivo XML for the call. It is only used and only
-	// required if MessageType is PlivoMessageTypeCall. The alert text is
-	// appended as a "message" query parameter.
+	// voice call. If unset, the server delivers the alert as an SMS.
+	MessageType PlivoMessageType `json:"plivoMessageType,omitempty"`
+	// AnswerURL is fetched by Plivo with an HTTP GET to obtain the Plivo XML
+	// driving the call. It is only used and only required if MessageType is
+	// PlivoMessageTypeCall, where it must be an absolute URL. The server sets
+	// the alert text as the "message" query parameter, replacing any "message"
+	// parameter already present.
 	AnswerURL *string `json:"plivoAnswerUrl,omitempty"`
 }
 

--- a/notification/notification_plivo.go
+++ b/notification/notification_plivo.go
@@ -1,0 +1,76 @@
+package notification
+
+import (
+	"fmt"
+)
+
+// Plivo represents a plivo notification.
+type Plivo struct {
+	Base
+	PlivoDetails
+}
+
+// PlivoDetails contains plivo-specific notification configuration.
+type PlivoDetails struct {
+	AuthID     string `json:"plivoAuthID"`
+	AuthToken  string `json:"plivoAuthToken"`
+	FromNumber string `json:"plivoFromNumber"`
+	ToNumber   string `json:"plivoToNumber"`
+	// MessageType selects whether the alert is delivered as an SMS or as a
+	// voice call.
+	MessageType PlivoMessageType `json:"plivoMessageType"`
+	// AnswerURL returns the Plivo XML for the call. It is only used and only
+	// required if MessageType is PlivoMessageTypeCall. The alert text is
+	// appended as a "message" query parameter.
+	AnswerURL *string `json:"plivoAnswerUrl,omitempty"`
+}
+
+// PlivoMessageType represents the delivery type of a plivo notification.
+type PlivoMessageType string
+
+// Plivo message types.
+const (
+	PlivoMessageTypeSMS  PlivoMessageType = "sms"
+	PlivoMessageTypeCall PlivoMessageType = "call"
+)
+
+// String returns the string representation of the plivo message type.
+func (t PlivoMessageType) String() string {
+	return string(t)
+}
+
+// Type returns the notification type.
+func (p Plivo) Type() string {
+	return p.PlivoDetails.Type()
+}
+
+// Type returns the notification type.
+func (PlivoDetails) Type() string {
+	return "plivo"
+}
+
+// String returns a string representation of the notification.
+func (p Plivo) String() string {
+	return fmt.Sprintf("%s, %s", formatNotification(p.Base, false), formatNotification(p.PlivoDetails, true))
+}
+
+// UnmarshalJSON unmarshals a JSON byte slice into a notification.
+func (p *Plivo) UnmarshalJSON(data []byte) error {
+	detail := PlivoDetails{}
+	base, err := unmarshalTo(data, &detail)
+	if err != nil {
+		return err
+	}
+
+	*p = Plivo{
+		Base:         base,
+		PlivoDetails: detail,
+	}
+
+	return nil
+}
+
+// MarshalJSON marshals a notification into a JSON byte slice.
+func (p Plivo) MarshalJSON() ([]byte, error) {
+	return marshalJSON(p.Base, &p.PlivoDetails)
+}

--- a/notification/notification_plivo_test.go
+++ b/notification/notification_plivo_test.go
@@ -1,0 +1,106 @@
+package notification_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/breml/go-uptime-kuma-client/internal/ptr"
+	"github.com/breml/go-uptime-kuma-client/notification"
+)
+
+func TestNotificationPlivo_Unmarshal(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+
+		want     notification.Plivo
+		wantJSON string
+		wantErr  bool
+	}{
+		{
+			name: "success",
+			data: []byte(
+				`{"id":1,"name":"My Plivo Alert","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"My Plivo Alert\",\"plivoAnswerUrl\":\"https://example.com/answer.xml\",\"plivoAuthID\":\"MAXXXXXXXXXXXXXXXXXX\",\"plivoAuthToken\":\"test_auth_token\",\"plivoFromNumber\":\"+15559876543\",\"plivoMessageType\":\"call\",\"plivoToNumber\":\"+15551234567\",\"type\":\"plivo\"}"}`,
+			),
+
+			want: notification.Plivo{
+				Base: notification.Base{
+					ID:            1,
+					Name:          "My Plivo Alert",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     true,
+					ApplyExisting: true,
+				},
+				PlivoDetails: notification.PlivoDetails{
+					AuthID:      "MAXXXXXXXXXXXXXXXXXX",
+					AuthToken:   "test_auth_token",
+					FromNumber:  "+15559876543",
+					ToNumber:    "+15551234567",
+					MessageType: notification.PlivoMessageTypeCall,
+					AnswerURL:   ptr.To("https://example.com/answer.xml"),
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":true,"id":1,"isDefault":true,"name":"My Plivo Alert","plivoAnswerUrl":"https://example.com/answer.xml","plivoAuthID":"MAXXXXXXXXXXXXXXXXXX","plivoAuthToken":"test_auth_token","plivoFromNumber":"+15559876543","plivoMessageType":"call","plivoToNumber":"+15551234567","type":"plivo","userId":1}`,
+		},
+		{
+			name: "minimal",
+			data: []byte(
+				`{"id":2,"name":"Simple Plivo","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Simple Plivo\",\"plivoAuthID\":\"MAXXXXXXXXXXXXXXXXXX\",\"plivoAuthToken\":\"test_auth_token\",\"plivoFromNumber\":\"+15559876543\",\"plivoMessageType\":\"sms\",\"plivoToNumber\":\"+15551234567\",\"type\":\"plivo\"}"}`,
+			),
+
+			want: notification.Plivo{
+				Base: notification.Base{
+					ID:            2,
+					Name:          "Simple Plivo",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				PlivoDetails: notification.PlivoDetails{
+					AuthID:      "MAXXXXXXXXXXXXXXXXXX",
+					AuthToken:   "test_auth_token",
+					FromNumber:  "+15559876543",
+					ToNumber:    "+15551234567",
+					MessageType: notification.PlivoMessageTypeSMS,
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"id":2,"isDefault":false,"name":"Simple Plivo","plivoAuthID":"MAXXXXXXXXXXXXXXXXXX","plivoAuthToken":"test_auth_token","plivoFromNumber":"+15559876543","plivoMessageType":"sms","plivoToNumber":"+15551234567","type":"plivo","userId":1}`,
+		},
+		{
+			name:    "missing config field",
+			data:    []byte(`{"id":1,"name":"x","active":true,"userId":1,"isDefault":false}`),
+			wantErr: true,
+		},
+		{
+			name:    "invalid config json",
+			data:    []byte(`{"id":1,"name":"x","active":true,"userId":1,"isDefault":false,"config":"not-json"}`),
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			plivo := notification.Plivo{}
+
+			err := json.Unmarshal(tc.data, &plivo)
+			if tc.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+
+			require.EqualExportedValues(t, tc.want, plivo)
+
+			data, err := json.Marshal(plivo)
+			require.NoError(t, err)
+
+			require.JSONEq(t, tc.wantJSON, string(data))
+		})
+	}
+}

--- a/notification/notification_plivo_test.go
+++ b/notification/notification_plivo_test.go
@@ -71,6 +71,30 @@ func TestNotificationPlivo_Unmarshal(t *testing.T) {
 			wantJSON: `{"active":true,"applyExisting":false,"id":2,"isDefault":false,"name":"Simple Plivo","plivoAuthID":"MAXXXXXXXXXXXXXXXXXX","plivoAuthToken":"test_auth_token","plivoFromNumber":"+15559876543","plivoMessageType":"sms","plivoToNumber":"+15551234567","type":"plivo","userId":1}`,
 		},
 		{
+			name: "message type unset",
+			data: []byte(
+				`{"id":3,"name":"Default Plivo","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Default Plivo\",\"plivoAuthID\":\"MAXXXXXXXXXXXXXXXXXX\",\"plivoAuthToken\":\"test_auth_token\",\"plivoFromNumber\":\"+15559876543\",\"plivoToNumber\":\"+15551234567\",\"type\":\"plivo\"}"}`,
+			),
+
+			want: notification.Plivo{
+				Base: notification.Base{
+					ID:            3,
+					Name:          "Default Plivo",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				PlivoDetails: notification.PlivoDetails{
+					AuthID:     "MAXXXXXXXXXXXXXXXXXX",
+					AuthToken:  "test_auth_token",
+					FromNumber: "+15559876543",
+					ToNumber:   "+15551234567",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"id":3,"isDefault":false,"name":"Default Plivo","plivoAuthID":"MAXXXXXXXXXXXXXXXXXX","plivoAuthToken":"test_auth_token","plivoFromNumber":"+15559876543","plivoToNumber":"+15551234567","type":"plivo","userId":1}`,
+		},
+		{
 			name:    "missing config field",
 			data:    []byte(`{"id":1,"name":"x","active":true,"userId":1,"isDefault":false}`),
 			wantErr: true,
@@ -101,6 +125,22 @@ func TestNotificationPlivo_Unmarshal(t *testing.T) {
 			require.NoError(t, err)
 
 			require.JSONEq(t, tc.wantJSON, string(data))
+		})
+	}
+}
+
+func TestPlivoMessageType_String(t *testing.T) {
+	tests := []struct {
+		messageType notification.PlivoMessageType
+		want        string
+	}{
+		{notification.PlivoMessageTypeSMS, "sms"},
+		{notification.PlivoMessageTypeCall, "call"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.want, func(t *testing.T) {
+			require.Equal(t, tc.want, tc.messageType.String())
 		})
 	}
 }

--- a/notification_test.go
+++ b/notification_test.go
@@ -1061,6 +1061,8 @@ func TestNotificationCRUD(t *testing.T) {
 
 				plivo.Name = "Test Plivo Updated"
 				plivo.ToNumber = "+15559999999"
+				plivo.MessageType = notification.PlivoMessageTypeSMS
+				plivo.AnswerURL = nil
 			},
 			verifyCreatedFunc: func(t *testing.T, actual notification.Notification, expected notification.Notification, id int64) {
 				t.Helper()

--- a/notification_test.go
+++ b/notification_test.go
@@ -1035,6 +1035,62 @@ func TestNotificationCRUD(t *testing.T) {
 			},
 		},
 		{
+			name:         "Plivo",
+			expectedType: "plivo",
+			create: notification.Plivo{
+				Base: notification.Base{
+					ApplyExisting: false,
+					IsDefault:     false,
+					IsActive:      true,
+					Name:          "Test Plivo Created",
+				},
+				PlivoDetails: notification.PlivoDetails{
+					AuthID:      "MAXXXXXXXXXXXXXXXXXX",
+					AuthToken:   "test_auth_token",
+					FromNumber:  "+15559876543",
+					ToNumber:    "+15551234567",
+					MessageType: notification.PlivoMessageTypeCall,
+					AnswerURL:   ptr.To("https://example.com/answer.xml"),
+				},
+			},
+			updateFunc: func(n notification.Notification) {
+				plivo, ok := n.(*notification.Plivo)
+				if !ok {
+					panic("failed to assert Plivo notification")
+				}
+
+				plivo.Name = "Test Plivo Updated"
+				plivo.ToNumber = "+15559999999"
+			},
+			verifyCreatedFunc: func(t *testing.T, actual notification.Notification, expected notification.Notification, id int64) {
+				t.Helper()
+				exp, ok := expected.(notification.Plivo)
+				require.True(t, ok)
+				var plivo notification.Plivo
+				err := actual.As(&plivo)
+				require.NoError(t, err)
+				exp.ID = id
+				exp.UserID = plivo.UserID
+				require.EqualExportedValues(t, exp, plivo)
+			},
+			createTypedFunc: func(t *testing.T, base notification.Notification) notification.Notification {
+				t.Helper()
+				var plivo notification.Plivo
+				err := base.As(&plivo)
+				require.NoError(t, err)
+				return &plivo
+			},
+			verifyUpdatedFunc: func(t *testing.T, actual notification.Notification, expected notification.Notification) {
+				t.Helper()
+				exp, ok := expected.(*notification.Plivo)
+				require.True(t, ok)
+				var plivo notification.Plivo
+				err := actual.As(&plivo)
+				require.NoError(t, err)
+				require.EqualExportedValues(t, *exp, plivo)
+			},
+		},
+		{
 			name:         "EgoSMS",
 			expectedType: "egosms",
 			create: notification.EgoSMS{


### PR DESCRIPTION
Adds support for the `plivo` notification provider, introduced upstream in Uptime Kuma v2.5.0 (louislam/uptime-kuma#7584) and extended with a voice-call option in the same release (louislam/uptime-kuma#7597).

## Changes

- `notification/notification_plivo.go`: new `Plivo` type embedding `Base` and `PlivoDetails`, following the existing provider pattern (`Type()`, `String()`, `UnmarshalJSON` via `unmarshalTo`, `MarshalJSON` via `marshalJSON`). `Type()` returns `plivo` (lowercase, matching the upstream class `name`).
- A typed `PlivoMessageType` enum (`PlivoMessageTypeSMS` / `PlivoMessageTypeCall`) with a `String()` method, modelled on `monitor.GlobalpingSubtype`.
- `AnswerURL` is modelled as `*string` with `omitempty`, since it is only used and only required when the message type is `call`.
- `notification/notification_plivo_test.go`: table-driven unmarshal/marshal round-trip tests covering the `call` variant (with answer URL), the minimal `sms` variant, a missing `config` field, and invalid `config` JSON.
- `notification_test.go`: a `Plivo` entry in the `TestNotificationCRUD` table, placed next to the other SMS providers.

## Testing

- `task fmt`, `task lint` — clean.
- `task test-e2e` — full suite passes, including `TestNotificationCRUD/Plivo` (create/update/delete against a real `louislam/uptime-kuma:2.5.0` container).

Closes #337

https://claude.ai/code/session_01WNpmcxXbr7sy5LuHMD6syk