### PR TITLE
feat(notification): add additional headers support to SMTP notifications

### DIFF
--- a/notification/notification_smtp.go
+++ b/notification/notification_smtp.go
@@ -12,26 +12,27 @@ type SMTP struct {
 
 // SMTPDetails contains smtp-specific notification configuration.
 type SMTPDetails struct {
-	Host                 string `json:"smtpHost"`
-	Port                 int    `json:"smtpPort"`
-	Secure               bool   `json:"smtpSecure"`
-	IgnoreSTARTTLS       bool   `json:"smtpIgnoreSTARTTLS"`
-	IgnoreTLSError       bool   `json:"smtpIgnoreTLSError"`
-	DkimDomain           string `json:"smtpDkimDomain"`
-	DkimKeySelector      string `json:"smtpDkimKeySelector"`
-	DkimPrivateKey       string `json:"smtpDkimPrivateKey"`
-	DkimHashAlgo         string `json:"smtpDkimHashAlgo"`
-	DkimHeaderFieldNames string `json:"smtpDkimheaderFieldNames"`
-	DkimSkipFields       string `json:"smtpDkimskipFields"`
-	Username             string `json:"smtpUsername"`
-	Password             string `json:"smtpPassword"`
-	From                 string `json:"smtpFrom"`
-	CC                   string `json:"smtpCC"`
-	BCC                  string `json:"smtpBCC"`
-	To                   string `json:"smtpTo"`
-	CustomSubject        string `json:"customSubject"`
-	CustomBody           string `json:"customBody"`
-	HTMLBody             bool   `json:"htmlBody"`
+	Host                 string  `json:"smtpHost"`
+	Port                 int     `json:"smtpPort"`
+	Secure               bool    `json:"smtpSecure"`
+	IgnoreSTARTTLS       bool    `json:"smtpIgnoreSTARTTLS"`
+	IgnoreTLSError       bool    `json:"smtpIgnoreTLSError"`
+	DkimDomain           string  `json:"smtpDkimDomain"`
+	DkimKeySelector      string  `json:"smtpDkimKeySelector"`
+	DkimPrivateKey       string  `json:"smtpDkimPrivateKey"`
+	DkimHashAlgo         string  `json:"smtpDkimHashAlgo"`
+	DkimHeaderFieldNames string  `json:"smtpDkimheaderFieldNames"`
+	DkimSkipFields       string  `json:"smtpDkimskipFields"`
+	Username             string  `json:"smtpUsername"`
+	Password             string  `json:"smtpPassword"`
+	From                 string  `json:"smtpFrom"`
+	CC                   string  `json:"smtpCC"`
+	BCC                  string  `json:"smtpBCC"`
+	To                   string  `json:"smtpTo"`
+	CustomSubject        string  `json:"customSubject"`
+	CustomBody           string  `json:"customBody"`
+	HTMLBody             bool    `json:"htmlBody"`
+	AdditionalHeaders    *string `json:"smtpAdditionalHeaders,omitempty"`
 }
 
 // Type returns the notification type.

--- a/notification/notification_smtp.go
+++ b/notification/notification_smtp.go
@@ -12,27 +12,32 @@ type SMTP struct {
 
 // SMTPDetails contains smtp-specific notification configuration.
 type SMTPDetails struct {
-	Host                 string  `json:"smtpHost"`
-	Port                 int     `json:"smtpPort"`
-	Secure               bool    `json:"smtpSecure"`
-	IgnoreSTARTTLS       bool    `json:"smtpIgnoreSTARTTLS"`
-	IgnoreTLSError       bool    `json:"smtpIgnoreTLSError"`
-	DkimDomain           string  `json:"smtpDkimDomain"`
-	DkimKeySelector      string  `json:"smtpDkimKeySelector"`
-	DkimPrivateKey       string  `json:"smtpDkimPrivateKey"`
-	DkimHashAlgo         string  `json:"smtpDkimHashAlgo"`
-	DkimHeaderFieldNames string  `json:"smtpDkimheaderFieldNames"`
-	DkimSkipFields       string  `json:"smtpDkimskipFields"`
-	Username             string  `json:"smtpUsername"`
-	Password             string  `json:"smtpPassword"`
-	From                 string  `json:"smtpFrom"`
-	CC                   string  `json:"smtpCC"`
-	BCC                  string  `json:"smtpBCC"`
-	To                   string  `json:"smtpTo"`
-	CustomSubject        string  `json:"customSubject"`
-	CustomBody           string  `json:"customBody"`
-	HTMLBody             bool    `json:"htmlBody"`
-	AdditionalHeaders    *string `json:"smtpAdditionalHeaders,omitempty"`
+	Host                 string `json:"smtpHost"`
+	Port                 int    `json:"smtpPort"`
+	Secure               bool   `json:"smtpSecure"`
+	IgnoreSTARTTLS       bool   `json:"smtpIgnoreSTARTTLS"`
+	IgnoreTLSError       bool   `json:"smtpIgnoreTLSError"`
+	DkimDomain           string `json:"smtpDkimDomain"`
+	DkimKeySelector      string `json:"smtpDkimKeySelector"`
+	DkimPrivateKey       string `json:"smtpDkimPrivateKey"`
+	DkimHashAlgo         string `json:"smtpDkimHashAlgo"`
+	DkimHeaderFieldNames string `json:"smtpDkimheaderFieldNames"`
+	DkimSkipFields       string `json:"smtpDkimskipFields"`
+	Username             string `json:"smtpUsername"`
+	Password             string `json:"smtpPassword"`
+	From                 string `json:"smtpFrom"`
+	CC                   string `json:"smtpCC"`
+	BCC                  string `json:"smtpBCC"`
+	To                   string `json:"smtpTo"`
+	CustomSubject        string `json:"customSubject"`
+	CustomBody           string `json:"customBody"`
+	HTMLBody             bool   `json:"htmlBody"`
+	// AdditionalHeaders holds a JSON object encoded as a string, which the
+	// server merges into the headers of the outgoing mail, for example
+	// `{"X-Custom-Header": "Additional Header"}`. A nil value omits the
+	// field, while a pointer to the empty string keeps it present but
+	// unset, which the server distinguishes.
+	AdditionalHeaders *string `json:"smtpAdditionalHeaders,omitempty"`
 }
 
 // Type returns the notification type.

--- a/notification/notification_smtp_test.go
+++ b/notification/notification_smtp_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/breml/go-uptime-kuma-client/internal/ptr"
 	"github.com/breml/go-uptime-kuma-client/notification"
 )
 
@@ -108,6 +109,62 @@ func TestNotificationSMTP_Unmarshal(t *testing.T) {
 				},
 			},
 			wantJSON: `{"active":true,"applyExisting":false,"customBody":"","customSubject":"","htmlBody":false,"id":3,"isDefault":false,"name":"SMTP No STARTTLS","smtpBCC":"","smtpCC":"","smtpDkimDomain":"","smtpDkimHashAlgo":"","smtpDkimKeySelector":"","smtpDkimPrivateKey":"","smtpDkimheaderFieldNames":"","smtpDkimskipFields":"","smtpFrom":"sender@example.com","smtpHost":"legacy.example.com","smtpIgnoreSTARTTLS":true,"smtpIgnoreTLSError":false,"smtpPassword":"","smtpPort":25,"smtpSecure":false,"smtpTo":"recipient@example.com","smtpUsername":"","type":"smtp","userId":1}`,
