### PR TITLE
feat(monitor): add connection timeout support to Kafka Producer monitor

### DIFF
--- a/monitor/monitor_kafka_producer.go
+++ b/monitor/monitor_kafka_producer.go
@@ -76,6 +76,7 @@ func (k KafkaProducer) MarshalJSON() ([]byte, error) {
 	raw["kafkaProducerSsl"] = k.SSL
 	raw["kafkaProducerAllowAutoTopicCreation"] = k.AllowAutoTopicCreation
 	raw["kafkaProducerSaslOptions"] = k.SASLOptions
+	raw["timeout"] = k.Timeout
 
 	// Server expects these fields to be arrays and not null.
 	raw["accepted_statuscodes"] = []string{}
@@ -105,6 +106,9 @@ type KafkaProducerDetails struct {
 	AllowAutoTopicCreation bool `json:"kafkaProducerAllowAutoTopicCreation"`
 	// SASLOptions is an optional map containing string with SASL configuration.
 	SASLOptions *map[string]any `json:"kafkaProducerSaslOptions"`
+	// Timeout is the optional connection timeout in seconds. The server defaults
+	// to 1 second, if it is not set.
+	Timeout *int64 `json:"timeout"`
 }
 
 // Type returns the monitor type.

--- a/monitor/monitor_kafka_producer.go
+++ b/monitor/monitor_kafka_producer.go
@@ -6,6 +6,12 @@ import (
 	"strconv"
 )
 
+// defaultKafkaProducerTimeout is the connection timeout in seconds the UI
+// assigns to a new Kafka Producer monitor. The client sends it explicitly,
+// because the monitor.timeout column is NOT NULL and the server rejects an
+// explicit null.
+const defaultKafkaProducerTimeout = 1
+
 // KafkaProducer represents a Kafka Producer monitor for testing Kafka connectivity.
 type KafkaProducer struct {
 	Base
@@ -76,7 +82,15 @@ func (k KafkaProducer) MarshalJSON() ([]byte, error) {
 	raw["kafkaProducerSsl"] = k.SSL
 	raw["kafkaProducerAllowAutoTopicCreation"] = k.AllowAutoTopicCreation
 	raw["kafkaProducerSaslOptions"] = k.SASLOptions
-	raw["timeout"] = k.Timeout
+
+	// The monitor.timeout column is NOT NULL, so an unset Timeout is sent as
+	// the value a new monitor is created with instead of as null.
+	timeout := int64(defaultKafkaProducerTimeout)
+	if k.Timeout != nil {
+		timeout = *k.Timeout
+	}
+
+	raw["timeout"] = timeout
 
 	// Server expects these fields to be arrays and not null.
 	raw["accepted_statuscodes"] = []string{}
@@ -106,8 +120,10 @@ type KafkaProducerDetails struct {
 	AllowAutoTopicCreation bool `json:"kafkaProducerAllowAutoTopicCreation"`
 	// SASLOptions is an optional map containing string with SASL configuration.
 	SASLOptions *map[string]any `json:"kafkaProducerSaslOptions"`
-	// Timeout is the optional connection timeout in seconds. The server defaults
-	// to 1 second, if it is not set.
+	// Timeout is the optional connection timeout in seconds. While unset the
+	// client sends 1, the value the UI assigns to a new Kafka Producer
+	// monitor, because the server stores the column as NOT NULL and passes it
+	// to kafkajs verbatim.
 	Timeout *int64 `json:"timeout"`
 }
 

--- a/monitor/monitor_kafka_producer_test.go
+++ b/monitor/monitor_kafka_producer_test.go
@@ -25,7 +25,7 @@ func TestMonitorKafkaProducer_Unmarshal(t *testing.T) {
 		{
 			name: "success with single broker and SSL",
 			data: []byte(
-				`{"id":1,"name":"kafka-monitor","description":"Test Kafka monitor","pathName":"group / kafka-monitor","parent":1,"childrenIDs":[],"url":null,"method":"GET","hostname":null,"port":null,"maxretries":2,"weight":2000,"active":true,"forceInactive":false,"type":"kafka-producer","timeout":48,"interval":60,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":null,"dns_resolve_server":null,"dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{"1":true,"2":true},"tags":[],"maintenance":false,"mqttTopic":"","mqttSuccessMessage":"","databaseQuery":null,"authMethod":null,"grpcUrl":null,"grpcProtobuf":null,"grpcMethod":null,"grpcServiceName":null,"grpcEnableTls":false,"radiusCalledStationId":null,"radiusCallingStationId":null,"game":null,"gamedigGivenPortOnly":true,"httpBodyEncoding":"json","jsonPath":null,"expectedValue":null,"kafkaProducerTopic":"test-topic","kafkaProducerBrokers":["localhost:9092"],"kafkaProducerSsl":true,"kafkaProducerAllowAutoTopicCreation":false,"kafkaProducerMessage":"test message","screenshot":null,"headers":null,"body":null,"grpcBody":null,"grpcMetadata":null,"basic_auth_user":null,"basic_auth_pass":null,"oauth_client_id":null,"oauth_client_secret":null,"oauth_token_url":null,"oauth_scopes":null,"oauth_auth_method":"client_secret_basic","pushToken":null,"databaseConnectionString":null,"radiusUsername":null,"radiusPassword":null,"radiusSecret":null,"mqttUsername":"","mqttPassword":"","authWorkstation":null,"authDomain":null,"tlsCa":null,"tlsCert":null,"tlsKey":null,"kafkaProducerSaslOptions":{"mechanism":"None"},"includeSensitiveData":true}`,
+				`{"id":1,"name":"kafka-monitor","description":"Test Kafka monitor","pathName":"group / kafka-monitor","parent":1,"childrenIDs":[],"url":null,"method":"GET","hostname":null,"port":null,"maxretries":2,"weight":2000,"active":true,"forceInactive":false,"type":"kafka-producer","timeout":1,"interval":60,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":null,"dns_resolve_server":null,"dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{"1":true,"2":true},"tags":[],"maintenance":false,"mqttTopic":"","mqttSuccessMessage":"","databaseQuery":null,"authMethod":null,"grpcUrl":null,"grpcProtobuf":null,"grpcMethod":null,"grpcServiceName":null,"grpcEnableTls":false,"radiusCalledStationId":null,"radiusCallingStationId":null,"game":null,"gamedigGivenPortOnly":true,"httpBodyEncoding":"json","jsonPath":null,"expectedValue":null,"kafkaProducerTopic":"test-topic","kafkaProducerBrokers":["localhost:9092"],"kafkaProducerSsl":true,"kafkaProducerAllowAutoTopicCreation":false,"kafkaProducerMessage":"test message","screenshot":null,"headers":null,"body":null,"grpcBody":null,"grpcMetadata":null,"basic_auth_user":null,"basic_auth_pass":null,"oauth_client_id":null,"oauth_client_secret":null,"oauth_token_url":null,"oauth_scopes":null,"oauth_auth_method":"client_secret_basic","pushToken":null,"databaseConnectionString":null,"radiusUsername":null,"radiusPassword":null,"radiusSecret":null,"mqttUsername":"","mqttPassword":"","authWorkstation":null,"authDomain":null,"tlsCa":null,"tlsCert":null,"tlsKey":null,"kafkaProducerSaslOptions":{"mechanism":"None"},"includeSensitiveData":true}`,
 			),
 
 			want: monitor.KafkaProducer{
@@ -50,15 +50,15 @@ func TestMonitorKafkaProducer_Unmarshal(t *testing.T) {
 					SSL:                    true,
 					AllowAutoTopicCreation: false,
 					SASLOptions:            &saslOptionsNone,
-					Timeout:                ptr.To(int64(48)),
+					Timeout:                ptr.To(int64(1)),
 				},
 			},
-			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":"Test Kafka monitor","id":1,"interval":60,"kafkaProducerAllowAutoTopicCreation":false,"kafkaProducerBrokers":["localhost:9092"],"kafkaProducerMessage":"test message","kafkaProducerSaslOptions":{"mechanism":"None"},"kafkaProducerSsl":true,"kafkaProducerTopic":"test-topic","maxretries":2,"name":"kafka-monitor","notificationIDList":{"1":true,"2":true},"parent":1,"resendInterval":0,"retryInterval":60,"timeout":48,"type":"kafka-producer","upsideDown":false}`,
+			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":"Test Kafka monitor","id":1,"interval":60,"kafkaProducerAllowAutoTopicCreation":false,"kafkaProducerBrokers":["localhost:9092"],"kafkaProducerMessage":"test message","kafkaProducerSaslOptions":{"mechanism":"None"},"kafkaProducerSsl":true,"kafkaProducerTopic":"test-topic","maxretries":2,"name":"kafka-monitor","notificationIDList":{"1":true,"2":true},"parent":1,"resendInterval":0,"retryInterval":60,"timeout":1,"type":"kafka-producer","upsideDown":false}`,
 		},
 		{
 			name: "success with multiple brokers and SASL",
 			data: []byte(
-				`{"id":2,"name":"kafka-cluster","description":"Test Kafka cluster","pathName":"group / kafka-cluster","parent":1,"childrenIDs":[],"url":null,"method":"GET","hostname":null,"port":null,"maxretries":3,"weight":2000,"active":true,"forceInactive":false,"type":"kafka-producer","timeout":30,"interval":120,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":null,"dns_resolve_server":null,"dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{},"tags":[],"maintenance":false,"mqttTopic":"","mqttSuccessMessage":"","databaseQuery":null,"authMethod":null,"grpcUrl":null,"grpcProtobuf":null,"grpcMethod":null,"grpcServiceName":null,"grpcEnableTls":false,"radiusCalledStationId":null,"radiusCallingStationId":null,"game":null,"gamedigGivenPortOnly":true,"httpBodyEncoding":"json","jsonPath":null,"expectedValue":null,"kafkaProducerTopic":"events","kafkaProducerBrokers":["kafka1:9092","kafka2:9092","kafka3:9092"],"kafkaProducerSsl":false,"kafkaProducerAllowAutoTopicCreation":true,"kafkaProducerMessage":"health check","screenshot":null,"headers":null,"body":null,"grpcBody":null,"grpcMetadata":null,"basic_auth_user":null,"basic_auth_pass":null,"oauth_client_id":null,"oauth_client_secret":null,"oauth_token_url":null,"oauth_scopes":null,"oauth_auth_method":"client_secret_basic","pushToken":null,"databaseConnectionString":null,"radiusUsername":null,"radiusPassword":null,"radiusSecret":null,"mqttUsername":"","mqttPassword":"","authWorkstation":null,"authDomain":null,"tlsCa":null,"tlsCert":null,"tlsKey":null,"kafkaProducerSaslOptions":{"mechanism":"plain","username":"user","password":"pass"},"includeSensitiveData":true}`,
+				`{"id":2,"name":"kafka-cluster","description":"Test Kafka cluster","pathName":"group / kafka-cluster","parent":1,"childrenIDs":[],"url":null,"method":"GET","hostname":null,"port":null,"maxretries":3,"weight":2000,"active":true,"forceInactive":false,"type":"kafka-producer","timeout":5,"interval":120,"retryInterval":60,"resendInterval":0,"keyword":null,"invertKeyword":false,"expiryNotification":false,"ignoreTls":false,"upsideDown":false,"packetSize":56,"maxredirects":10,"accepted_statuscodes":["200-299"],"dns_resolve_type":null,"dns_resolve_server":null,"dns_last_result":null,"docker_container":"","docker_host":null,"proxyId":null,"notificationIDList":{},"tags":[],"maintenance":false,"mqttTopic":"","mqttSuccessMessage":"","databaseQuery":null,"authMethod":null,"grpcUrl":null,"grpcProtobuf":null,"grpcMethod":null,"grpcServiceName":null,"grpcEnableTls":false,"radiusCalledStationId":null,"radiusCallingStationId":null,"game":null,"gamedigGivenPortOnly":true,"httpBodyEncoding":"json","jsonPath":null,"expectedValue":null,"kafkaProducerTopic":"events","kafkaProducerBrokers":["kafka1:9092","kafka2:9092","kafka3:9092"],"kafkaProducerSsl":false,"kafkaProducerAllowAutoTopicCreation":true,"kafkaProducerMessage":"health check","screenshot":null,"headers":null,"body":null,"grpcBody":null,"grpcMetadata":null,"basic_auth_user":null,"basic_auth_pass":null,"oauth_client_id":null,"oauth_client_secret":null,"oauth_token_url":null,"oauth_scopes":null,"oauth_auth_method":"client_secret_basic","pushToken":null,"databaseConnectionString":null,"radiusUsername":null,"radiusPassword":null,"radiusSecret":null,"mqttUsername":"","mqttPassword":"","authWorkstation":null,"authDomain":null,"tlsCa":null,"tlsCert":null,"tlsKey":null,"kafkaProducerSaslOptions":{"mechanism":"plain","username":"user","password":"pass"},"includeSensitiveData":true}`,
 			),
 
 			want: monitor.KafkaProducer{
@@ -83,10 +83,42 @@ func TestMonitorKafkaProducer_Unmarshal(t *testing.T) {
 					SSL:                    false,
 					AllowAutoTopicCreation: true,
 					SASLOptions:            &saslOptionsBasic,
-					Timeout:                ptr.To(int64(30)),
+					Timeout:                ptr.To(int64(5)),
 				},
 			},
-			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":"Test Kafka cluster","id":2,"interval":120,"kafkaProducerAllowAutoTopicCreation":true,"kafkaProducerBrokers":["kafka1:9092","kafka2:9092","kafka3:9092"],"kafkaProducerMessage":"health check","kafkaProducerSaslOptions":{"mechanism":"plain","password":"pass","username":"user"},"kafkaProducerSsl":false,"kafkaProducerTopic":"events","maxretries":3,"name":"kafka-cluster","notificationIDList":{},"parent":1,"resendInterval":0,"retryInterval":60,"timeout":30,"type":"kafka-producer","upsideDown":false}`,
+			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":"Test Kafka cluster","id":2,"interval":120,"kafkaProducerAllowAutoTopicCreation":true,"kafkaProducerBrokers":["kafka1:9092","kafka2:9092","kafka3:9092"],"kafkaProducerMessage":"health check","kafkaProducerSaslOptions":{"mechanism":"plain","password":"pass","username":"user"},"kafkaProducerSsl":false,"kafkaProducerTopic":"events","maxretries":3,"name":"kafka-cluster","notificationIDList":{},"parent":1,"resendInterval":0,"retryInterval":60,"timeout":5,"type":"kafka-producer","upsideDown":false}`,
+		},
+		{
+			name: "success with unset timeout",
+			data: []byte(
+				`{"id":3,"name":"kafka-minimal","description":null,"pathName":"kafka-minimal","parent":null,"childrenIDs":[],"url":null,"method":"GET","hostname":null,"port":null,"maxretries":0,"weight":2000,"active":true,"forceInactive":false,"type":"kafka-producer","timeout":null,"interval":60,"retryInterval":60,"resendInterval":0,"upsideDown":false,"accepted_statuscodes":["200-299"],"notificationIDList":{},"tags":[],"maintenance":false,"conditions":[],"kafkaProducerTopic":"events","kafkaProducerBrokers":["localhost:9092"],"kafkaProducerSsl":false,"kafkaProducerAllowAutoTopicCreation":false,"kafkaProducerMessage":"health check","kafkaProducerSaslOptions":null}`,
+			),
+
+			want: monitor.KafkaProducer{
+				Base: monitor.Base{
+					ID:             3,
+					Name:           "kafka-minimal",
+					PathName:       "kafka-minimal",
+					Interval:       60,
+					RetryInterval:  60,
+					ResendInterval: 0,
+					MaxRetries:     0,
+					UpsideDown:     false,
+					IsActive:       true,
+				},
+				KafkaProducerDetails: monitor.KafkaProducerDetails{
+					Brokers:                []string{"localhost:9092"},
+					Topic:                  "events",
+					Message:                "health check",
+					SSL:                    false,
+					AllowAutoTopicCreation: false,
+					SASLOptions:            nil,
+					Timeout:                nil,
+				},
+			},
+			// The monitor.timeout column is NOT NULL, so timeout is substituted
+			// on marshal while the SASL options stay null.
+			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":null,"id":3,"interval":60,"kafkaProducerAllowAutoTopicCreation":false,"kafkaProducerBrokers":["localhost:9092"],"kafkaProducerMessage":"health check","kafkaProducerSaslOptions":null,"kafkaProducerSsl":false,"kafkaProducerTopic":"events","maxretries":0,"name":"kafka-minimal","notificationIDList":{},"parent":null,"resendInterval":0,"retryInterval":60,"timeout":1,"type":"kafka-producer","upsideDown":false}`,
 		},
 	}
 

--- a/monitor/monitor_kafka_producer_test.go
+++ b/monitor/monitor_kafka_producer_test.go
@@ -50,9 +50,10 @@ func TestMonitorKafkaProducer_Unmarshal(t *testing.T) {
 					SSL:                    true,
 					AllowAutoTopicCreation: false,
 					SASLOptions:            &saslOptionsNone,
+					Timeout:                ptr.To(int64(48)),
 				},
 			},
-			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":"Test Kafka monitor","id":1,"interval":60,"kafkaProducerAllowAutoTopicCreation":false,"kafkaProducerBrokers":["localhost:9092"],"kafkaProducerMessage":"test message","kafkaProducerSaslOptions":{"mechanism":"None"},"kafkaProducerSsl":true,"kafkaProducerTopic":"test-topic","maxretries":2,"name":"kafka-monitor","notificationIDList":{"1":true,"2":true},"parent":1,"resendInterval":0,"retryInterval":60,"type":"kafka-producer","upsideDown":false}`,
+			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":"Test Kafka monitor","id":1,"interval":60,"kafkaProducerAllowAutoTopicCreation":false,"kafkaProducerBrokers":["localhost:9092"],"kafkaProducerMessage":"test message","kafkaProducerSaslOptions":{"mechanism":"None"},"kafkaProducerSsl":true,"kafkaProducerTopic":"test-topic","maxretries":2,"name":"kafka-monitor","notificationIDList":{"1":true,"2":true},"parent":1,"resendInterval":0,"retryInterval":60,"timeout":48,"type":"kafka-producer","upsideDown":false}`,
 		},
 		{
 			name: "success with multiple brokers and SASL",
@@ -82,9 +83,10 @@ func TestMonitorKafkaProducer_Unmarshal(t *testing.T) {
 					SSL:                    false,
 					AllowAutoTopicCreation: true,
 					SASLOptions:            &saslOptionsBasic,
+					Timeout:                ptr.To(int64(30)),
 				},
 			},
-			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":"Test Kafka cluster","id":2,"interval":120,"kafkaProducerAllowAutoTopicCreation":true,"kafkaProducerBrokers":["kafka1:9092","kafka2:9092","kafka3:9092"],"kafkaProducerMessage":"health check","kafkaProducerSaslOptions":{"mechanism":"plain","password":"pass","username":"user"},"kafkaProducerSsl":false,"kafkaProducerTopic":"events","maxretries":3,"name":"kafka-cluster","notificationIDList":{},"parent":1,"resendInterval":0,"retryInterval":60,"type":"kafka-producer","upsideDown":false}`,
+			wantJSON: `{"accepted_statuscodes":[],"active":true,"conditions":[],"description":"Test Kafka cluster","id":2,"interval":120,"kafkaProducerAllowAutoTopicCreation":true,"kafkaProducerBrokers":["kafka1:9092","kafka2:9092","kafka3:9092"],"kafkaProducerMessage":"health check","kafkaProducerSaslOptions":{"mechanism":"plain","password":"pass","username":"user"},"kafkaProducerSsl":false,"kafkaProducerTopic":"events","maxretries":3,"name":"kafka-cluster","notificationIDList":{},"parent":1,"resendInterval":0,"retryInterval":60,"timeout":30,"type":"kafka-producer","upsideDown":false}`,
 		},
 	}
 

