### PR TITLE
feat(notification): add support for Flowtriq notifications

### DIFF
--- a/notification/notification_flowtriq.go
+++ b/notification/notification_flowtriq.go
@@ -1,0 +1,59 @@
+package notification
+
+import (
+	"fmt"
+)
+
+// Flowtriq represents a Flowtriq notification provider.
+// Flowtriq is a DDoS detection and incident platform, which receives the
+// notifications via a webhook.
+type Flowtriq struct {
+	Base
+	FlowtriqDetails
+}
+
+// FlowtriqDetails contains the configuration fields for Flowtriq notifications.
+type FlowtriqDetails struct {
+	// WebhookURL is the Flowtriq webhook endpoint the notification is posted
+	// to, for example https://app.flowtriq.com/api/webhooks/...
+	WebhookURL string `json:"flowtriqWebhookUrl"`
+	// APIKey authenticates the request against Flowtriq. If set, the server
+	// sends it as the "X-API-Key" header, otherwise the header is omitted.
+	APIKey *string `json:"flowtriqApiKey,omitempty"`
+}
+
+// Type returns the notification type identifier for Flowtriq.
+func (f Flowtriq) Type() string {
+	return f.FlowtriqDetails.Type()
+}
+
+// Type returns the notification type identifier for FlowtriqDetails.
+func (FlowtriqDetails) Type() string {
+	return "Flowtriq"
+}
+
+// String returns a string representation of the Flowtriq notification.
+func (f Flowtriq) String() string {
+	return fmt.Sprintf("%s, %s", formatNotification(f.Base, false), formatNotification(f.FlowtriqDetails, true))
+}
+
+// UnmarshalJSON unmarshals JSON data into a Flowtriq notification.
+func (f *Flowtriq) UnmarshalJSON(data []byte) error {
+	detail := FlowtriqDetails{}
+	base, err := unmarshalTo(data, &detail)
+	if err != nil {
+		return err
+	}
+
+	*f = Flowtriq{
+		Base:            base,
+		FlowtriqDetails: detail,
+	}
+
+	return nil
+}
+
+// MarshalJSON marshals the Flowtriq notification into JSON.
+func (f Flowtriq) MarshalJSON() ([]byte, error) {
+	return marshalJSON(f.Base, &f.FlowtriqDetails)
+}

--- a/notification/notification_flowtriq.go
+++ b/notification/notification_flowtriq.go
@@ -17,8 +17,8 @@ type FlowtriqDetails struct {
 	// WebhookURL is the Flowtriq webhook endpoint the notification is posted
 	// to, for example https://app.flowtriq.com/api/webhooks/...
 	WebhookURL string `json:"flowtriqWebhookUrl"`
-	// APIKey authenticates the request against Flowtriq. If set, the server
-	// sends it as the "X-API-Key" header, otherwise the header is omitted.
+	// APIKey authenticates the request against Flowtriq. The server sends it
+	// as the "X-API-Key" header. If unset or empty, the header is omitted.
 	APIKey *string `json:"flowtriqApiKey,omitempty"`
 }
 

