### PR TITLE
feat(notification): add support for Ooredoo notifications

### DIFF
--- a/notification/notification_ooredoo.go
+++ b/notification/notification_ooredoo.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Ooredoo represents an Ooredoo notification provider.
-// Ooredoo is a Maldivian bulk SMS gateway for sending text message notifications.
+// Ooredoo Maldives is a bulk SMS gateway for sending text message notifications.
 type Ooredoo struct {
 	Base
 	OoredooDetails
@@ -22,9 +22,11 @@ type OoredooDetails struct {
 	// an "Authorization: Bearer" header.
 	BearerToken string `json:"ooredooBearerToken"`
 	// ToNumber holds one or more recipient phone numbers, separated by comma,
-	// semicolon, whitespace or newline. Bare 7 digit numbers are prefixed with
-	// the Maldives country code 960 by the server, which sends the recipients
-	// in batches of 20 per request.
+	// semicolon or whitespace. Since whitespace separates recipients, an
+	// individual number must not contain spaces. The server strips a leading
+	// "+" and prefixes bare 7 digit numbers with the Maldives country code 960.
+	// If no valid number remains, the server rejects the notification when it
+	// is sent.
 	ToNumber string `json:"ooredooToNumber"`
 	// ServerURL is the Ooredoo API endpoint. If unset, the server falls back to
 	// https://o-papi1-lb01.ooredoo.mv/bulk_sms/v2.

--- a/notification/notification_ooredoo.go
+++ b/notification/notification_ooredoo.go
@@ -1,0 +1,68 @@
+package notification
+
+import (
+	"fmt"
+)
+
+// Ooredoo represents an Ooredoo notification provider.
+// Ooredoo is a Maldivian bulk SMS gateway for sending text message notifications.
+type Ooredoo struct {
+	Base
+	OoredooDetails
+}
+
+// OoredooDetails contains the configuration fields for Ooredoo notifications.
+type OoredooDetails struct {
+	// Username is the Ooredoo bulk SMS account username.
+	Username string `json:"ooredooUsername"`
+	// AccessKey is the Ooredoo account access key. It is Base64 encoded by the
+	// server before it is passed on to the gateway.
+	AccessKey string `json:"ooredooAccessKey"`
+	// BearerToken authenticates the request against the gateway and is sent as
+	// an "Authorization: Bearer" header.
+	BearerToken string `json:"ooredooBearerToken"`
+	// ToNumber holds one or more recipient phone numbers, separated by comma,
+	// semicolon, whitespace or newline. Bare 7 digit numbers are prefixed with
+	// the Maldives country code 960 by the server, which sends the recipients
+	// in batches of 20 per request.
+	ToNumber string `json:"ooredooToNumber"`
+	// ServerURL is the Ooredoo API endpoint. If unset, the server falls back to
+	// https://o-papi1-lb01.ooredoo.mv/bulk_sms/v2.
+	ServerURL *string `json:"ooredooServerUrl,omitempty"`
+}
+
+// Type returns the notification type identifier for Ooredoo.
+func (o Ooredoo) Type() string {
+	return o.OoredooDetails.Type()
+}
+
+// Type returns the notification type identifier for OoredooDetails.
+func (OoredooDetails) Type() string {
+	return "Ooredoo"
+}
+
+// String returns a string representation of the Ooredoo notification.
+func (o Ooredoo) String() string {
+	return fmt.Sprintf("%s, %s", formatNotification(o.Base, false), formatNotification(o.OoredooDetails, true))
+}
+
+// UnmarshalJSON unmarshals JSON data into an Ooredoo notification.
+func (o *Ooredoo) UnmarshalJSON(data []byte) error {
+	detail := OoredooDetails{}
+	base, err := unmarshalTo(data, &detail)
+	if err != nil {
+		return err
+	}
+
+	*o = Ooredoo{
+		Base:           base,
+		OoredooDetails: detail,
+	}
+
+	return nil
+}
+
+// MarshalJSON marshals the Ooredoo notification into JSON.
+func (o Ooredoo) MarshalJSON() ([]byte, error) {
+	return marshalJSON(o.Base, &o.OoredooDetails)
+}

--- a/notification/notification_ooredoo.go
+++ b/notification/notification_ooredoo.go
@@ -23,13 +23,14 @@ type OoredooDetails struct {
 	BearerToken string `json:"ooredooBearerToken"`
 	// ToNumber holds one or more recipient phone numbers, separated by comma,
 	// semicolon or whitespace. Since whitespace separates recipients, an
-	// individual number must not contain spaces. The server strips a leading
-	// "+" and prefixes bare 7 digit numbers with the Maldives country code 960.
-	// If no valid number remains, the server rejects the notification when it
-	// is sent.
+	// individual number must not contain spaces. The server strips every "+"
+	// character and prefixes bare 7 digit numbers with the Maldives country
+	// code 960. The numbers are not validated: the server only rejects the
+	// notification when it is sent and no recipient remains at all, any other
+	// value is passed on to the gateway as is.
 	ToNumber string `json:"ooredooToNumber"`
-	// ServerURL is the Ooredoo API endpoint. If unset, the server falls back to
-	// https://o-papi1-lb01.ooredoo.mv/bulk_sms/v2.
+	// ServerURL is the Ooredoo API endpoint. If unset or empty, the server
+	// falls back to https://o-papi1-lb01.ooredoo.mv/bulk_sms/v2.
 	ServerURL *string `json:"ooredooServerUrl,omitempty"`
 }
 

--- a/notification/notification_ooredoo_test.go
+++ b/notification/notification_ooredoo_test.go
@@ -1,0 +1,104 @@
+package notification_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/breml/go-uptime-kuma-client/internal/ptr"
+	"github.com/breml/go-uptime-kuma-client/notification"
+)
+
+func TestNotificationOoredoo_Unmarshal(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+
+		want     notification.Ooredoo
+		wantJSON string
+		wantErr  bool
+	}{
+		{
+			name: "success",
+			data: []byte(
+				`{"id":1,"name":"My Ooredoo Alert","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"My Ooredoo Alert\",\"ooredooAccessKey\":\"test_access_key\",\"ooredooBearerToken\":\"test_bearer_token\",\"ooredooServerUrl\":\"https://o-papi1-lb01.ooredoo.mv/bulk_sms/v2\",\"ooredooToNumber\":\"7712345, 9607798765\",\"ooredooUsername\":\"test_user\",\"type\":\"Ooredoo\"}"}`,
+			),
+
+			want: notification.Ooredoo{
+				Base: notification.Base{
+					ID:            1,
+					Name:          "My Ooredoo Alert",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     true,
+					ApplyExisting: true,
+				},
+				OoredooDetails: notification.OoredooDetails{
+					Username:    "test_user",
+					AccessKey:   "test_access_key",
+					BearerToken: "test_bearer_token",
+					ToNumber:    "7712345, 9607798765",
+					ServerURL:   ptr.To("https://o-papi1-lb01.ooredoo.mv/bulk_sms/v2"),
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":true,"id":1,"isDefault":true,"name":"My Ooredoo Alert","ooredooAccessKey":"test_access_key","ooredooBearerToken":"test_bearer_token","ooredooServerUrl":"https://o-papi1-lb01.ooredoo.mv/bulk_sms/v2","ooredooToNumber":"7712345, 9607798765","ooredooUsername":"test_user","type":"Ooredoo","userId":1}`,
+		},
+		{
+			name: "minimal",
+			data: []byte(
+				`{"id":2,"name":"Simple Ooredoo","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Simple Ooredoo\",\"ooredooAccessKey\":\"test_access_key\",\"ooredooBearerToken\":\"test_bearer_token\",\"ooredooToNumber\":\"7712345\",\"ooredooUsername\":\"test_user\",\"type\":\"Ooredoo\"}"}`,
+			),
+
+			want: notification.Ooredoo{
+				Base: notification.Base{
+					ID:            2,
+					Name:          "Simple Ooredoo",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				OoredooDetails: notification.OoredooDetails{
+					Username:    "test_user",
+					AccessKey:   "test_access_key",
+					BearerToken: "test_bearer_token",
+					ToNumber:    "7712345",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"id":2,"isDefault":false,"name":"Simple Ooredoo","ooredooAccessKey":"test_access_key","ooredooBearerToken":"test_bearer_token","ooredooToNumber":"7712345","ooredooUsername":"test_user","type":"Ooredoo","userId":1}`,
+		},
+		{
+			name:    "missing config field",
+			data:    []byte(`{"id":1,"name":"x","active":true,"userId":1,"isDefault":false}`),
+			wantErr: true,
+		},
+		{
+			name:    "invalid config json",
+			data:    []byte(`{"id":1,"name":"x","active":true,"userId":1,"isDefault":false,"config":"not-json"}`),
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ooredoo := notification.Ooredoo{}
+
+			err := json.Unmarshal(tc.data, &ooredoo)
+			if tc.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+
+			require.EqualExportedValues(t, tc.want, ooredoo)
+
+			data, err := json.Marshal(ooredoo)
+			require.NoError(t, err)
+
+			require.JSONEq(t, tc.wantJSON, string(data))
+		})
+	}
+}

--- a/notification_test.go
+++ b/notification_test.go
@@ -1093,6 +1093,62 @@ func TestNotificationCRUD(t *testing.T) {
 			},
 		},
 		{
+			name:         "Ooredoo",
+			expectedType: "Ooredoo",
+			create: notification.Ooredoo{
+				Base: notification.Base{
+					ApplyExisting: false,
+					IsDefault:     false,
+					IsActive:      true,
+					Name:          "Test Ooredoo Created",
+				},
+				OoredooDetails: notification.OoredooDetails{
+					Username:    "test_user",
+					AccessKey:   "test_access_key",
+					BearerToken: "test_bearer_token",
+					ToNumber:    "7712345, 9607798765",
+					ServerURL:   ptr.To("https://o-papi1-lb01.ooredoo.mv/bulk_sms/v2"),
+				},
+			},
+			updateFunc: func(n notification.Notification) {
+				ooredoo, ok := n.(*notification.Ooredoo)
+				if !ok {
+					panic("failed to assert Ooredoo notification")
+				}
+
+				ooredoo.Name = "Test Ooredoo Updated"
+				ooredoo.ToNumber = "9607712345"
+				ooredoo.ServerURL = nil
+			},
+			verifyCreatedFunc: func(t *testing.T, actual notification.Notification, expected notification.Notification, id int64) {
+				t.Helper()
+				exp, ok := expected.(notification.Ooredoo)
+				require.True(t, ok)
+				var ooredoo notification.Ooredoo
+				err := actual.As(&ooredoo)
+				require.NoError(t, err)
+				exp.ID = id
+				exp.UserID = ooredoo.UserID
+				require.EqualExportedValues(t, exp, ooredoo)
+			},
+			createTypedFunc: func(t *testing.T, base notification.Notification) notification.Notification {
+				t.Helper()
+				var ooredoo notification.Ooredoo
+				err := base.As(&ooredoo)
+				require.NoError(t, err)
+				return &ooredoo
+			},
+			verifyUpdatedFunc: func(t *testing.T, actual notification.Notification, expected notification.Notification) {
+				t.Helper()
+				exp, ok := expected.(*notification.Ooredoo)
+				require.True(t, ok)
+				var ooredoo notification.Ooredoo
+				err := actual.As(&ooredoo)
+				require.NoError(t, err)
+				require.EqualExportedValues(t, *exp, ooredoo)
+			},
+		},
+		{
 			name:         "EgoSMS",
 			expectedType: "egosms",
 			create: notification.EgoSMS{


### PR DESCRIPTION
Adds the `Ooredoo` notification provider, a Maldivian bulk SMS gateway introduced upstream in Uptime Kuma v2.5.0 (louislam/uptime-kuma#7571).

## Changes

- `notification/notification_ooredoo.go` — `Ooredoo` / `OoredooDetails` types following the existing provider pattern (`notification_plivo.go`, `notification_smsir.go`), with `Type()` returning `Ooredoo` to match the upstream provider name.
- `ServerURL` (`ooredooServerUrl`) is modelled as `*string` with `omitempty` so the server default endpoint (`https://o-papi1-lb01.ooredoo.mv/bulk_sms/v2`) applies when it is left unset.
- `ToNumber` documents that multiple recipients are accepted, separated by comma, semicolon, whitespace or newline, that bare 7-digit numbers get the Maldives country code `960` prefixed, and that recipients are batched 20 per request.
- `notification/notification_ooredoo_test.go` — JSON round-trip coverage including the minimal case that exercises the `omitempty` path.
- `notification_test.go` — integration CRUD coverage; the update step clears `ServerURL` to verify the optional field round-trips as unset.

## Verification

- `task lint` — 0 issues
- `task fmt` — clean
- `task test-e2e` — full suite passes against a live Uptime Kuma instance, including the new `TestNotificationCRUD/Ooredoo` create/update/delete subtests.

Closes #338