### PR TITLE
feat(statuspage): add rybbit analytics type

### DIFF
--- a/statuspage/helpers.go
+++ b/statuspage/helpers.go
@@ -14,6 +14,7 @@ const (
 	analyticsTypeUmami     = "umami"
 	analyticsTypePlausible = "plausible"
 	analyticsTypeMatomo    = "matomo"
+	analyticsTypeRybbit    = "rybbit"
 )
 
 // ThemeLight returns the "light" theme identifier.
@@ -81,8 +82,17 @@ func AnalyticsTypeMatomo() string {
 	return analyticsTypeMatomo
 }
 
+// AnalyticsTypeRybbit returns the "rybbit" analytics type identifier.
+func AnalyticsTypeRybbit() string {
+	return analyticsTypeRybbit
+}
+
 // ValidAnalyticsType checks if the provided analytics type is valid.
 // A nil value is considered valid, as Uptime Kuma accepts null for this field.
+// The check is an allowlist of the analytics types supported by Uptime Kuma.
+// While the status_page.analytics_type column is a free-form string since
+// Uptime Kuma v2.5.0, the server still rejects any other value, so the
+// allowlist is kept in sync with the server side validation.
 func ValidAnalyticsType(analyticsType *string) bool {
 	if analyticsType == nil {
 		return true
@@ -91,5 +101,6 @@ func ValidAnalyticsType(analyticsType *string) bool {
 	at := *analyticsType
 	return at == analyticsTypeGoogle || at == analyticsTypeUmami ||
 		at == analyticsTypePlausible ||
-		at == analyticsTypeMatomo
+		at == analyticsTypeMatomo ||
+		at == analyticsTypeRybbit
 }

--- a/statuspage/helpers_test.go
+++ b/statuspage/helpers_test.go
@@ -191,6 +191,11 @@ func TestAnalyticsTypeHelpers(t *testing.T) {
 			analyticsType: "matomo",
 			wantFunc:      statuspage.AnalyticsTypeMatomo,
 		},
+		{
+			name:          "rybbit analytics type",
+			analyticsType: "rybbit",
+			wantFunc:      statuspage.AnalyticsTypeRybbit,
+		},
 	}
 
 	for _, tt := range tests {
@@ -231,6 +236,11 @@ func TestValidAnalyticsType(t *testing.T) {
 		{
 			name:          "matomo is valid",
 			analyticsType: ptr.To("matomo"),
+			want:          true,
+		},
+		{
+			name:          "rybbit is valid",
+			analyticsType: ptr.To("rybbit"),
 			want:          true,
 		},
 		{


### PR DESCRIPTION
## Summary

Uptime Kuma v2.5.0 added Rybbit as a status page analytics provider
([louislam/uptime-kuma#7525](https://github.com/louislam/uptime-kuma/pull/7525)). It
reuses the existing `analyticsId` / `analyticsScriptUrl` fields, so no status page
struct change is needed — only the analytics type identifier is new.

## Changes

- Add the `analyticsTypeRybbit` constant and the `AnalyticsTypeRybbit()` accessor
- Accept `"rybbit"` in `ValidAnalyticsType`
- Extend `statuspage/helpers_test.go` accordingly

## Notes

Migration
[louislam/uptime-kuma#7544](https://github.com/louislam/uptime-kuma/pull/7544) changed
`status_page.analytics_type` from a DB enum to a free-form string. `ValidAnalyticsType`
is deliberately kept as an allowlist, since the socket handler still validates against
the five known values; the doc comment now states this.

## Testing

- `task lint`
- `task fmt`
- `task test-e2e`

Closes #343