--- a/notification/notification_flowtriq_test.go
+++ b/notification/notification_flowtriq_test.go
@@ -1,0 +1,98 @@
+package notification_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/breml/go-uptime-kuma-client/internal/ptr"
+	"github.com/breml/go-uptime-kuma-client/notification"
+)
+
+func TestNotificationFlowtriq_Unmarshal(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+
+		want     notification.Flowtriq
+		wantJSON string
+		wantErr  bool
+	}{
+		{
+			name: "success",
+			data: []byte(
+				`{"id":1,"name":"My Flowtriq Alert","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"flowtriqApiKey\":\"test_api_key\",\"flowtriqWebhookUrl\":\"https://app.flowtriq.com/api/webhooks/test\",\"isDefault\":true,\"name\":\"My Flowtriq Alert\",\"type\":\"Flowtriq\"}"}`,
+			),
+
+			want: notification.Flowtriq{
+				Base: notification.Base{
+					ID:            1,
+					Name:          "My Flowtriq Alert",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     true,
+					ApplyExisting: true,
+				},
+				FlowtriqDetails: notification.FlowtriqDetails{
+					WebhookURL: "https://app.flowtriq.com/api/webhooks/test",
+					APIKey:     ptr.To("test_api_key"),
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":true,"flowtriqApiKey":"test_api_key","flowtriqWebhookUrl":"https://app.flowtriq.com/api/webhooks/test","id":1,"isDefault":true,"name":"My Flowtriq Alert","type":"Flowtriq","userId":1}`,
+		},
+		{
+			name: "minimal",
+			data: []byte(
+				`{"id":2,"name":"Simple Flowtriq","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"flowtriqWebhookUrl\":\"https://app.flowtriq.com/api/webhooks/test\",\"isDefault\":false,\"name\":\"Simple Flowtriq\",\"type\":\"Flowtriq\"}"}`,
+			),
+
+			want: notification.Flowtriq{
+				Base: notification.Base{
+					ID:            2,
+					Name:          "Simple Flowtriq",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				FlowtriqDetails: notification.FlowtriqDetails{
+					WebhookURL: "https://app.flowtriq.com/api/webhooks/test",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"flowtriqWebhookUrl":"https://app.flowtriq.com/api/webhooks/test","id":2,"isDefault":false,"name":"Simple Flowtriq","type":"Flowtriq","userId":1}`,
+		},
+		{
+			name:    "missing config field",
+			data:    []byte(`{"id":1,"name":"x","active":true,"userId":1,"isDefault":false}`),
+			wantErr: true,
+		},
+		{
+			name:    "invalid config json",
+			data:    []byte(`{"id":1,"name":"x","active":true,"userId":1,"isDefault":false,"config":"not-json"}`),
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			flowtriq := notification.Flowtriq{}
+
+			err := json.Unmarshal(tc.data, &flowtriq)
+			if tc.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+
+			require.EqualExportedValues(t, tc.want, flowtriq)
+
+			data, err := json.Marshal(flowtriq)
+			require.NoError(t, err)
+
+			require.JSONEq(t, tc.wantJSON, string(data))
+		})
+	}
+}

--- a/notification/notification_flowtriq_test.go
+++ b/notification/notification_flowtriq_test.go
@@ -63,6 +63,28 @@ func TestNotificationFlowtriq_Unmarshal(t *testing.T) {
 			wantJSON: `{"active":true,"applyExisting":false,"flowtriqWebhookUrl":"https://app.flowtriq.com/api/webhooks/test","id":2,"isDefault":false,"name":"Simple Flowtriq","type":"Flowtriq","userId":1}`,
 		},
 		{
+			name: "empty api key",
+			data: []byte(
+				`{"id":3,"name":"Cleared Flowtriq","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"flowtriqApiKey\":\"\",\"flowtriqWebhookUrl\":\"https://app.flowtriq.com/api/webhooks/test\",\"isDefault\":false,\"name\":\"Cleared Flowtriq\",\"type\":\"Flowtriq\"}"}`,
+			),
+
+			want: notification.Flowtriq{
+				Base: notification.Base{
+					ID:            3,
+					Name:          "Cleared Flowtriq",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				FlowtriqDetails: notification.FlowtriqDetails{
+					WebhookURL: "https://app.flowtriq.com/api/webhooks/test",
+					APIKey:     ptr.To(""),
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"flowtriqApiKey":"","flowtriqWebhookUrl":"https://app.flowtriq.com/api/webhooks/test","id":3,"isDefault":false,"name":"Cleared Flowtriq","type":"Flowtriq","userId":1}`,
+		},
+		{
 			name:    "missing config field",
 			data:    []byte(`{"id":1,"name":"x","active":true,"userId":1,"isDefault":false}`),
 			wantErr: true,
@@ -70,6 +92,13 @@ func TestNotificationFlowtriq_Unmarshal(t *testing.T) {
 		{
 			name:    "invalid config json",
 			data:    []byte(`{"id":1,"name":"x","active":true,"userId":1,"isDefault":false,"config":"not-json"}`),
+			wantErr: true,
+		},
+		{
+			name: "invalid config detail type",
+			data: []byte(
+				`{"id":1,"name":"x","active":true,"userId":1,"isDefault":false,"config":"{\"flowtriqWebhookUrl\":123,\"type\":\"Flowtriq\"}"}`,
+			),
 			wantErr: true,
 		},
 	}

--- a/notification_test.go
+++ b/notification_test.go
@@ -1149,6 +1149,59 @@ func TestNotificationCRUD(t *testing.T) {
 			},
 		},
 		{
+			name:         "Flowtriq",
+			expectedType: "Flowtriq",
+			create: notification.Flowtriq{
+				Base: notification.Base{
+					ApplyExisting: false,
+					IsDefault:     false,
+					IsActive:      true,
+					Name:          "Test Flowtriq Created",
+				},
+				FlowtriqDetails: notification.FlowtriqDetails{
+					WebhookURL: "https://app.flowtriq.com/api/webhooks/created",
+					APIKey:     ptr.To("test_api_key"),
+				},
+			},
+			updateFunc: func(n notification.Notification) {
+				flowtriq, ok := n.(*notification.Flowtriq)
+				if !ok {
+					panic("failed to assert Flowtriq notification")
+				}
+
+				flowtriq.Name = "Test Flowtriq Updated"
+				flowtriq.WebhookURL = "https://app.flowtriq.com/api/webhooks/updated"
+				flowtriq.APIKey = nil
+			},
+			verifyCreatedFunc: func(t *testing.T, actual notification.Notification, expected notification.Notification, id int64) {
+				t.Helper()
+				exp, ok := expected.(notification.Flowtriq)
+				require.True(t, ok)
+				var flowtriq notification.Flowtriq
+				err := actual.As(&flowtriq)
+				require.NoError(t, err)
+				exp.ID = id
+				exp.UserID = flowtriq.UserID
+				require.EqualExportedValues(t, exp, flowtriq)
+			},
+			createTypedFunc: func(t *testing.T, base notification.Notification) notification.Notification {
+				t.Helper()
+				var flowtriq notification.Flowtriq
+				err := base.As(&flowtriq)
+				require.NoError(t, err)
+				return &flowtriq
+			},
+			verifyUpdatedFunc: func(t *testing.T, actual notification.Notification, expected notification.Notification) {
+				t.Helper()
+				exp, ok := expected.(*notification.Flowtriq)
+				require.True(t, ok)
+				var flowtriq notification.Flowtriq
+				err := actual.As(&flowtriq)
+				require.NoError(t, err)
+				require.EqualExportedValues(t, *exp, flowtriq)
+			},
+		},
+		{
 			name:         "EgoSMS",
 			expectedType: "egosms",
 			create: notification.EgoSMS{


### PR DESCRIPTION
Add support for the `Flowtriq` notification provider, introduced upstream in
Uptime Kuma v2.5.0 (louislam/uptime-kuma#7546). Flowtriq is a DDoS detection
and incident platform, which receives the notifications via a webhook.

## Changes

- `notification/notification_flowtriq.go`: `Flowtriq` type with the
  `FlowtriqDetails` configuration block, following the existing provider
  pattern (`notification_ooredoo.go`).
  - `flowtriqWebhookUrl` (string, required): the webhook endpoint the
    notification is posted to.
  - `flowtriqApiKey` (`*string`, `omitempty`): optional, the server only sends
    it as the `X-API-Key` header if it is set.
- `notification/notification_flowtriq_test.go`: JSON round-trip coverage for
  the full and the minimal configuration, plus the error cases.
- `notification_test.go`: `Flowtriq` entry in the notification CRUD
  integration test, covering the optional API key being both set and unset.

## Verification

- `task fmt`, `task lint`: clean
- `task test-e2e`: passes, including `TestNotificationCRUD/Flowtriq`

Closes #339