+		},
+		{
+			name: "with additional headers",
+			data: []byte(
+				`{"id":4,"name":"SMTP Additional Headers","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"SMTP Additional Headers\",\"smtpHost\":\"smtp.example.com\",\"smtpPort\":587,\"smtpSecure\":false,\"smtpIgnoreTLSError\":false,\"smtpFrom\":\"sender@example.com\",\"smtpTo\":\"recipient@example.com\",\"smtpAdditionalHeaders\":\"{\\\"X-Custom-Header\\\": \\\"Additional Header\\\"}\",\"htmlBody\":false,\"type\":\"smtp\"}"}`,
+			),
+
+			want: notification.SMTP{
+				Base: notification.Base{
+					ID:            4,
+					Name:          "SMTP Additional Headers",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				SMTPDetails: notification.SMTPDetails{
+					Host:              "smtp.example.com",
+					Port:              587,
+					Secure:            false,
+					IgnoreTLSError:    false,
+					From:              "sender@example.com",
+					To:                "recipient@example.com",
+					AdditionalHeaders: ptr.To(`{"X-Custom-Header": "Additional Header"}`),
+					HTMLBody:          false,
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"customBody":"","customSubject":"","htmlBody":false,"id":4,"isDefault":false,"name":"SMTP Additional Headers","smtpAdditionalHeaders":"{\"X-Custom-Header\": \"Additional Header\"}","smtpBCC":"","smtpCC":"","smtpDkimDomain":"","smtpDkimHashAlgo":"","smtpDkimKeySelector":"","smtpDkimPrivateKey":"","smtpDkimheaderFieldNames":"","smtpDkimskipFields":"","smtpFrom":"sender@example.com","smtpHost":"smtp.example.com","smtpIgnoreSTARTTLS":false,"smtpIgnoreTLSError":false,"smtpPassword":"","smtpPort":587,"smtpSecure":false,"smtpTo":"recipient@example.com","smtpUsername":"","type":"smtp","userId":1}`,
+		},
+		{
+			name: "with empty additional headers",
+			data: []byte(
+				`{"id":5,"name":"SMTP Empty Additional Headers","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"SMTP Empty Additional Headers\",\"smtpHost\":\"smtp.example.com\",\"smtpPort\":587,\"smtpSecure\":false,\"smtpIgnoreTLSError\":false,\"smtpFrom\":\"sender@example.com\",\"smtpTo\":\"recipient@example.com\",\"smtpAdditionalHeaders\":\"\",\"htmlBody\":false,\"type\":\"smtp\"}"}`,
+			),
+
+			want: notification.SMTP{
+				Base: notification.Base{
+					ID:            5,
+					Name:          "SMTP Empty Additional Headers",
+					IsActive:      true,
+					UserID:        1,
+					IsDefault:     false,
+					ApplyExisting: false,
+				},
+				SMTPDetails: notification.SMTPDetails{
+					Host:              "smtp.example.com",
+					Port:              587,
+					Secure:            false,
+					IgnoreTLSError:    false,
+					From:              "sender@example.com",
+					To:                "recipient@example.com",
+					AdditionalHeaders: ptr.To(""),
+					HTMLBody:          false,
+				},
+			},
+			wantJSON: `{"active":true,"applyExisting":false,"customBody":"","customSubject":"","htmlBody":false,"id":5,"isDefault":false,"name":"SMTP Empty Additional Headers","smtpAdditionalHeaders":"","smtpBCC":"","smtpCC":"","smtpDkimDomain":"","smtpDkimHashAlgo":"","smtpDkimKeySelector":"","smtpDkimPrivateKey":"","smtpDkimheaderFieldNames":"","smtpDkimskipFields":"","smtpFrom":"sender@example.com","smtpHost":"smtp.example.com","smtpIgnoreSTARTTLS":false,"smtpIgnoreTLSError":false,"smtpPassword":"","smtpPort":587,"smtpSecure":false,"smtpTo":"recipient@example.com","smtpUsername":"","type":"smtp","userId":1}`,
 		},
 	}
 

--- a/notification_test.go
+++ b/notification_test.go
@@ -297,6 +297,7 @@ func TestNotificationCRUD(t *testing.T) {
 				smtp.BCC = "bcc@example.com"
 				smtp.Secure = false
 				smtp.IgnoreSTARTTLS = true
+				smtp.AdditionalHeaders = ptr.To(`{"X-Custom-Header": "Additional Header"}`)
 			},
 			verifyCreatedFunc: func(t *testing.T, actual notification.Notification, expected notification.Notification, id int64) {
 				t.Helper()

--- a/notification_test.go
+++ b/notification_test.go
@@ -271,15 +271,16 @@ func TestNotificationCRUD(t *testing.T) {
 					Name:          "Test SMTP Created",
 				},
 				SMTPDetails: notification.SMTPDetails{
-					Host:           "smtp.gmail.com",
-					Port:           587,
-					Secure:         false,
-					IgnoreTLSError: false,
-					From:           "noreply@example.com",
-					To:             "alerts@example.com",
-					CustomSubject:  "Alert: {{ monitorJSON['name'] }}",
-					CustomBody:     "Status: {{ msg }}",
-					HTMLBody:       true,
+					Host:              "smtp.gmail.com",
+					Port:              587,
+					Secure:            false,
+					IgnoreTLSError:    false,
+					From:              "noreply@example.com",
+					To:                "alerts@example.com",
+					CustomSubject:     "Alert: {{ monitorJSON['name'] }}",
+					CustomBody:        "Status: {{ msg }}",
+					HTMLBody:          true,
+					AdditionalHeaders: ptr.To(`{"X-Custom-Header": "Additional Header"}`),
 				},
 			},
 			updateFunc: func(n notification.Notification) {
@@ -297,7 +298,7 @@ func TestNotificationCRUD(t *testing.T) {
 				smtp.BCC = "bcc@example.com"
 				smtp.Secure = false
 				smtp.IgnoreSTARTTLS = true
-				smtp.AdditionalHeaders = ptr.To(`{"X-Custom-Header": "Additional Header"}`)
+				smtp.AdditionalHeaders = nil
 			},
 			verifyCreatedFunc: func(t *testing.T, actual notification.Notification, expected notification.Notification, id int64) {
 				t.Helper()


### PR DESCRIPTION
Uptime Kuma v2.5.0 added an "Additional Headers" option to the SMTP notification provider ([louislam/uptime-kuma#7506](https://github.com/louislam/uptime-kuma/pull/7506)). The server parses the value with `JSON.parse` and merges the result into the nodemailer transport config and the outgoing message.

## Changes

- Add `AdditionalHeaders *string` (`smtpAdditionalHeaders`, `omitempty`) to `notification.SMTPDetails`, documenting that the value is a JSON object encoded as a string and that nil differs from a pointer to the empty string.
- Extend `notification/notification_smtp_test.go` with marshal/unmarshal cases for a populated header object and for an empty string (the latter proves empty-vs-absent round-trips).
- Extend the SMTP case in the e2e `TestNotificationCRUD` table so create sets the field and update clears it, exercising both directions against a real Uptime Kuma instance.

## Notes

The value stays a raw JSON string on the wire rather than a `map[string]string`, since the server does the parsing itself and rejects invalid input with `Additional Headers is not a valid JSON`. A map would also fail to read back headers with array values, which nodemailer permits.

It is modelled as `*string` with `omitempty` because the UI derives the feature toggle from `smtpAdditionalHeaders != null`; always emitting an empty string would enable the toggle for existing notifications.

The `smtp` **monitor** type is unrelated and unchanged.

Closes #341