--- a/monitor_test.go
+++ b/monitor_test.go
@@ -1315,7 +1315,8 @@ func TestMonitorCRUD(t *testing.T) {
 					SSL:                    false,
 					AllowAutoTopicCreation: false,
 					SASLOptions:            nil,
-					Timeout:                ptr.To(int64(1)),
+					// Timeout is left unset on purpose: the server column is
+					// NOT NULL, so MarshalJSON has to substitute a value.
 				},
 			},
 			updateFunc: func(m monitor.Monitor) {
@@ -1339,6 +1340,8 @@ func TestMonitorCRUD(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, id, kafka.ID)
 				require.Equal(t, "Test Kafka Producer Monitor", kafka.Name)
+				require.NotNil(t, kafka.Timeout)
+				require.Equal(t, int64(1), *kafka.Timeout)
 			},
 			createTypedFunc: func(t *testing.T, base monitor.Monitor) monitor.Monitor {
 				t.Helper()
@@ -1358,6 +1361,7 @@ func TestMonitorCRUD(t *testing.T) {
 				require.Equal(t, "updated message", kafka.Message)
 				require.True(t, kafka.SSL)
 				require.True(t, kafka.AllowAutoTopicCreation)
+				require.NotNil(t, kafka.Timeout)
 				require.Equal(t, int64(5), *kafka.Timeout)
 			},
 			testPauseResume: true,

--- a/monitor_test.go
+++ b/monitor_test.go
@@ -1315,6 +1315,7 @@ func TestMonitorCRUD(t *testing.T) {
 					SSL:                    false,
 					AllowAutoTopicCreation: false,
 					SASLOptions:            nil,
+					Timeout:                ptr.To(int64(1)),
 				},
 			},
 			updateFunc: func(m monitor.Monitor) {
@@ -1329,6 +1330,7 @@ func TestMonitorCRUD(t *testing.T) {
 				kafka.Message = "updated message"
 				kafka.SSL = true
 				kafka.AllowAutoTopicCreation = true
+				kafka.Timeout = ptr.To(int64(5))
 			},
 			verifyCreatedFunc: func(t *testing.T, actual monitor.Monitor, id int64) {
 				t.Helper()
@@ -1356,6 +1358,7 @@ func TestMonitorCRUD(t *testing.T) {
 				require.Equal(t, "updated message", kafka.Message)
 				require.True(t, kafka.SSL)
 				require.True(t, kafka.AllowAutoTopicCreation)
+				require.Equal(t, int64(5), *kafka.Timeout)
 			},
 			testPauseResume: true,
 		},


### PR DESCRIPTION
## Summary

Uptime Kuma v2.5.0 ([louislam/uptime-kuma#7472](https://github.com/louislam/uptime-kuma/pull/7472)) made the monitor `timeout` field effective for `kafka-producer` monitors: it is passed to kafkajs as `connectionTimeout`, so a broker that never answers no longer hangs the check. The client had no way to configure it.

- Add `Timeout *int64` with tag `json:"timeout"` to `monitor.KafkaProducerDetails`. The optional pointer type follows the existing optional timeout types (`RabbitMQDetails`, `SteamDetails`).
- Emit `raw["timeout"]` in `KafkaProducer.MarshalJSON`, which builds a fresh map and therefore needs the field added explicitly.
- The `monitor.timeout` column is NOT NULL, so an unset `Timeout` is sent as `defaultKafkaProducerTimeout` rather than as null, which the server rejects with a constraint error. This mirrors `monitor.NTP`.

The `connectionTimeout = 1` fallback in the server applies to an undefined value only, which the NOT NULL column never yields, so 1 is the value the UI assigns to a new Kafka Producer monitor rather than a server-side default.

## Tests

- Extended the round-trip coverage in `monitor/monitor_kafka_producer_test.go`, including a case with `timeout` null on the wire that asserts the substituted value on marshal.
- Extended the `Kafka Producer` case in the `TestMonitorCRUD` end-to-end test to create with an unset timeout and update to `timeout: 5`.

`task lint`, `task fmt`, `task test` and `task test-e2e` pass.

Closes #342