### PR TITLE
feat(notification): add support for WxPusher notifications

### DIFF
--- a/notification/notification_wxpusher.go
+++ b/notification/notification_wxpusher.go
@@ -5,8 +5,8 @@ import (
 )
 
 // WxPusher represents a WxPusher notification provider.
-// WxPusher delivers notifications to WeChat via the WxPusher simple push
-// (极简推送) endpoint.
+// WxPusher delivers notifications through the standalone WxPusher app via
+// the simple push (极简推送) endpoint.
 type WxPusher struct {
 	Base
 	WxPusherDetails
@@ -15,8 +15,10 @@ type WxPusher struct {
 // WxPusherDetails contains the configuration fields for WxPusher notifications.
 type WxPusherDetails struct {
 	// SPT is the WxPusher simple push token, for example SPT_xxxxxxxxxxxx.
-	// Multiple tokens are supported and have to be separated by commas, the
-	// server trims the individual tokens and sends at most 10 per request.
+	// Required: the server rejects the notification at send time if no token
+	// remains. Multiple tokens are separated by commas, the server trims each
+	// one, discards empty entries and delivers to all of them, batching at
+	// most 10 tokens per request.
 	SPT string `json:"wxpusherSPT"`
 }
 

--- a/notification/notification_wxpusher.go
+++ b/notification/notification_wxpusher.go
@@ -1,0 +1,57 @@
+package notification
+
+import (
+	"fmt"
+)
+
+// WxPusher represents a WxPusher notification provider.
+// WxPusher delivers notifications to WeChat via the WxPusher simple push
+// (极简推送) endpoint.
+type WxPusher struct {
+	Base
+	WxPusherDetails
+}
+
+// WxPusherDetails contains the configuration fields for WxPusher notifications.
+type WxPusherDetails struct {
+	// SPT is the WxPusher simple push token, for example SPT_xxxxxxxxxxxx.
+	// Multiple tokens are supported and have to be separated by commas, the
+	// server trims the individual tokens and sends at most 10 per request.
+	SPT string `json:"wxpusherSPT"`
+}
+
+// Type returns the notification type identifier for WxPusher.
+func (w WxPusher) Type() string {
+	return w.WxPusherDetails.Type()
+}
+
+// Type returns the notification type identifier for WxPusherDetails.
+func (WxPusherDetails) Type() string {
+	return "WxPusher"
+}
+
+// String returns a string representation of the WxPusher notification.
+func (w WxPusher) String() string {
+	return fmt.Sprintf("%s, %s", formatNotification(w.Base, false), formatNotification(w.WxPusherDetails, true))
+}
+
+// UnmarshalJSON unmarshals JSON data into a WxPusher notification.
+func (w *WxPusher) UnmarshalJSON(data []byte) error {
+	detail := WxPusherDetails{}
+	base, err := unmarshalTo(data, &detail)
+	if err != nil {
+		return err
+	}
+
+	*w = WxPusher{
+		Base:            base,
+		WxPusherDetails: detail,
+	}
+
+	return nil
+}
+
+// MarshalJSON marshals the WxPusher notification into JSON.
+func (w WxPusher) MarshalJSON() ([]byte, error) {
+	return marshalJSON(w.Base, w.WxPusherDetails)
+}

--- a/notification/notification_wxpusher_test.go
+++ b/notification/notification_wxpusher_test.go
@@ -1,0 +1,124 @@
+package notification_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/breml/go-uptime-kuma-client/notification"
+)
+
+func TestNotificationWxPusher_Unmarshal(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+
+		want     notification.WxPusher
+		wantJSON string
+		wantErr  bool
+	}{
+		{
+			name: "success with single spt",
+			data: []byte(
+				`{"id":1,"name":"My WxPusher Alert","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"My WxPusher Alert\",\"type\":\"WxPusher\",\"wxpusherSPT\":\"SPT_xxxxxxxxxxxx\"}"}`,
+			),
+
+			want: notification.WxPusher{
+				Base: notification.Base{
+					ID:            1,
+					Name:          "My WxPusher Alert",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     true,
+					ApplyExisting: true,
+				},
+				WxPusherDetails: notification.WxPusherDetails{
+					SPT: "SPT_xxxxxxxxxxxx",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":true,"id":1,"isDefault":true,"name":"My WxPusher Alert","type":"WxPusher","userId":1,"wxpusherSPT":"SPT_xxxxxxxxxxxx"}`,
+		},
+		{
+			name: "success with multiple spts",
+			data: []byte(
+				`{"id":2,"name":"WxPusher Team","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"WxPusher Team\",\"type\":\"WxPusher\",\"wxpusherSPT\":\"SPT_aaaaaaaaaaaa, SPT_bbbbbbbbbbbb,SPT_cccccccccccc\"}"}`,
+			),
+
+			want: notification.WxPusher{
+				Base: notification.Base{
+					ID:            2,
+					Name:          "WxPusher Team",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				WxPusherDetails: notification.WxPusherDetails{
+					SPT: "SPT_aaaaaaaaaaaa, SPT_bbbbbbbbbbbb,SPT_cccccccccccc",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"id":2,"isDefault":false,"name":"WxPusher Team","type":"WxPusher","userId":1,"wxpusherSPT":"SPT_aaaaaaaaaaaa, SPT_bbbbbbbbbbbb,SPT_cccccccccccc"}`,
+		},
+		{
+			name: "inactive notification",
+			data: []byte(
+				`{"id":3,"name":"Disabled WxPusher","active":false,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Disabled WxPusher\",\"type\":\"WxPusher\",\"wxpusherSPT\":\"SPT_dddddddddddd\"}"}`,
+			),
+
+			want: notification.WxPusher{
+				Base: notification.Base{
+					ID:            3,
+					Name:          "Disabled WxPusher",
+					IsActive:      false,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				WxPusherDetails: notification.WxPusherDetails{
+					SPT: "SPT_dddddddddddd",
+				},
+			},
+			wantJSON: `{"active":false,"applyExisting":false,"id":3,"isDefault":false,"name":"Disabled WxPusher","type":"WxPusher","userId":1,"wxpusherSPT":"SPT_dddddddddddd"}`,
+		},
+		{
+			name:    "missing config field",
+			data:    []byte(`{"id":1,"name":"x","active":true,"userId":1,"isDefault":false}`),
+			wantErr: true,
+		},
+		{
+			name:    "invalid config json",
+			data:    []byte(`{"id":1,"name":"x","active":true,"userId":1,"isDefault":false,"config":"not-json"}`),
+			wantErr: true,
+		},
+		{
+			name: "invalid config detail type",
+			data: []byte(
+				`{"id":1,"name":"x","active":true,"userId":1,"isDefault":false,"config":"{\"type\":\"WxPusher\",\"wxpusherSPT\":123}"}`,
+			),
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			wxpusher := notification.WxPusher{}
+
+			err := json.Unmarshal(tc.data, &wxpusher)
+			if tc.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+
+			require.EqualExportedValues(t, tc.want, wxpusher)
+
+			data, err := json.Marshal(wxpusher)
+			require.NoError(t, err)
+
+			require.JSONEq(t, tc.wantJSON, string(data))
+		})
+	}
+}

--- a/notification/notification_wxpusher_test.go
+++ b/notification/notification_wxpusher_test.go
@@ -40,7 +40,7 @@ func TestNotificationWxPusher_Unmarshal(t *testing.T) {
 			wantJSON: `{"active":true,"applyExisting":true,"id":1,"isDefault":true,"name":"My WxPusher Alert","type":"WxPusher","userId":1,"wxpusherSPT":"SPT_xxxxxxxxxxxx"}`,
 		},
 		{
-			name: "success with multiple spts",
+			name: "comma separated spt list is preserved verbatim",
 			data: []byte(
 				`{"id":2,"name":"WxPusher Team","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"WxPusher Team\",\"type\":\"WxPusher\",\"wxpusherSPT\":\"SPT_aaaaaaaaaaaa, SPT_bbbbbbbbbbbb,SPT_cccccccccccc\"}"}`,
 			),
@@ -80,6 +80,48 @@ func TestNotificationWxPusher_Unmarshal(t *testing.T) {
 				},
 			},
 			wantJSON: `{"active":false,"applyExisting":false,"id":3,"isDefault":false,"name":"Disabled WxPusher","type":"WxPusher","userId":1,"wxpusherSPT":"SPT_dddddddddddd"}`,
+		},
+		{
+			name: "empty spt",
+			data: []byte(
+				`{"id":4,"name":"Empty WxPusher","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Empty WxPusher\",\"type\":\"WxPusher\",\"wxpusherSPT\":\"\"}"}`,
+			),
+
+			want: notification.WxPusher{
+				Base: notification.Base{
+					ID:            4,
+					Name:          "Empty WxPusher",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				WxPusherDetails: notification.WxPusherDetails{
+					SPT: "",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"id":4,"isDefault":false,"name":"Empty WxPusher","type":"WxPusher","userId":1,"wxpusherSPT":""}`,
+		},
+		{
+			name: "spt missing from config is marshaled back as empty",
+			data: []byte(
+				`{"id":5,"name":"No SPT WxPusher","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"No SPT WxPusher\",\"type\":\"WxPusher\"}"}`,
+			),
+
+			want: notification.WxPusher{
+				Base: notification.Base{
+					ID:            5,
+					Name:          "No SPT WxPusher",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				WxPusherDetails: notification.WxPusherDetails{
+					SPT: "",
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"id":5,"isDefault":false,"name":"No SPT WxPusher","type":"WxPusher","userId":1,"wxpusherSPT":""}`,
 		},
 		{
 			name:    "missing config field",

--- a/notification_test.go
+++ b/notification_test.go
@@ -4895,6 +4895,57 @@ func TestNotificationCRUD(t *testing.T) {
 			},
 		},
 		{
+			name:         "WxPusher",
+			expectedType: "WxPusher",
+			create: notification.WxPusher{
+				Base: notification.Base{
+					ApplyExisting: false,
+					IsDefault:     false,
+					IsActive:      true,
+					Name:          "Test WxPusher Created",
+				},
+				WxPusherDetails: notification.WxPusherDetails{
+					SPT: "SPT_xxxxxxxxxxxx",
+				},
+			},
+			updateFunc: func(n notification.Notification) {
+				wxpusher, ok := n.(*notification.WxPusher)
+				if !ok {
+					panic("failed to assert WxPusher notification")
+				}
+
+				wxpusher.Name = "Test WxPusher Updated"
+				wxpusher.SPT = "SPT_aaaaaaaaaaaa,SPT_bbbbbbbbbbbb"
+			},
+			verifyCreatedFunc: func(t *testing.T, actual notification.Notification, expected notification.Notification, id int64) {
+				t.Helper()
+				exp, ok := expected.(notification.WxPusher)
+				require.True(t, ok)
+				var wxpusher notification.WxPusher
+				err := actual.As(&wxpusher)
+				require.NoError(t, err)
+				exp.ID = id
+				exp.UserID = wxpusher.UserID
+				require.EqualExportedValues(t, exp, wxpusher)
+			},
+			createTypedFunc: func(t *testing.T, base notification.Notification) notification.Notification {
+				t.Helper()
+				var wxpusher notification.WxPusher
+				err := base.As(&wxpusher)
+				require.NoError(t, err)
+				return &wxpusher
+			},
+			verifyUpdatedFunc: func(t *testing.T, actual notification.Notification, expected notification.Notification) {
+				t.Helper()
+				exp, ok := expected.(*notification.WxPusher)
+				require.True(t, ok)
+				var wxpusher notification.WxPusher
+				err := actual.As(&wxpusher)
+				require.NoError(t, err)
+				require.EqualExportedValues(t, *exp, wxpusher)
+			},
+		},
+		{
 			name:         "YZJ",
 			expectedType: "YZJ",
 			create: notification.YZJ{


### PR DESCRIPTION
Adds the `WxPusher` notification provider, introduced upstream in Uptime Kuma v2.5.0 ([louislam/uptime-kuma#7569](https://github.com/louislam/uptime-kuma/pull/7569)). It delivers notifications through the standalone WxPusher app via the simple push (极简推送) endpoint.

## Changes

- `notification/notification_wxpusher.go`: `WxPusher` / `WxPusherDetails` with the single `wxpusherSPT` field, following the `WPush` pattern.
- `notification/notification_wxpusher_test.go`: JSON round-trip coverage for a single SPT, a comma-separated SPT list, an inactive notification and an empty or absent SPT, plus the unmarshal error branches.
- `notification_test.go`: CRUD integration coverage.

The server splits `wxpusherSPT` on commas, trims the individual tokens, discards empty entries and batches at most 10 tokens per request, delivering to all of them. The client therefore keeps the raw string as entered in the UI.

Closes #340