### PR TITLE
fix(notification): align Type() with upstream provider names

### DIFF
--- a/notification/notification_46elks.go
+++ b/notification/notification_46elks.go
@@ -24,6 +24,11 @@ func (f FortySixElks) Type() string {
 }
 
 // Type returns the notification type.
+//
+// Note: this is the provider name of Uptime Kuma
+// (server/notification-providers/46elks.js) and deliberately does not follow the
+// casing of the Go type. Do not "fix" it, the server dispatches on this exact
+// string.
 func (FortySixElksDetails) Type() string {
 	return "Elks"
 }

--- a/notification/notification_46elks.go
+++ b/notification/notification_46elks.go
@@ -25,7 +25,7 @@ func (f FortySixElks) Type() string {
 
 // Type returns the notification type.
 func (FortySixElksDetails) Type() string {
-	return "46elks"
+	return "Elks"
 }
 
 // String returns a string representation of the notification.

--- a/notification/notification_46elks_test.go
+++ b/notification/notification_46elks_test.go
@@ -20,7 +20,7 @@ func TestNotificationFortySixElks_Unmarshal(t *testing.T) {
 		{
 			name: "success",
 			data: []byte(
-				`{"id":1,"name":"My 46elks Alert","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"My 46elks Alert\",\"elksUsername\":\"username@example.com\",\"elksAuthToken\":\"auth_token_secret\",\"elksFromNumber\":\"1234\",\"elksToNumber\":\"0701234567\",\"type\":\"46elks\"}"}`,
+				`{"id":1,"name":"My 46elks Alert","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"My 46elks Alert\",\"elksUsername\":\"username@example.com\",\"elksAuthToken\":\"auth_token_secret\",\"elksFromNumber\":\"1234\",\"elksToNumber\":\"0701234567\",\"type\":\"Elks\"}"}`,
 			),
 
 			want: notification.FortySixElks{
@@ -39,12 +39,12 @@ func TestNotificationFortySixElks_Unmarshal(t *testing.T) {
 					ToNumber:   "0701234567",
 				},
 			},
-			wantJSON: `{"active":true,"applyExisting":true,"elksAuthToken":"auth_token_secret","elksFromNumber":"1234","elksToNumber":"0701234567","elksUsername":"username@example.com","id":1,"isDefault":true,"name":"My 46elks Alert","type":"46elks","userId":1}`,
+			wantJSON: `{"active":true,"applyExisting":true,"elksAuthToken":"auth_token_secret","elksFromNumber":"1234","elksToNumber":"0701234567","elksUsername":"username@example.com","id":1,"isDefault":true,"name":"My 46elks Alert","type":"Elks","userId":1}`,
 		},
 		{
 			name: "minimal",
 			data: []byte(
-				`{"id":2,"name":"Simple 46elks","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Simple 46elks\",\"elksUsername\":\"user\",\"elksAuthToken\":\"token\",\"elksFromNumber\":\"1234\",\"elksToNumber\":\"0701234567\",\"type\":\"46elks\"}"}`,
+				`{"id":2,"name":"Simple 46elks","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Simple 46elks\",\"elksUsername\":\"user\",\"elksAuthToken\":\"token\",\"elksFromNumber\":\"1234\",\"elksToNumber\":\"0701234567\",\"type\":\"Elks\"}"}`,
 			),
 
 			want: notification.FortySixElks{
@@ -63,7 +63,7 @@ func TestNotificationFortySixElks_Unmarshal(t *testing.T) {
 					ToNumber:   "0701234567",
 				},
 			},
-			wantJSON: `{"active":true,"applyExisting":false,"elksAuthToken":"token","elksFromNumber":"1234","elksToNumber":"0701234567","elksUsername":"user","id":2,"isDefault":false,"name":"Simple 46elks","type":"46elks","userId":1}`,
+			wantJSON: `{"active":true,"applyExisting":false,"elksAuthToken":"token","elksFromNumber":"1234","elksToNumber":"0701234567","elksUsername":"user","id":2,"isDefault":false,"name":"Simple 46elks","type":"Elks","userId":1}`,
 		},
 	}
 

--- a/notification/notification_bark.go
+++ b/notification/notification_bark.go
@@ -30,7 +30,7 @@ func (b Bark) Type() string {
 
 // Type returns the notification type identifier for BarkDetails.
 func (BarkDetails) Type() string {
-	return "bark"
+	return "Bark"
 }
 
 // String returns a string representation of the Bark notification.

--- a/notification/notification_bark_test.go
+++ b/notification/notification_bark_test.go
@@ -20,7 +20,7 @@ func TestNotificationBark_Unmarshal(t *testing.T) {
 		{
 			name: "success with all fields",
 			data: []byte(
-				`{"id":1,"name":"My Bark Alert","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"My Bark Alert\",\"barkEndpoint\":\"https://bark.example.com\",\"barkGroup\":\"Monitoring\",\"barkSound\":\"alarm\",\"apiVersion\":\"v1\",\"type\":\"bark\"}"}`,
+				`{"id":1,"name":"My Bark Alert","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"My Bark Alert\",\"barkEndpoint\":\"https://bark.example.com\",\"barkGroup\":\"Monitoring\",\"barkSound\":\"alarm\",\"apiVersion\":\"v1\",\"type\":\"Bark\"}"}`,
 			),
 
 			want: notification.Bark{
@@ -39,12 +39,12 @@ func TestNotificationBark_Unmarshal(t *testing.T) {
 					APIVersion: "v1",
 				},
 			},
-			wantJSON: `{"active":true,"apiVersion":"v1","applyExisting":true,"barkEndpoint":"https://bark.example.com","barkGroup":"Monitoring","barkSound":"alarm","id":1,"isDefault":true,"name":"My Bark Alert","type":"bark","userId":1}`,
+			wantJSON: `{"active":true,"apiVersion":"v1","applyExisting":true,"barkEndpoint":"https://bark.example.com","barkGroup":"Monitoring","barkSound":"alarm","id":1,"isDefault":true,"name":"My Bark Alert","type":"Bark","userId":1}`,
 		},
 		{
 			name: "minimal configuration",
 			data: []byte(
-				`{"id":2,"name":"Simple Bark","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Simple Bark\",\"barkEndpoint\":\"https://bark.example.com\",\"type\":\"bark\"}"}`,
+				`{"id":2,"name":"Simple Bark","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Simple Bark\",\"barkEndpoint\":\"https://bark.example.com\",\"type\":\"Bark\"}"}`,
 			),
 
 			want: notification.Bark{
@@ -60,12 +60,12 @@ func TestNotificationBark_Unmarshal(t *testing.T) {
 					Endpoint: "https://bark.example.com",
 				},
 			},
-			wantJSON: `{"active":true,"apiVersion":"","applyExisting":false,"barkEndpoint":"https://bark.example.com","barkGroup":"","barkSound":"","id":2,"isDefault":false,"name":"Simple Bark","type":"bark","userId":1}`,
+			wantJSON: `{"active":true,"apiVersion":"","applyExisting":false,"barkEndpoint":"https://bark.example.com","barkGroup":"","barkSound":"","id":2,"isDefault":false,"name":"Simple Bark","type":"Bark","userId":1}`,
 		},
 		{
 			name: "with v2 API version",
 			data: []byte(
-				`{"id":3,"name":"Bark v2","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Bark v2\",\"barkEndpoint\":\"https://bark.example.com\",\"barkGroup\":\"UptimeKuma\",\"barkSound\":\"telegraph\",\"apiVersion\":\"v2\",\"type\":\"bark\"}"}`,
+				`{"id":3,"name":"Bark v2","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Bark v2\",\"barkEndpoint\":\"https://bark.example.com\",\"barkGroup\":\"UptimeKuma\",\"barkSound\":\"telegraph\",\"apiVersion\":\"v2\",\"type\":\"Bark\"}"}`,
 			),
 
 			want: notification.Bark{
@@ -84,7 +84,7 @@ func TestNotificationBark_Unmarshal(t *testing.T) {
 					APIVersion: "v2",
 				},
 			},
-			wantJSON: `{"active":true,"apiVersion":"v2","applyExisting":false,"barkEndpoint":"https://bark.example.com","barkGroup":"UptimeKuma","barkSound":"telegraph","id":3,"isDefault":false,"name":"Bark v2","type":"bark","userId":1}`,
+			wantJSON: `{"active":true,"apiVersion":"v2","applyExisting":false,"barkEndpoint":"https://bark.example.com","barkGroup":"UptimeKuma","barkSound":"telegraph","id":3,"isDefault":false,"name":"Bark v2","type":"Bark","userId":1}`,
 		},
 	}
 

--- a/notification/notification_brevo.go
+++ b/notification/notification_brevo.go
@@ -36,7 +36,7 @@ func (b Brevo) Type() string {
 
 // Type returns the notification type identifier for BrevoDetails.
 func (BrevoDetails) Type() string {
-	return "brevo"
+	return "Brevo"
 }
 
 // String returns a string representation of the Brevo notification.

--- a/notification/notification_brevo_test.go
+++ b/notification/notification_brevo_test.go
@@ -20,7 +20,7 @@ func TestNotificationBrevo_Unmarshal(t *testing.T) {
 		{
 			name: "success with all fields",
 			data: []byte(
-				`{"id":1,"name":"My Brevo Alert","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"My Brevo Alert\",\"brevoApiKey\":\"test-api-key\",\"brevoToEmail\":\"recipient@example.com\",\"brevoFromEmail\":\"sender@example.com\",\"brevoFromName\":\"Uptime Kuma\",\"brevoSubject\":\"Alert Notification\",\"brevoCcEmail\":\"cc@example.com\",\"brevoBccEmail\":\"bcc@example.com\",\"type\":\"brevo\"}"}`,
+				`{"id":1,"name":"My Brevo Alert","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"My Brevo Alert\",\"brevoApiKey\":\"test-api-key\",\"brevoToEmail\":\"recipient@example.com\",\"brevoFromEmail\":\"sender@example.com\",\"brevoFromName\":\"Uptime Kuma\",\"brevoSubject\":\"Alert Notification\",\"brevoCcEmail\":\"cc@example.com\",\"brevoBccEmail\":\"bcc@example.com\",\"type\":\"Brevo\"}"}`,
 			),
 
 			want: notification.Brevo{
@@ -42,12 +42,12 @@ func TestNotificationBrevo_Unmarshal(t *testing.T) {
 					BCCEmail:  "bcc@example.com",
 				},
 			},
-			wantJSON: `{"active":true,"applyExisting":true,"brevoBccEmail":"bcc@example.com","brevoCcEmail":"cc@example.com","brevoApiKey":"test-api-key","brevoFromEmail":"sender@example.com","brevoFromName":"Uptime Kuma","brevoSubject":"Alert Notification","brevoToEmail":"recipient@example.com","id":1,"isDefault":true,"name":"My Brevo Alert","type":"brevo","userId":1}`,
+			wantJSON: `{"active":true,"applyExisting":true,"brevoBccEmail":"bcc@example.com","brevoCcEmail":"cc@example.com","brevoApiKey":"test-api-key","brevoFromEmail":"sender@example.com","brevoFromName":"Uptime Kuma","brevoSubject":"Alert Notification","brevoToEmail":"recipient@example.com","id":1,"isDefault":true,"name":"My Brevo Alert","type":"Brevo","userId":1}`,
 		},
 		{
 			name: "minimal configuration",
 			data: []byte(
-				`{"id":2,"name":"Simple Brevo","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Simple Brevo\",\"brevoApiKey\":\"minimal-key\",\"brevoToEmail\":\"to@example.com\",\"brevoFromEmail\":\"from@example.com\",\"type\":\"brevo\"}"}`,
+				`{"id":2,"name":"Simple Brevo","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Simple Brevo\",\"brevoApiKey\":\"minimal-key\",\"brevoToEmail\":\"to@example.com\",\"brevoFromEmail\":\"from@example.com\",\"type\":\"Brevo\"}"}`,
 			),
 
 			want: notification.Brevo{
@@ -65,12 +65,12 @@ func TestNotificationBrevo_Unmarshal(t *testing.T) {
 					FromEmail: "from@example.com",
 				},
 			},
-			wantJSON: `{"active":true,"applyExisting":false,"brevoBccEmail":"","brevoCcEmail":"","brevoApiKey":"minimal-key","brevoFromEmail":"from@example.com","brevoFromName":"","brevoSubject":"","brevoToEmail":"to@example.com","id":2,"isDefault":false,"name":"Simple Brevo","type":"brevo","userId":1}`,
+			wantJSON: `{"active":true,"applyExisting":false,"brevoBccEmail":"","brevoCcEmail":"","brevoApiKey":"minimal-key","brevoFromEmail":"from@example.com","brevoFromName":"","brevoSubject":"","brevoToEmail":"to@example.com","id":2,"isDefault":false,"name":"Simple Brevo","type":"Brevo","userId":1}`,
 		},
 		{
 			name: "with multiple CC and BCC recipients",
 			data: []byte(
-				`{"id":3,"name":"Brevo Multi CC","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Brevo Multi CC\",\"brevoApiKey\":\"api-key\",\"brevoToEmail\":\"main@example.com\",\"brevoFromEmail\":\"sender@example.com\",\"brevoFromName\":\"Alert System\",\"brevoSubject\":\"System Alert\",\"brevoCcEmail\":\"cc1@example.com, cc2@example.com\",\"brevoBccEmail\":\"bcc1@example.com, bcc2@example.com\",\"type\":\"brevo\"}"}`,
+				`{"id":3,"name":"Brevo Multi CC","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Brevo Multi CC\",\"brevoApiKey\":\"api-key\",\"brevoToEmail\":\"main@example.com\",\"brevoFromEmail\":\"sender@example.com\",\"brevoFromName\":\"Alert System\",\"brevoSubject\":\"System Alert\",\"brevoCcEmail\":\"cc1@example.com, cc2@example.com\",\"brevoBccEmail\":\"bcc1@example.com, bcc2@example.com\",\"type\":\"Brevo\"}"}`,
 			),
 
 			want: notification.Brevo{
@@ -92,7 +92,7 @@ func TestNotificationBrevo_Unmarshal(t *testing.T) {
 					BCCEmail:  "bcc1@example.com, bcc2@example.com",
 				},
 			},
-			wantJSON: `{"active":true,"applyExisting":false,"brevoBccEmail":"bcc1@example.com, bcc2@example.com","brevoCcEmail":"cc1@example.com, cc2@example.com","brevoApiKey":"api-key","brevoFromEmail":"sender@example.com","brevoFromName":"Alert System","brevoSubject":"System Alert","brevoToEmail":"main@example.com","id":3,"isDefault":false,"name":"Brevo Multi CC","type":"brevo","userId":1}`,
+			wantJSON: `{"active":true,"applyExisting":false,"brevoBccEmail":"bcc1@example.com, bcc2@example.com","brevoCcEmail":"cc1@example.com, cc2@example.com","brevoApiKey":"api-key","brevoFromEmail":"sender@example.com","brevoFromName":"Alert System","brevoSubject":"System Alert","brevoToEmail":"main@example.com","id":3,"isDefault":false,"name":"Brevo Multi CC","type":"Brevo","userId":1}`,
 		},
 	}
 

--- a/notification/notification_evolution.go
+++ b/notification/notification_evolution.go
@@ -33,6 +33,11 @@ func (e Evolution) Type() string {
 }
 
 // Type returns the notification type identifier for EvolutionDetails.
+//
+// Note: this is the provider name of Uptime Kuma
+// (server/notification-providers/evolution.js) and deliberately does not follow the
+// casing of the Go type. Do not "fix" it, the server dispatches on this exact
+// string.
 func (EvolutionDetails) Type() string {
 	return "evolution"
 }

--- a/notification/notification_evolution.go
+++ b/notification/notification_evolution.go
@@ -34,7 +34,7 @@ func (e Evolution) Type() string {
 
 // Type returns the notification type identifier for EvolutionDetails.
 func (EvolutionDetails) Type() string {
-	return "EvolutionApi"
+	return "evolution"
 }
 
 // String returns a string representation of the Evolution notification.

--- a/notification/notification_evolution_test.go
+++ b/notification/notification_evolution_test.go
@@ -21,7 +21,7 @@ func TestNotificationEvolution_Unmarshal(t *testing.T) {
 		{
 			name: "success with all fields",
 			data: []byte(
-				`{"id":1,"name":"My Evolution Alert","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"My Evolution Alert\",\"evolutionApiUrl\":\"https://evolapicloud.com\",\"evolutionInstanceName\":\"myinstance\",\"evolutionAuthToken\":\"token123\",\"evolutionRecipient\":\"5511999999999\",\"type\":\"EvolutionApi\"}"}`,
+				`{"id":1,"name":"My Evolution Alert","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"My Evolution Alert\",\"evolutionApiUrl\":\"https://evolapicloud.com\",\"evolutionInstanceName\":\"myinstance\",\"evolutionAuthToken\":\"token123\",\"evolutionRecipient\":\"5511999999999\",\"type\":\"evolution\"}"}`,
 			),
 
 			want: notification.Evolution{
@@ -40,12 +40,12 @@ func TestNotificationEvolution_Unmarshal(t *testing.T) {
 					Recipient:    "5511999999999",
 				},
 			},
-			wantJSON: `{"active":true,"applyExisting":true,"evolutionApiUrl":"https://evolapicloud.com","evolutionAuthToken":"token123","evolutionInstanceName":"myinstance","evolutionRecipient":"5511999999999","id":1,"isDefault":true,"name":"My Evolution Alert","type":"EvolutionApi","userId":1}`,
+			wantJSON: `{"active":true,"applyExisting":true,"evolutionApiUrl":"https://evolapicloud.com","evolutionAuthToken":"token123","evolutionInstanceName":"myinstance","evolutionRecipient":"5511999999999","id":1,"isDefault":true,"name":"My Evolution Alert","type":"evolution","userId":1}`,
 		},
 		{
 			name: "minimal configuration",
 			data: []byte(
-				`{"id":2,"name":"Simple Evolution","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Simple Evolution\",\"evolutionApiUrl\":\"https://api.example.com\",\"evolutionInstanceName\":\"instance1\",\"evolutionAuthToken\":\"key\",\"evolutionRecipient\":\"551187654321\",\"type\":\"EvolutionApi\"}"}`,
+				`{"id":2,"name":"Simple Evolution","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Simple Evolution\",\"evolutionApiUrl\":\"https://api.example.com\",\"evolutionInstanceName\":\"instance1\",\"evolutionAuthToken\":\"key\",\"evolutionRecipient\":\"551187654321\",\"type\":\"evolution\"}"}`,
 			),
 
 			want: notification.Evolution{
@@ -64,12 +64,12 @@ func TestNotificationEvolution_Unmarshal(t *testing.T) {
 					Recipient:    "551187654321",
 				},
 			},
-			wantJSON: `{"active":true,"applyExisting":false,"evolutionApiUrl":"https://api.example.com","evolutionAuthToken":"key","evolutionInstanceName":"instance1","evolutionRecipient":"551187654321","id":2,"isDefault":false,"name":"Simple Evolution","type":"EvolutionApi","userId":1}`,
+			wantJSON: `{"active":true,"applyExisting":false,"evolutionApiUrl":"https://api.example.com","evolutionAuthToken":"key","evolutionInstanceName":"instance1","evolutionRecipient":"551187654321","id":2,"isDefault":false,"name":"Simple Evolution","type":"evolution","userId":1}`,
 		},
 		{
 			name: "with different recipient",
 			data: []byte(
-				`{"id":3,"name":"Evolution US","active":false,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Evolution US\",\"evolutionApiUrl\":\"https://custom.api.com\",\"evolutionInstanceName\":\"usinstance\",\"evolutionAuthToken\":\"ustoken\",\"evolutionRecipient\":\"12025551234\",\"type\":\"EvolutionApi\"}"}`,
+				`{"id":3,"name":"Evolution US","active":false,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Evolution US\",\"evolutionApiUrl\":\"https://custom.api.com\",\"evolutionInstanceName\":\"usinstance\",\"evolutionAuthToken\":\"ustoken\",\"evolutionRecipient\":\"12025551234\",\"type\":\"evolution\"}"}`,
 			),
 
 			want: notification.Evolution{
@@ -88,12 +88,12 @@ func TestNotificationEvolution_Unmarshal(t *testing.T) {
 					Recipient:    "12025551234",
 				},
 			},
-			wantJSON: `{"active":false,"applyExisting":false,"evolutionApiUrl":"https://custom.api.com","evolutionAuthToken":"ustoken","evolutionInstanceName":"usinstance","evolutionRecipient":"12025551234","id":3,"isDefault":false,"name":"Evolution US","type":"EvolutionApi","userId":1}`,
+			wantJSON: `{"active":false,"applyExisting":false,"evolutionApiUrl":"https://custom.api.com","evolutionAuthToken":"ustoken","evolutionInstanceName":"usinstance","evolutionRecipient":"12025551234","id":3,"isDefault":false,"name":"Evolution US","type":"evolution","userId":1}`,
 		},
 		{
 			name: "with custom message template",
 			data: []byte(
-				`{"id":4,"name":"Evolution Template","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Evolution Template\",\"evolutionApiUrl\":\"https://evolapicloud.com\",\"evolutionInstanceName\":\"myinstance\",\"evolutionAuthToken\":\"token123\",\"evolutionRecipient\":\"5511999999999\",\"evolutionUseCustomMessage\":true,\"evolutionCustomMessage\":\"Alert: {{ msg }}\",\"type\":\"EvolutionApi\"}"}`,
+				`{"id":4,"name":"Evolution Template","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Evolution Template\",\"evolutionApiUrl\":\"https://evolapicloud.com\",\"evolutionInstanceName\":\"myinstance\",\"evolutionAuthToken\":\"token123\",\"evolutionRecipient\":\"5511999999999\",\"evolutionUseCustomMessage\":true,\"evolutionCustomMessage\":\"Alert: {{ msg }}\",\"type\":\"evolution\"}"}`,
 			),
 
 			want: notification.Evolution{
@@ -114,12 +114,12 @@ func TestNotificationEvolution_Unmarshal(t *testing.T) {
 					CustomMessage:    ptr.To("Alert: {{ msg }}"),
 				},
 			},
-			wantJSON: `{"active":true,"applyExisting":false,"evolutionApiUrl":"https://evolapicloud.com","evolutionAuthToken":"token123","evolutionCustomMessage":"Alert: {{ msg }}","evolutionInstanceName":"myinstance","evolutionRecipient":"5511999999999","evolutionUseCustomMessage":true,"id":4,"isDefault":false,"name":"Evolution Template","type":"EvolutionApi","userId":1}`,
+			wantJSON: `{"active":true,"applyExisting":false,"evolutionApiUrl":"https://evolapicloud.com","evolutionAuthToken":"token123","evolutionCustomMessage":"Alert: {{ msg }}","evolutionInstanceName":"myinstance","evolutionRecipient":"5511999999999","evolutionUseCustomMessage":true,"id":4,"isDefault":false,"name":"Evolution Template","type":"evolution","userId":1}`,
 		},
 		{
 			name: "pointer to false and empty string are serialized",
 			data: []byte(
-				`{"id":5,"name":"Evolution Explicit False","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Evolution Explicit False\",\"evolutionApiUrl\":\"https://evolapicloud.com\",\"evolutionInstanceName\":\"myinstance\",\"evolutionAuthToken\":\"token123\",\"evolutionRecipient\":\"5511999999999\",\"evolutionUseCustomMessage\":false,\"evolutionCustomMessage\":\"\",\"type\":\"EvolutionApi\"}"}`,
+				`{"id":5,"name":"Evolution Explicit False","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Evolution Explicit False\",\"evolutionApiUrl\":\"https://evolapicloud.com\",\"evolutionInstanceName\":\"myinstance\",\"evolutionAuthToken\":\"token123\",\"evolutionRecipient\":\"5511999999999\",\"evolutionUseCustomMessage\":false,\"evolutionCustomMessage\":\"\",\"type\":\"evolution\"}"}`,
 			),
 
 			want: notification.Evolution{
@@ -140,7 +140,7 @@ func TestNotificationEvolution_Unmarshal(t *testing.T) {
 					CustomMessage:    ptr.To(""),
 				},
 			},
-			wantJSON: `{"active":true,"applyExisting":false,"evolutionApiUrl":"https://evolapicloud.com","evolutionAuthToken":"token123","evolutionCustomMessage":"","evolutionInstanceName":"myinstance","evolutionRecipient":"5511999999999","evolutionUseCustomMessage":false,"id":5,"isDefault":false,"name":"Evolution Explicit False","type":"EvolutionApi","userId":1}`,
+			wantJSON: `{"active":true,"applyExisting":false,"evolutionApiUrl":"https://evolapicloud.com","evolutionAuthToken":"token123","evolutionCustomMessage":"","evolutionInstanceName":"myinstance","evolutionRecipient":"5511999999999","evolutionUseCustomMessage":false,"id":5,"isDefault":false,"name":"Evolution Explicit False","type":"evolution","userId":1}`,
 		},
 	}
 

--- a/notification/notification_legacy_type_test.go
+++ b/notification/notification_legacy_type_test.go
@@ -1,0 +1,42 @@
+package notification_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/breml/go-uptime-kuma-client/notification"
+)
+
+// TestLegacyTypeIsRewrittenOnMarshal pins the migration behavior for a
+// notification stored with a notification type this package reported before it
+// was aligned with the upstream provider names.
+//
+// The stored type is preserved as read from the server and is reported by
+// notification.Base. Marshaling always emits the type of the details struct, so
+// writing such a notification back repairs the stored type.
+func TestLegacyTypeIsRewrittenOnMarshal(t *testing.T) {
+	legacy := []byte(
+		`{"id":1,"name":"My 46elks Alert","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"My 46elks Alert\",\"elksUsername\":\"username@example.com\",\"elksAuthToken\":\"auth_token_secret\",\"elksFromNumber\":\"1234\",\"elksToNumber\":\"0701234567\",\"type\":\"46elks\"}"}`,
+	)
+
+	elks := notification.FortySixElks{}
+
+	err := json.Unmarshal(legacy, &elks)
+	require.NoError(t, err)
+
+	require.Equal(t, "46elks", elks.Base.Type(),
+		"the stored notification type is preserved until the notification is written back")
+	require.Equal(t, "Elks", elks.Type(),
+		"the notification itself reports the upstream provider name")
+
+	data, err := json.Marshal(elks)
+	require.NoError(t, err)
+
+	require.JSONEq(
+		t,
+		`{"active":true,"applyExisting":true,"elksAuthToken":"auth_token_secret","elksFromNumber":"1234","elksToNumber":"0701234567","elksUsername":"username@example.com","id":1,"isDefault":true,"name":"My 46elks Alert","type":"Elks","userId":1}`,
+		string(data),
+	)
+}

--- a/notification/notification_nextcloudtalk.go
+++ b/notification/notification_nextcloudtalk.go
@@ -32,7 +32,7 @@ func (n NextcloudTalk) Type() string {
 
 // Type returns the notification type identifier for NextcloudTalkDetails.
 func (NextcloudTalkDetails) Type() string {
-	return "NextcloudTalk"
+	return "nextcloudtalk"
 }
 
 // String returns a string representation of the NextcloudTalk notification.

--- a/notification/notification_nextcloudtalk.go
+++ b/notification/notification_nextcloudtalk.go
@@ -31,6 +31,11 @@ func (n NextcloudTalk) Type() string {
 }
 
 // Type returns the notification type identifier for NextcloudTalkDetails.
+//
+// Note: this is the provider name of Uptime Kuma
+// (server/notification-providers/nextcloudtalk.js) and deliberately does not follow the
+// casing of the Go type. Do not "fix" it, the server dispatches on this exact
+// string.
 func (NextcloudTalkDetails) Type() string {
 	return "nextcloudtalk"
 }

--- a/notification/notification_nextcloudtalk_test.go
+++ b/notification/notification_nextcloudtalk_test.go
@@ -19,7 +19,7 @@ func TestNotificationNextcloudTalk_Unmarshal(t *testing.T) {
 		{
 			name: "success with all fields",
 			data: []byte(
-				`{"id":1,"name":"My Nextcloud Talk Alert","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"My Nextcloud Talk Alert\",\"host\":\"https://nextcloud.example.com\",\"conversationToken\":\"token123\",\"botSecret\":\"secret-key-123\",\"sendSilentUp\":true,\"sendSilentDown\":false,\"type\":\"NextcloudTalk\"}"}`,
+				`{"id":1,"name":"My Nextcloud Talk Alert","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"My Nextcloud Talk Alert\",\"host\":\"https://nextcloud.example.com\",\"conversationToken\":\"token123\",\"botSecret\":\"secret-key-123\",\"sendSilentUp\":true,\"sendSilentDown\":false,\"type\":\"nextcloudtalk\"}"}`,
 			),
 
 			want: notification.NextcloudTalk{
@@ -39,12 +39,12 @@ func TestNotificationNextcloudTalk_Unmarshal(t *testing.T) {
 					SendSilentDown:    false,
 				},
 			},
-			wantJSON: `{"active":true,"applyExisting":true,"botSecret":"secret-key-123","conversationToken":"token123","host":"https://nextcloud.example.com","id":1,"isDefault":true,"name":"My Nextcloud Talk Alert","sendSilentDown":false,"sendSilentUp":true,"type":"NextcloudTalk","userId":1}`,
+			wantJSON: `{"active":true,"applyExisting":true,"botSecret":"secret-key-123","conversationToken":"token123","host":"https://nextcloud.example.com","id":1,"isDefault":true,"name":"My Nextcloud Talk Alert","sendSilentDown":false,"sendSilentUp":true,"type":"nextcloudtalk","userId":1}`,
 		},
 		{
 			name: "minimal configuration",
 			data: []byte(
-				`{"id":2,"name":"Simple Nextcloud Talk","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Simple Nextcloud Talk\",\"host\":\"https://nc.example.com\",\"conversationToken\":\"abc123\",\"botSecret\":\"secret-abc\",\"sendSilentUp\":false,\"sendSilentDown\":false,\"type\":\"NextcloudTalk\"}"}`,
+				`{"id":2,"name":"Simple Nextcloud Talk","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Simple Nextcloud Talk\",\"host\":\"https://nc.example.com\",\"conversationToken\":\"abc123\",\"botSecret\":\"secret-abc\",\"sendSilentUp\":false,\"sendSilentDown\":false,\"type\":\"nextcloudtalk\"}"}`,
 			),
 
 			want: notification.NextcloudTalk{
@@ -64,12 +64,12 @@ func TestNotificationNextcloudTalk_Unmarshal(t *testing.T) {
 					SendSilentDown:    false,
 				},
 			},
-			wantJSON: `{"active":true,"applyExisting":false,"botSecret":"secret-abc","conversationToken":"abc123","host":"https://nc.example.com","id":2,"isDefault":false,"name":"Simple Nextcloud Talk","sendSilentDown":false,"sendSilentUp":false,"type":"NextcloudTalk","userId":1}`,
+			wantJSON: `{"active":true,"applyExisting":false,"botSecret":"secret-abc","conversationToken":"abc123","host":"https://nc.example.com","id":2,"isDefault":false,"name":"Simple Nextcloud Talk","sendSilentDown":false,"sendSilentUp":false,"type":"nextcloudtalk","userId":1}`,
 		},
 		{
 			name: "with silent down enabled",
 			data: []byte(
-				`{"id":3,"name":"Nextcloud Talk Silent","active":false,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Nextcloud Talk Silent\",\"host\":\"https://cloud.example.com\",\"conversationToken\":\"xyz789\",\"botSecret\":\"prod-secret\",\"sendSilentUp\":false,\"sendSilentDown\":true,\"type\":\"NextcloudTalk\"}"}`,
+				`{"id":3,"name":"Nextcloud Talk Silent","active":false,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Nextcloud Talk Silent\",\"host\":\"https://cloud.example.com\",\"conversationToken\":\"xyz789\",\"botSecret\":\"prod-secret\",\"sendSilentUp\":false,\"sendSilentDown\":true,\"type\":\"nextcloudtalk\"}"}`,
 			),
 
 			want: notification.NextcloudTalk{
@@ -89,7 +89,7 @@ func TestNotificationNextcloudTalk_Unmarshal(t *testing.T) {
 					SendSilentDown:    true,
 				},
 			},
-			wantJSON: `{"active":false,"applyExisting":false,"botSecret":"prod-secret","conversationToken":"xyz789","host":"https://cloud.example.com","id":3,"isDefault":false,"name":"Nextcloud Talk Silent","sendSilentDown":true,"sendSilentUp":false,"type":"NextcloudTalk","userId":1}`,
+			wantJSON: `{"active":false,"applyExisting":false,"botSecret":"prod-secret","conversationToken":"xyz789","host":"https://cloud.example.com","id":3,"isDefault":false,"name":"Nextcloud Talk Silent","sendSilentDown":true,"sendSilentUp":false,"type":"nextcloudtalk","userId":1}`,
 		},
 	}
 

--- a/notification/notification_onesender.go
+++ b/notification/notification_onesender.go
@@ -30,7 +30,7 @@ func (o OneSender) Type() string {
 
 // Type returns the notification type identifier for OneSenderDetails.
 func (OneSenderDetails) Type() string {
-	return "onesender"
+	return "Onesender"
 }
 
 // String returns a string representation of the OneSender notification.

--- a/notification/notification_onesender.go
+++ b/notification/notification_onesender.go
@@ -29,6 +29,11 @@ func (o OneSender) Type() string {
 }
 
 // Type returns the notification type identifier for OneSenderDetails.
+//
+// Note: this is the provider name of Uptime Kuma
+// (server/notification-providers/onesender.js) and deliberately does not follow the
+// casing of the Go type. Do not "fix" it, the server dispatches on this exact
+// string.
 func (OneSenderDetails) Type() string {
 	return "Onesender"
 }

--- a/notification/notification_onesender_test.go
+++ b/notification/notification_onesender_test.go
@@ -20,7 +20,7 @@ func TestNotificationOneSender_Unmarshal(t *testing.T) {
 		{
 			name: "success private",
 			data: []byte(
-				`{"id":1,"name":"Test OneSender Private","active":true,"userId":42,"isDefault":false,"config":"{\"type\":\"onesender\",\"onesenderURL\":\"https://api.onesender.com/send\",\"onesenderToken\":\"test-token\",\"onesenderReceiver\":\"5511999999999\",\"onesenderTypeReceiver\":\"private\"}"}`,
+				`{"id":1,"name":"Test OneSender Private","active":true,"userId":42,"isDefault":false,"config":"{\"type\":\"Onesender\",\"onesenderURL\":\"https://api.onesender.com/send\",\"onesenderToken\":\"test-token\",\"onesenderReceiver\":\"5511999999999\",\"onesenderTypeReceiver\":\"private\"}"}`,
 			),
 
 			want: notification.OneSender{
@@ -38,12 +38,12 @@ func TestNotificationOneSender_Unmarshal(t *testing.T) {
 					TypeReceiver: "private",
 				},
 			},
-			wantJSON: `{"active":true,"applyExisting":false,"id":1,"isDefault":false,"name":"Test OneSender Private","onesenderReceiver":"5511999999999","onesenderToken":"test-token","onesenderTypeReceiver":"private","onesenderURL":"https://api.onesender.com/send","type":"onesender","userId":42}`,
+			wantJSON: `{"active":true,"applyExisting":false,"id":1,"isDefault":false,"name":"Test OneSender Private","onesenderReceiver":"5511999999999","onesenderToken":"test-token","onesenderTypeReceiver":"private","onesenderURL":"https://api.onesender.com/send","type":"Onesender","userId":42}`,
 		},
 		{
 			name: "success group",
 			data: []byte(
-				`{"id":2,"name":"Test OneSender Group","active":true,"userId":42,"isDefault":true,"config":"{\"type\":\"onesender\",\"onesenderURL\":\"https://api.onesender.com/send\",\"onesenderToken\":\"secret-token\",\"onesenderReceiver\":\"120363123456789-1234567890\",\"onesenderTypeReceiver\":\"group\"}"}`,
+				`{"id":2,"name":"Test OneSender Group","active":true,"userId":42,"isDefault":true,"config":"{\"type\":\"Onesender\",\"onesenderURL\":\"https://api.onesender.com/send\",\"onesenderToken\":\"secret-token\",\"onesenderReceiver\":\"120363123456789-1234567890\",\"onesenderTypeReceiver\":\"group\"}"}`,
 			),
 
 			want: notification.OneSender{
@@ -62,12 +62,12 @@ func TestNotificationOneSender_Unmarshal(t *testing.T) {
 					TypeReceiver: "group",
 				},
 			},
-			wantJSON: `{"active":true,"applyExisting":false,"id":2,"isDefault":true,"name":"Test OneSender Group","onesenderReceiver":"120363123456789-1234567890","onesenderToken":"secret-token","onesenderTypeReceiver":"group","onesenderURL":"https://api.onesender.com/send","type":"onesender","userId":42}`,
+			wantJSON: `{"active":true,"applyExisting":false,"id":2,"isDefault":true,"name":"Test OneSender Group","onesenderReceiver":"120363123456789-1234567890","onesenderToken":"secret-token","onesenderTypeReceiver":"group","onesenderURL":"https://api.onesender.com/send","type":"Onesender","userId":42}`,
 		},
 		{
 			name: "minimal",
 			data: []byte(
-				`{"id":3,"name":"Test OneSender Minimal","active":false,"userId":10,"isDefault":false,"config":"{\"type\":\"onesender\",\"onesenderURL\":\"\",\"onesenderToken\":\"\",\"onesenderReceiver\":\"\",\"onesenderTypeReceiver\":\"\"}"}`,
+				`{"id":3,"name":"Test OneSender Minimal","active":false,"userId":10,"isDefault":false,"config":"{\"type\":\"Onesender\",\"onesenderURL\":\"\",\"onesenderToken\":\"\",\"onesenderReceiver\":\"\",\"onesenderTypeReceiver\":\"\"}"}`,
 			),
 
 			want: notification.OneSender{
@@ -86,7 +86,7 @@ func TestNotificationOneSender_Unmarshal(t *testing.T) {
 					TypeReceiver: "",
 				},
 			},
-			wantJSON: `{"active":false,"applyExisting":false,"id":3,"isDefault":false,"name":"Test OneSender Minimal","onesenderReceiver":"","onesenderToken":"","onesenderTypeReceiver":"","onesenderURL":"","type":"onesender","userId":10}`,
+			wantJSON: `{"active":false,"applyExisting":false,"id":3,"isDefault":false,"name":"Test OneSender Minimal","onesenderReceiver":"","onesenderToken":"","onesenderTypeReceiver":"","onesenderURL":"","type":"Onesender","userId":10}`,
 		},
 	}
 

--- a/notification/notification_pumble.go
+++ b/notification/notification_pumble.go
@@ -22,6 +22,11 @@ func (p Pumble) Type() string {
 }
 
 // Type returns the notification type identifier for Pumble details.
+//
+// Note: this is the provider name of Uptime Kuma
+// (server/notification-providers/pumble.js) and deliberately does not follow the
+// casing of the Go type. Do not "fix" it, the server dispatches on this exact
+// string.
 func (PumbleDetails) Type() string {
 	return "pumble"
 }

--- a/notification/notification_pumble.go
+++ b/notification/notification_pumble.go
@@ -23,7 +23,7 @@ func (p Pumble) Type() string {
 
 // Type returns the notification type identifier for Pumble details.
 func (PumbleDetails) Type() string {
-	return "Pumble"
+	return "pumble"
 }
 
 // String returns a human-readable representation of the Pumble notification.

--- a/notification/notification_pumble_test.go
+++ b/notification/notification_pumble_test.go
@@ -20,7 +20,7 @@ func TestNotificationPumble_Unmarshal(t *testing.T) {
 		{
 			name: "success",
 			data: []byte(
-				`{"id":1,"name":"My Pumble Alert","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"My Pumble Alert\",\"webhookURL\":\"https://pumble.com/webhook/xxx\",\"type\":\"Pumble\"}"}`,
+				`{"id":1,"name":"My Pumble Alert","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"My Pumble Alert\",\"webhookURL\":\"https://pumble.com/webhook/xxx\",\"type\":\"pumble\"}"}`,
 			),
 
 			want: notification.Pumble{
@@ -36,12 +36,12 @@ func TestNotificationPumble_Unmarshal(t *testing.T) {
 					WebhookURL: "https://pumble.com/webhook/xxx",
 				},
 			},
-			wantJSON: `{"active":true,"applyExisting":true,"id":1,"isDefault":true,"name":"My Pumble Alert","type":"Pumble","userId":1,"webhookURL":"https://pumble.com/webhook/xxx"}`,
+			wantJSON: `{"active":true,"applyExisting":true,"id":1,"isDefault":true,"name":"My Pumble Alert","type":"pumble","userId":1,"webhookURL":"https://pumble.com/webhook/xxx"}`,
 		},
 		{
 			name: "minimal",
 			data: []byte(
-				`{"id":2,"name":"Simple Pumble","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Simple Pumble\",\"webhookURL\":\"https://pumble.com/webhook/yyy\",\"type\":\"Pumble\"}"}`,
+				`{"id":2,"name":"Simple Pumble","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Simple Pumble\",\"webhookURL\":\"https://pumble.com/webhook/yyy\",\"type\":\"pumble\"}"}`,
 			),
 
 			want: notification.Pumble{
@@ -57,7 +57,7 @@ func TestNotificationPumble_Unmarshal(t *testing.T) {
 					WebhookURL: "https://pumble.com/webhook/yyy",
 				},
 			},
-			wantJSON: `{"active":true,"applyExisting":false,"id":2,"isDefault":false,"name":"Simple Pumble","type":"Pumble","userId":1,"webhookURL":"https://pumble.com/webhook/yyy"}`,
+			wantJSON: `{"active":true,"applyExisting":false,"id":2,"isDefault":false,"name":"Simple Pumble","type":"pumble","userId":1,"webhookURL":"https://pumble.com/webhook/yyy"}`,
 		},
 	}
 

--- a/notification/notification_sevenio.go
+++ b/notification/notification_sevenio.go
@@ -28,7 +28,7 @@ func (s SevenIO) Type() string {
 
 // Type returns the notification type identifier for SevenIODetails.
 func (SevenIODetails) Type() string {
-	return "sevenio"
+	return "SevenIO"
 }
 
 // String returns a string representation of the SevenIO notification.

--- a/notification/notification_sevenio_test.go
+++ b/notification/notification_sevenio_test.go
@@ -20,7 +20,7 @@ func TestNotificationSevenIO_Unmarshal(t *testing.T) {
 		{
 			name: "success with all fields",
 			data: []byte(
-				`{"id":1,"name":"My Seven.io Alert","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"My Seven.io Alert\",\"sevenioApiKey\":\"test-api-key\",\"sevenioSender\":\"UptimeKuma\",\"sevenioTo\":\"49123456789\",\"type\":\"sevenio\"}"}`,
+				`{"id":1,"name":"My Seven.io Alert","active":true,"userId":1,"isDefault":true,"config":"{\"applyExisting\":true,\"isDefault\":true,\"name\":\"My Seven.io Alert\",\"sevenioApiKey\":\"test-api-key\",\"sevenioSender\":\"UptimeKuma\",\"sevenioTo\":\"49123456789\",\"type\":\"SevenIO\"}"}`,
 			),
 
 			want: notification.SevenIO{
@@ -38,12 +38,12 @@ func TestNotificationSevenIO_Unmarshal(t *testing.T) {
 					To:     "49123456789",
 				},
 			},
-			wantJSON: `{"active":true,"applyExisting":true,"id":1,"isDefault":true,"name":"My Seven.io Alert","sevenioApiKey":"test-api-key","sevenioSender":"UptimeKuma","sevenioTo":"49123456789","type":"sevenio","userId":1}`,
+			wantJSON: `{"active":true,"applyExisting":true,"id":1,"isDefault":true,"name":"My Seven.io Alert","sevenioApiKey":"test-api-key","sevenioSender":"UptimeKuma","sevenioTo":"49123456789","type":"SevenIO","userId":1}`,
 		},
 		{
 			name: "minimal configuration",
 			data: []byte(
-				`{"id":2,"name":"Simple Seven.io","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Simple Seven.io\",\"sevenioApiKey\":\"minimal-key\",\"sevenioSender\":\"\",\"sevenioTo\":\"49999999999\",\"type\":\"sevenio\"}"}`,
+				`{"id":2,"name":"Simple Seven.io","active":true,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Simple Seven.io\",\"sevenioApiKey\":\"minimal-key\",\"sevenioSender\":\"\",\"sevenioTo\":\"49999999999\",\"type\":\"SevenIO\"}"}`,
 			),
 
 			want: notification.SevenIO{
@@ -61,12 +61,12 @@ func TestNotificationSevenIO_Unmarshal(t *testing.T) {
 					To:     "49999999999",
 				},
 			},
-			wantJSON: `{"active":true,"applyExisting":false,"id":2,"isDefault":false,"name":"Simple Seven.io","sevenioApiKey":"minimal-key","sevenioSender":"","sevenioTo":"49999999999","type":"sevenio","userId":1}`,
+			wantJSON: `{"active":true,"applyExisting":false,"id":2,"isDefault":false,"name":"Simple Seven.io","sevenioApiKey":"minimal-key","sevenioSender":"","sevenioTo":"49999999999","type":"SevenIO","userId":1}`,
 		},
 		{
 			name: "with custom sender",
 			data: []byte(
-				`{"id":3,"name":"Seven.io Custom","active":false,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Seven.io Custom\",\"sevenioApiKey\":\"custom-key\",\"sevenioSender\":\"CustomAlert\",\"sevenioTo\":\"358501234567\",\"type\":\"sevenio\"}"}`,
+				`{"id":3,"name":"Seven.io Custom","active":false,"userId":1,"isDefault":false,"config":"{\"applyExisting\":false,\"isDefault\":false,\"name\":\"Seven.io Custom\",\"sevenioApiKey\":\"custom-key\",\"sevenioSender\":\"CustomAlert\",\"sevenioTo\":\"358501234567\",\"type\":\"SevenIO\"}"}`,
 			),
 
 			want: notification.SevenIO{
@@ -84,7 +84,7 @@ func TestNotificationSevenIO_Unmarshal(t *testing.T) {
 					To:     "358501234567",
 				},
 			},
-			wantJSON: `{"active":false,"applyExisting":false,"id":3,"isDefault":false,"name":"Seven.io Custom","sevenioApiKey":"custom-key","sevenioSender":"CustomAlert","sevenioTo":"358501234567","type":"sevenio","userId":1}`,
+			wantJSON: `{"active":false,"applyExisting":false,"id":3,"isDefault":false,"name":"Seven.io Custom","sevenioApiKey":"custom-key","sevenioSender":"CustomAlert","sevenioTo":"358501234567","type":"SevenIO","userId":1}`,
 		},
 	}
 

--- a/notification/notification_type_test.go
+++ b/notification/notification_type_test.go
@@ -4,6 +4,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"maps"
 	"path/filepath"
 	"slices"
 	"strconv"
@@ -13,15 +14,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestTypeMatchesUpstreamProviderName ensures that every Type() implementation
-// of this package, which returns a constant string, reports a notification type
-// known to Uptime Kuma.
+// TestTypeMatchesUpstreamProviderName ensures that the notification types
+// reported by this package are exactly the provider names known to Uptime Kuma.
 //
 // Uptime Kuma builds its provider registry from the `name` class field of the
 // notification providers (server/notification-providers/*.js) and dispatches on
-// the stored notification type. A type not present in this registry results in
-// a notification, which can not be sent.
+// the stored notification type (server/notification.js, Notification.send). A
+// type absent from this registry is still accepted on create, so the mismatch
+// only surfaces when a notification is sent, which fails with "Notification
+// type is not supported".
+//
+// Only a Type() implemented as a single return of a string literal is
+// collected. Wrapper types delegating to their details counterpart are covered
+// transitively, Base and Generic report a type read from the notification
+// itself and have none to check.
 func TestTypeMatchesUpstreamProviderName(t *testing.T) {
+	// Provider names of Uptime Kuma 2.5.0, the `name` field of every class in
+	// server/notification-providers/*.js. Regenerate after an upstream bump by
+	// running the following in a checkout of Uptime Kuma:
+	//
+	//	grep -hoP '^\s*name = "\K[^"]+' server/notification-providers/*.js | sort -f
 	upstreamProviderNames := []string{
 		"alerta",
 		"AlertNow",
@@ -148,23 +160,31 @@ func TestTypeMatchesUpstreamProviderName(t *testing.T) {
 				continue
 			}
 
-			types[receiverTypeName(funcDecl)] = value
+			receiver := receiverTypeName(funcDecl)
+			require.NotEmpty(t, receiver, "Type() in %s has an unsupported receiver", name)
+
+			types[receiver] = value
 		}
 	}
 
-	require.NotEmpty(t, types)
-
 	for receiver, notificationType := range types {
 		t.Run(receiver, func(t *testing.T) {
-			require.True(t, slices.Contains(upstreamProviderNames, notificationType),
+			require.Contains(t, upstreamProviderNames, notificationType,
 				"Type() returns %q, which is not a provider name known to Uptime Kuma", notificationType)
 		})
 	}
+
+	// Assert the two sets are equal, not just that every collected type is
+	// known upstream. This catches a provider whose Type() is no longer a
+	// string literal and therefore silently escapes collection, two providers
+	// reporting the same type, and a provider added upstream but not
+	// implemented here.
+	require.ElementsMatch(t, upstreamProviderNames, slices.Collect(maps.Values(types)),
+		"the notification types of this package do not match the upstream provider names one to one")
 }
 
-// constantReturnValue returns the constant string returned by the given
-// function, if its body consists of a single return statement returning a
-// string literal.
+// constantReturnValue returns the string returned by the given function, if its
+// body consists of a single return statement returning a string literal.
 func constantReturnValue(funcDecl *ast.FuncDecl) (string, bool) {
 	if funcDecl.Body == nil || len(funcDecl.Body.List) != 1 {
 		return "", false
@@ -188,7 +208,9 @@ func constantReturnValue(funcDecl *ast.FuncDecl) (string, bool) {
 	return value, true
 }
 
-// receiverTypeName returns the name of the receiver type of the given method.
+// receiverTypeName returns the name of the receiver type of the given method,
+// dereferencing a pointer receiver. It returns an empty string, if the receiver
+// is not a plain identifier, for example a generic type.
 func receiverTypeName(funcDecl *ast.FuncDecl) string {
 	expr := funcDecl.Recv.List[0].Type
 

--- a/notification/notification_type_test.go
+++ b/notification/notification_type_test.go
@@ -1,0 +1,206 @@
+package notification_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestTypeMatchesUpstreamProviderName ensures that every Type() implementation
+// of this package, which returns a constant string, reports a notification type
+// known to Uptime Kuma.
+//
+// Uptime Kuma builds its provider registry from the `name` class field of the
+// notification providers (server/notification-providers/*.js) and dispatches on
+// the stored notification type. A type not present in this registry results in
+// a notification, which can not be sent.
+func TestTypeMatchesUpstreamProviderName(t *testing.T) {
+	upstreamProviderNames := []string{
+		"alerta",
+		"AlertNow",
+		"AliyunSMS",
+		"apprise",
+		"bale",
+		"Bark",
+		"Bitrix24",
+		"Brevo",
+		"CallMeBot",
+		"Cellsynt",
+		"clicksendsms",
+		"DingDing",
+		"discord",
+		"egosms",
+		"Elks",
+		"evolution",
+		"Feishu",
+		"FlashDuty",
+		"Flowtriq",
+		"fluxer",
+		"FreeMobile",
+		"GoAlert",
+		"GoogleChat",
+		"GoogleSheets",
+		"gorush",
+		"gotify",
+		"GrafanaOncall",
+		"gtxmessaging",
+		"HaloPSA",
+		"HeiiOnCall",
+		"HomeAssistant",
+		"JiraServiceManagement",
+		"Keep",
+		"Kook",
+		"line",
+		"lunasea",
+		"matrix",
+		"mattermost",
+		"max",
+		"nextcloudtalk",
+		"nostr",
+		"notifery",
+		"ntfy",
+		"octopush",
+		"OneBot",
+		"OneChat",
+		"Onesender",
+		"Ooredoo",
+		"Opsgenie",
+		"PagerDuty",
+		"PagerTree",
+		"plivo",
+		"promosms",
+		"pumble",
+		"pushbullet",
+		"PushByTechulus",
+		"PushDeer",
+		"pushover",
+		"PushPlus",
+		"pushy",
+		"Resend",
+		"rocket.chat",
+		"SendGrid",
+		"ServerChan",
+		"serwersms",
+		"SevenIO",
+		"signal",
+		"SIGNL4",
+		"slack",
+		"smsc",
+		"SMSEagle",
+		"smsir",
+		"SMSManager",
+		"SMSPartner",
+		"SMSPlanet",
+		"smtp",
+		"Splunk",
+		"SpugPush",
+		"squadcast",
+		"stackfield",
+		"teams",
+		"telegram",
+		"telnyx",
+		"Teltonika",
+		"threema",
+		"twilio",
+		"VK",
+		"VKTeams",
+		"waha",
+		"webhook",
+		"Webpush",
+		"WeCom",
+		"whapi",
+		"Whatsapp360messenger",
+		"WPush",
+		"WxPusher",
+		"YZJ",
+		"ZohoCliq",
+	}
+
+	files, err := filepath.Glob("*.go")
+	require.NoError(t, err)
+
+	fset := token.NewFileSet()
+	types := map[string]string{}
+
+	for _, name := range files {
+		if strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+
+		file, err := parser.ParseFile(fset, name, nil, 0)
+		require.NoError(t, err)
+
+		for _, decl := range file.Decls {
+			funcDecl, isFunc := decl.(*ast.FuncDecl)
+			if !isFunc || funcDecl.Recv == nil || funcDecl.Name.Name != "Type" {
+				continue
+			}
+
+			value, isConstant := constantReturnValue(funcDecl)
+			if !isConstant {
+				continue
+			}
+
+			types[receiverTypeName(funcDecl)] = value
+		}
+	}
+
+	require.NotEmpty(t, types)
+
+	for receiver, notificationType := range types {
+		t.Run(receiver, func(t *testing.T) {
+			require.True(t, slices.Contains(upstreamProviderNames, notificationType),
+				"Type() returns %q, which is not a provider name known to Uptime Kuma", notificationType)
+		})
+	}
+}
+
+// constantReturnValue returns the constant string returned by the given
+// function, if its body consists of a single return statement returning a
+// string literal.
+func constantReturnValue(funcDecl *ast.FuncDecl) (string, bool) {
+	if funcDecl.Body == nil || len(funcDecl.Body.List) != 1 {
+		return "", false
+	}
+
+	returnStmt, ok := funcDecl.Body.List[0].(*ast.ReturnStmt)
+	if !ok || len(returnStmt.Results) != 1 {
+		return "", false
+	}
+
+	lit, ok := returnStmt.Results[0].(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return "", false
+	}
+
+	value, err := strconv.Unquote(lit.Value)
+	if err != nil {
+		return "", false
+	}
+
+	return value, true
+}
+
+// receiverTypeName returns the name of the receiver type of the given method.
+func receiverTypeName(funcDecl *ast.FuncDecl) string {
+	expr := funcDecl.Recv.List[0].Type
+
+	starExpr, isStar := expr.(*ast.StarExpr)
+	if isStar {
+		expr = starExpr.X
+	}
+
+	ident, isIdent := expr.(*ast.Ident)
+	if !isIdent {
+		return ""
+	}
+
+	return ident.Name
+}

--- a/notification_test.go
+++ b/notification_test.go
@@ -1587,7 +1587,7 @@ func TestNotificationCRUD(t *testing.T) {
 		},
 		{
 			name:         "FortySixElks",
-			expectedType: "46elks",
+			expectedType: "Elks",
 			create: notification.FortySixElks{
 				Base: notification.Base{
 					ApplyExisting: false,
@@ -2014,7 +2014,7 @@ func TestNotificationCRUD(t *testing.T) {
 		},
 		{
 			name:         "Bark",
-			expectedType: "bark",
+			expectedType: "Bark",
 			create: notification.Bark{
 				Base: notification.Base{
 					ApplyExisting: false,
@@ -2121,7 +2121,7 @@ func TestNotificationCRUD(t *testing.T) {
 		},
 		{
 			name:         "Brevo",
-			expectedType: "brevo",
+			expectedType: "Brevo",
 			create: notification.Brevo{
 				Base: notification.Base{
 					ApplyExisting: false,
@@ -2345,7 +2345,7 @@ func TestNotificationCRUD(t *testing.T) {
 		},
 		{
 			name:         "Evolution",
-			expectedType: "EvolutionApi",
+			expectedType: "evolution",
 			create: notification.Evolution{
 				Base: notification.Base{
 					ApplyExisting: false,
@@ -2933,7 +2933,7 @@ func TestNotificationCRUD(t *testing.T) {
 		},
 		{
 			name:         "NextcloudTalk",
-			expectedType: "NextcloudTalk",
+			expectedType: "nextcloudtalk",
 			create: notification.NextcloudTalk{
 				Base: notification.Base{
 					ApplyExisting: false,
@@ -3270,7 +3270,7 @@ func TestNotificationCRUD(t *testing.T) {
 		},
 		{
 			name:         "OneSender",
-			expectedType: "onesender",
+			expectedType: "Onesender",
 			create: notification.OneSender{
 				Base: notification.Base{
 					ApplyExisting: false,
@@ -3438,7 +3438,7 @@ func TestNotificationCRUD(t *testing.T) {
 		},
 		{
 			name:         "Pumble",
-			expectedType: "Pumble",
+			expectedType: "pumble",
 			create: notification.Pumble{
 				Base: notification.Base{
 					ApplyExisting: false,
@@ -3868,7 +3868,7 @@ func TestNotificationCRUD(t *testing.T) {
 		},
 		{
 			name:         "SevenIO",
-			expectedType: "sevenio",
+			expectedType: "SevenIO",
 			create: notification.SevenIO{
 				Base: notification.Base{
 					ApplyExisting: false,


### PR DESCRIPTION
Closes #345

## Problem

Eight notification providers returned a `Type()` string that does not match the provider name Uptime Kuma dispatches on. Uptime Kuma builds its provider registry from the `name` class field of `server/notification-providers/*.js` and looks up the stored notification `type`; with no matching key, `Notification.send()` falls through to the "not supported" error. CRUD still appears to succeed, so the failure only surfaces when an alert fires or "Test" is pressed.

`marshalJSON` in `notification/helpers.go` writes `details.Type()` over the type seeded from the config, so reading a correctly typed notification created in the UI and writing it back rewrote a working `type` into the broken one.

## Changes

- Corrected `Type()` on the `*Details` struct of the eight affected providers:

  | Provider | before | after |
  |---|---|---|
  | `notification_46elks.go` | `46elks` | `Elks` |
  | `notification_bark.go` | `bark` | `Bark` |
  | `notification_brevo.go` | `brevo` | `Brevo` |
  | `notification_evolution.go` | `EvolutionApi` | `evolution` |
  | `notification_nextcloudtalk.go` | `NextcloudTalk` | `nextcloudtalk` |
  | `notification_onesender.go` | `onesender` | `Onesender` |
  | `notification_pumble.go` | `Pumble` | `pumble` |
  | `notification_sevenio.go` | `sevenio` | `SevenIO` |

- Updated the affected unit fixtures (both the escaped `config` string and `wantJSON`) and the `expectedType` values in `notification_test.go`.
- Added `notification/notification_type_test.go`: a guard test that parses the package source, collects every `Type()` implementation returning a string literal and compares the result against the 98 provider names known to Uptime Kuma. The two sets are compared as sets rather than only checking membership, so the test also fails when a `Type()` stops being a string literal and silently escapes collection, when two providers report the same type, and when a provider is added upstream but not implemented here. Wrapper types are covered transitively through their details type; `Base` and `Generic` report a type read from the notification itself and have none to check. The provider names record the Uptime Kuma version they were taken from and the command to regenerate them.
- Added `notification/notification_legacy_type_test.go`, pinning the migration behavior described below: a notification stored with a superseded type keeps that type until it is written back, and marshaling emits the corrected one.
- Noted on the `Type()` of `FortySixElksDetails`, `EvolutionDetails`, `NextcloudTalkDetails`, `OneSenderDetails` and `PumbleDetails` that the returned string is the upstream provider name, so the deviating casing does not get "fixed" later.

## Compatibility

This is a breaking change for callers hard-coding the previous strings. Notifications already stored with a wrong type keep it until they are saved again, so affected notifications need to be re-saved (either through the client or by pressing Save in the UI).

## Verification

- `task lint` — 0 issues
- `task test` and `task test-e2e` — all packages pass
- `task fmt` — clean
- The guard test was mutation checked: a duplicated provider name, a `Type()` returning a named constant instead of a literal, and a misspelled provider name each make it fail.

## Follow-up

Tracked in #358. `expectedType` in `notification_test.go` cannot catch this class of bug on its own. The server stores the notification config verbatim without validating the type, so the assertion compares the type against the value the client itself wrote. Upstream only validates in `Notification.send`, reachable through the `testNotification` socket event, for which this client has no binding yet. Adding one would turn the hardcoded provider name list into a check against a running server.
