### PR TITLE
docs(monitor): align field docs with Uptime Kuma 2.5.0 behaviour

### DIFF
--- a/monitor/monitor_base.go
+++ b/monitor/monitor_base.go
@@ -31,7 +31,7 @@ type Base struct {
 	ProxyID     *int64  `json:"proxyId"`
 	// Interval is the check interval in seconds. The server only enforces a
 	// minimum of 1 second; the 24 day maximum was removed in Uptime Kuma 2.5.0,
-	// so intervals are unbounded from that version onwards.
+	// so no maximum is enforced as of that version.
 	Interval int64 `json:"interval"`
 	// RetryInterval is the interval in seconds between retries after a failed
 	// check. Like Interval, it is only bounded by a minimum of 1 second.

--- a/monitor/monitor_base.go
+++ b/monitor/monitor_base.go
@@ -23,13 +23,18 @@ type Monitor interface {
 
 // Base contains the common fields for all monitor types.
 type Base struct {
-	ID              int64            `json:"id"`
-	Name            string           `json:"name"`
-	Description     *string          `json:"description"`
-	PathName        string           `json:"pathName"`
-	Parent          *int64           `json:"parent"`
-	ProxyID         *int64           `json:"proxyId"`
-	Interval        int64            `json:"interval"`
+	ID          int64   `json:"id"`
+	Name        string  `json:"name"`
+	Description *string `json:"description"`
+	PathName    string  `json:"pathName"`
+	Parent      *int64  `json:"parent"`
+	ProxyID     *int64  `json:"proxyId"`
+	// Interval is the check interval in seconds. The server only enforces a
+	// minimum of 1 second; the 24 day maximum was removed in Uptime Kuma 2.5.0,
+	// so intervals are unbounded from that version onwards.
+	Interval int64 `json:"interval"`
+	// RetryInterval is the interval in seconds between retries after a failed
+	// check. Like Interval, it is only bounded by a minimum of 1 second.
 	RetryInterval   int64            `json:"retryInterval"`
 	ResendInterval  int64            `json:"resendInterval"`
 	MaxRetries      int64            `json:"maxretries"`

--- a/monitor/monitor_mqtt.go
+++ b/monitor/monitor_mqtt.go
@@ -98,7 +98,7 @@ func (m MQTT) MarshalJSON() ([]byte, error) {
 
 // MQTTDetails contains MQTT monitor specific fields.
 type MQTTDetails struct {
-	// Hostname is the MQTT broker address (supports mqtt://, ws://, wss:// protocols).
+	// Hostname is the MQTT broker address (supports mqtt://, mqtts://, ws://, wss:// protocols).
 	Hostname string `json:"hostname"`
 	// Port is the MQTT broker port.
 	Port *int64 `json:"port"`
@@ -109,6 +109,7 @@ type MQTTDetails struct {
 	// MQTTPassword is the optional password for MQTT authentication.
 	MQTTPassword *string `json:"mqttPassword"`
 	// MQTTWebsocketPath is the optional WebSocket path for WebSocket connections.
+	// Since Uptime Kuma 2.5.0 the UI also exposes this field for mqtts:// hostnames.
 	MQTTWebsocketPath *string `json:"mqttWebsocketPath"`
 	// MQTTCheckType is the check type: keyword or json-query.
 	MQTTCheckType MQTTCheckType `json:"mqttCheckType"`

--- a/monitor/monitor_mqtt.go
+++ b/monitor/monitor_mqtt.go
@@ -99,6 +99,7 @@ func (m MQTT) MarshalJSON() ([]byte, error) {
 // MQTTDetails contains MQTT monitor specific fields.
 type MQTTDetails struct {
 	// Hostname is the MQTT broker address (supports mqtt://, mqtts://, ws://, wss:// protocols).
+	// A hostname without a scheme is treated as mqtt:// by the server.
 	Hostname string `json:"hostname"`
 	// Port is the MQTT broker port.
 	Port *int64 `json:"port"`
@@ -109,7 +110,9 @@ type MQTTDetails struct {
 	// MQTTPassword is the optional password for MQTT authentication.
 	MQTTPassword *string `json:"mqttPassword"`
 	// MQTTWebsocketPath is the optional WebSocket path for WebSocket connections.
-	// Since Uptime Kuma 2.5.0 the UI also exposes this field for mqtts:// hostnames.
+	// It is only applied when Hostname uses ws:// or wss://; the server ignores
+	// it for mqtt:// and mqtts:// hostnames, even though the Uptime Kuma 2.5.0
+	// UI renders the input for those schemes as well.
 	MQTTWebsocketPath *string `json:"mqttWebsocketPath"`
 	// MQTTCheckType is the check type: keyword or json-query.
 	MQTTCheckType MQTTCheckType `json:"mqttCheckType"`

--- a/monitor/monitor_real_browser.go
+++ b/monitor/monitor_real_browser.go
@@ -100,13 +100,18 @@ type RealBrowserDetails struct {
 	// floating point column, so fractional values round-trip unchanged, but
 	// the realbrowser check never reads the column: it derives its timeout
 	// from 80 percent of the interval instead.
-	Timeout                  float64  `json:"timeout"`
-	IgnoreTLS                bool     `json:"ignoreTls"`
-	MaxRedirects             int      `json:"maxredirects"`
-	AcceptedStatusCodes      []string `json:"accepted_statuscodes"`
-	RemoteBrowser            *int64   `json:"remote_browser,omitempty"`
-	ScreenshotDelay          *int     `json:"screenshot_delay,omitempty"`
-	DomainExpiryNotification bool     `json:"domainExpiryNotification"`
+	Timeout             float64  `json:"timeout"`
+	IgnoreTLS           bool     `json:"ignoreTls"`
+	MaxRedirects        int      `json:"maxredirects"`
+	AcceptedStatusCodes []string `json:"accepted_statuscodes"`
+	RemoteBrowser       *int64   `json:"remote_browser,omitempty"`
+	// ScreenshotDelay is the delay in milliseconds the browser waits before
+	// taking the screenshot. Uptime Kuma persists and returns the value since
+	// 2.5.0, before that any value sent by the client was silently dropped.
+	// The server rejects negative values and values greater than or equal to
+	// 50 percent of the interval (in milliseconds).
+	ScreenshotDelay          *int `json:"screenshot_delay,omitempty"`
+	DomainExpiryNotification bool `json:"domainExpiryNotification"`
 }
 
 // Type returns the monitor type.

--- a/monitor/monitor_real_browser.go
+++ b/monitor/monitor_real_browser.go
@@ -106,10 +106,15 @@ type RealBrowserDetails struct {
 	AcceptedStatusCodes []string `json:"accepted_statuscodes"`
 	RemoteBrowser       *int64   `json:"remote_browser,omitempty"`
 	// ScreenshotDelay is the delay in milliseconds the browser waits before
-	// taking the screenshot. Uptime Kuma persists and returns the value since
-	// 2.5.0, before that any value sent by the client was silently dropped.
-	// The server rejects negative values and values greater than or equal to
-	// 50 percent of the interval (in milliseconds).
+	// taking the screenshot. Uptime Kuma only returns the value since 2.5.0;
+	// earlier versions stored it on create and applied it to the check, but
+	// never echoed it back and silently ignored it on update.
+	// As of 2.5.0 the server rejects negative values and values greater than or
+	// equal to Interval * 500, that is half the interval converted to
+	// milliseconds. Values at or above Interval * 800 are reported against the
+	// 80 percent bound instead, because the server checks that one first.
+	// A nil value omits the field from the request, which leaves any previously
+	// stored delay untouched; the delay cannot be cleared through this client.
 	ScreenshotDelay          *int `json:"screenshot_delay,omitempty"`
 	DomainExpiryNotification bool `json:"domainExpiryNotification"`
 }

--- a/monitor/monitor_system_service.go
+++ b/monitor/monitor_system_service.go
@@ -89,11 +89,13 @@ func (s SystemService) MarshalJSON() ([]byte, error) {
 // SystemServiceDetails contains system-service-specific monitor configuration.
 type SystemServiceDetails struct {
 	// SystemServiceName is the name of the service to check. Must be non-empty.
-	// On Linux (systemd), valid characters are alphanumeric plus '.', '_', '-', and '@'
-	// (e.g. "nginx.service", "sshd@0.service"). On Windows, valid characters are
-	// alphanumeric plus '.', '_', '-' (e.g. "Spooler").
-	// Since Uptime Kuma 2.5.0 the server trims surrounding whitespace and rejects
-	// names that do not match ^[a-zA-Z0-9._\-@]+$.
+	// Since Uptime Kuma 2.5.0 the server trims surrounding whitespace on write
+	// and rejects names that do not match ^[a-zA-Z0-9._\-@]+$. That regex is
+	// platform independent, so the trimmed name is what gets stored and
+	// returned. The narrower per-platform character sets are only enforced when
+	// the check runs: on Linux (systemd) alphanumeric plus '.', '_', '-', and
+	// '@' (e.g. "nginx.service", "sshd@0.service"), on Windows alphanumeric plus
+	// '.', '_', '-' (e.g. "Spooler").
 	// Note: the upstream API uses snake_case for this field, unlike most other Uptime Kuma fields.
 	SystemServiceName string `json:"system_service_name"`
 }

--- a/monitor/monitor_system_service.go
+++ b/monitor/monitor_system_service.go
@@ -92,6 +92,8 @@ type SystemServiceDetails struct {
 	// On Linux (systemd), valid characters are alphanumeric plus '.', '_', '-', and '@'
 	// (e.g. "nginx.service", "sshd@0.service"). On Windows, valid characters are
 	// alphanumeric plus '.', '_', '-' (e.g. "Spooler").
+	// Since Uptime Kuma 2.5.0 the server trims surrounding whitespace and rejects
+	// names that do not match ^[a-zA-Z0-9._\-@]+$.
 	// Note: the upstream API uses snake_case for this field, unlike most other Uptime Kuma fields.
 	SystemServiceName string `json:"system_service_name"`
 }

--- a/monitor_test.go
+++ b/monitor_test.go
@@ -666,6 +666,7 @@ func TestMonitorCRUD(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, id, browser.ID)
 				require.Equal(t, "Test RealBrowser Monitor", browser.Name)
+				require.Equal(t, ptr.To(1500), browser.ScreenshotDelay)
 			},
 			createTypedFunc: func(t *testing.T, base monitor.Monitor) monitor.Monitor {
 				t.Helper()
@@ -681,6 +682,7 @@ func TestMonitorCRUD(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, "Updated RealBrowser Monitor", browser.Name)
 				require.Equal(t, "https://httpbin.org/status/201", browser.URL)
+				require.Equal(t, ptr.To(2500), browser.ScreenshotDelay)
 				require.True(t, browser.DomainExpiryNotification)
 			},
 			testPauseResume: true,


### PR DESCRIPTION
Uptime Kuma 2.5.0 changes several server-side behaviours that need no new fields on the Go structs, but do affect what the client documents and what the integration tests can assert.

## Changes

- **MQTT `mqtts://`** (louislam/uptime-kuma#7290): `MQTTDetails.Hostname` now documents `mqtts://` alongside `mqtt://`, `ws://` and `wss://`, plus the server-side default of `mqtt://` for a schemeless hostname. `MQTTWebsocketPath` documents that the server only appends the path for `ws://` and `wss://` hostnames — 2.5.0 widened the UI visibility guard to `mqtt://` and `mqtts://`, but `server/monitor-types/mqtt.js` still ignores the field for those schemes.
- **24 day interval cap removed** (louislam/uptime-kuma#7607): upstream dropped `MAX_INTERVAL_SECOND` from `src/util.ts` and the corresponding checks from `Monitor.validate()`; only the 1 second minimum remains. The Go client never enforced a maximum of its own, so nothing had to be removed — this is now documented on `monitor.Base.Interval` and `monitor.Base.RetryInterval`, scoped to 2.5.0 rather than to all future versions.
- **`screenshot_delay` returned** (louislam/uptime-kuma#7515): `server/server.js` now sets `bean.screenshot_delay` on edit and `server/model/monitor.js` emits it in `toJSON()`. Earlier versions already persisted the value on create and applied it to the check; they only failed to echo it back and ignored it on update. `RealBrowserDetails.ScreenshotDelay` already used the correct JSON key, so the change is doc + coverage: the Real Browser e2e case asserts the value round-trips through create, read and update. The doc comment records the server-side bounds (non-negative, strictly below `Interval * 500`, with the 80 % bound reported first for larger values) and the fact that a nil delay leaves a stored value untouched.
- **`system-service` name handling** (louislam/uptime-kuma#7114): the server trims `system_service_name` and rejects names not matching `^[a-zA-Z0-9._\-@]+$`. That regex is platform independent; the narrower per-platform character sets are only enforced when the check runs. `SystemServiceDetails.SystemServiceName` now separates the two.

No wire format changes.

## Testing

- `task lint` — 0 issues
- `task test` — passes
- `task test-e2e` — passes against a running Uptime Kuma 2.5.0 instance, including the new `screenshot_delay` assertions

Closes #344