### PR TITLE
feat(notification): add TestNotification client method

### DIFF
--- a/client.go
+++ b/client.go
@@ -659,8 +659,8 @@ type ackResponse struct {
 
 func (c *Client) syncEmit(ctx context.Context, command string, args ...any) (ackResponse, error) {
 	// Buffered and never closed, so a late ack (e.g. after the context
-	// expired) neither blocks the socket.io callback nor sends on a closed
-	// channel.
+	// expired) neither leaks the ack goroutine forever nor panics sending on
+	// a closed channel.
 	res := make(chan ackResponse, 1)
 
 	args = append(args, emit.WithAck(func(response ackResponse) {
@@ -702,19 +702,19 @@ func (c *Client) syncEmitWithUpdateEvent(
 	listenerID := uuid.New()
 	c.updates.AddListener(func(_ context.Context, update string) {
 		if update == updateEvent {
-			c.updates.RemoveListener(listenerID.String())
 			closeDone()
 		}
 	}, listenerID.String())
+	defer c.updates.RemoveListener(listenerID.String())
 
-	res := make(chan ackResponse)
-	defer close(res)
+	// Buffered and never closed, for the same reason as in syncEmit: the ack
+	// runs on a goroutine of its own, so a send with no receiver left leaks it,
+	// and closing the channel underneath it panics the whole process. Checking
+	// ctx.Err() in the callback does not help, because the context can expire
+	// while the send is already blocked.
+	res := make(chan ackResponse, 1)
 
 	args = append(args, emit.WithAck(func(response ackResponse) {
-		if ctx.Err() != nil {
-			return
-		}
-
 		res <- response
 	}))
 	err := c.socketioClient.Emit(command, args...)

--- a/client.go
+++ b/client.go
@@ -658,14 +658,12 @@ type ackResponse struct {
 }
 
 func (c *Client) syncEmit(ctx context.Context, command string, args ...any) (ackResponse, error) {
-	res := make(chan ackResponse)
-	defer close(res)
+	// Buffered and never closed, so a late ack (e.g. after the context
+	// expired) neither blocks the socket.io callback nor sends on a closed
+	// channel.
+	res := make(chan ackResponse, 1)
 
 	args = append(args, emit.WithAck(func(response ackResponse) {
-		if ctx.Err() != nil {
-			return
-		}
-
 		res <- response
 	}))
 

--- a/client_ack_test.go
+++ b/client_ack_test.go
@@ -1,0 +1,243 @@
+package kuma_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	kuma "github.com/breml/go-uptime-kuma-client"
+	"github.com/breml/go-uptime-kuma-client/notification"
+)
+
+// readyEvents are the update events kuma.New() waits for before it returns. The
+// payloads only have to unmarshal into the registered handlers' argument types.
+//
+//nolint:gochecknoglobals // fixed table, shared by the fake server below.
+var readyEvents = []string{
+	`42["monitorList",{}]`,
+	`42["maintenanceList",{}]`,
+	`42["notificationList",[]]`,
+	`42["statusPageList",{}]`,
+	`42["proxyList",[]]`,
+	`42["dockerHostList",[]]`,
+	`42["apiKeyList",[]]`,
+}
+
+// fakeAckServer is a minimal socket.io server over HTTP long-polling that
+// completes the handshake, CONNECT, login and ready phases, so kuma.New()
+// returns a usable client. Unlike fakeSocketIOServer it then keeps serving:
+// every event the client emits afterwards is acknowledged after ackDelay,
+// which lets a test place the ack relative to the caller's deadline.
+//
+// It never emits an update event for those commands, so a caller using
+// syncEmitWithUpdateEvent keeps waiting after its ack arrived — the state in
+// which the deadline and the ack collide.
+type fakeAckServer struct {
+	messages chan []byte
+
+	mu       sync.Mutex
+	ackDelay time.Duration
+}
+
+func (s *fakeAckServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	sid := r.URL.Query().Get("sid")
+
+	switch {
+	case r.Method == http.MethodGet && sid == "":
+		type engineIOHandshake struct {
+			Sid          string   `json:"sid"`
+			Upgrades     []string `json:"upgrades"`
+			PingInterval int      `json:"pingInterval"`
+			PingTimeout  int      `json:"pingTimeout"`
+			MaxPayload   int      `json:"maxPayload"`
+		}
+		data, err := json.Marshal(engineIOHandshake{
+			Sid:          "ack-test-sid",
+			Upgrades:     []string{}, // no WebSocket upgrade keeps the client on polling
+			PingInterval: 50,
+			PingTimeout:  5000,
+			MaxPayload:   1000000,
+		})
+		if err != nil {
+			http.Error(w, "marshal handshake", http.StatusInternalServerError)
+			return
+		}
+
+		_, _ = w.Write(append([]byte("0"), data...))
+
+	case r.Method == http.MethodPost && sid != "":
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "read body", http.StatusInternalServerError)
+			return
+		}
+
+		s.handleClientMessage(body)
+		w.WriteHeader(http.StatusOK)
+
+	case r.Method == http.MethodGet && sid != "":
+		select {
+		case msg := <-s.messages:
+			_, _ = w.Write(msg)
+
+		case <-r.Context().Done():
+		}
+
+	default:
+	}
+}
+
+func (s *fakeAckServer) setAckDelay(d time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.ackDelay = d
+}
+
+func (s *fakeAckServer) currentAckDelay() time.Duration {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.ackDelay
+}
+
+func (s *fakeAckServer) handleClientMessage(body []byte) {
+	if len(body) < 2 {
+		return
+	}
+
+	socketIOData := body[1:] // strip engine.io "4" (Message) prefix
+
+	switch socketIOData[0] {
+	case '0': // socket.io CONNECT
+		s.messages <- []byte("40")
+
+	case '2': // socket.io EVENT
+		i := 1
+		for i < len(socketIOData) && socketIOData[i] >= '0' && socketIOData[i] <= '9' {
+			i++
+		}
+
+		ackID := string(socketIOData[1:i])
+		payload := string(socketIOData[i:])
+
+		if strings.Contains(payload, `"login"`) {
+			s.messages <- fmt.Appendf(nil, `43%s[{"ok":true,"msg":"Logged in successfully."}]`, ackID)
+
+			for _, event := range readyEvents {
+				s.messages <- []byte(event)
+			}
+
+			return
+		}
+
+		// Acknowledge out of band: blocking here would stall the client's
+		// send path instead of only delaying the ack.
+		delay := s.currentAckDelay()
+		go func() {
+			time.Sleep(delay)
+			s.messages <- fmt.Appendf(nil, `43%s[{"ok":true,"msg":"ok"}]`, ackID)
+		}()
+
+	default:
+	}
+}
+
+// TestAckDeliveryAroundDeadline sweeps the ack of an in-flight command across
+// the caller's deadline, so that early, colliding and late acks are all
+// exercised against the same call.
+//
+// The defect this guards against is a "send on closed channel" panic: the ack
+// callback runs on a goroutine owned by the socket.io client, so an ack that
+// arrives once the caller has returned finds the channel closed by its
+// `defer close(res)`, and the panic is raised where no caller can recover from
+// it. That kills the process, not just the request.
+//
+// What it catches, and what it does not: the late-ack iterations at the end of
+// the sweep panic every time if `close(res)` is reintroduced, so the invariant
+// "the ack channel is buffered and never closed" is genuinely enforced here.
+// The original code guarded the send with `if ctx.Err() != nil` and crashed
+// only when the context expired between that check and the send. That window
+// is a few instructions wide, and it was verified that this test does not
+// reproduce it — real transport latency swamps it. So a green run is not
+// evidence that a guard-based implementation is safe; it is evidence that the
+// channel is still handled the way syncEmit and syncEmitWithUpdateEvent
+// document.
+func TestAckDeliveryAroundDeadline(t *testing.T) {
+	const (
+		callTimeout = 30 * time.Millisecond
+		iterations  = 24
+		step        = 500 * time.Microsecond
+	)
+
+	fake := &fakeAckServer{messages: make(chan []byte, 32)}
+	server := httptest.NewServer(fake)
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	t.Cleanup(func() {
+		cancel()
+		server.CloseClientConnections()
+		server.Close()
+	})
+
+	kumaClient, err := kuma.New(
+		ctx,
+		server.URL,
+		"admin", "admin1",
+		kuma.WithConnectTimeout(10*time.Second),
+	)
+	require.NoError(t, err)
+
+	// Start clearly before the deadline and end clearly after it.
+	base := callTimeout - (iterations/2)*step
+
+	t.Run("sync_emit_with_update_event", func(t *testing.T) {
+		for i := range iterations {
+			fake.setAckDelay(base + time.Duration(i)*step)
+
+			callCtx, callCancel := context.WithTimeout(ctx, callTimeout)
+			// The fake acks the command but never emits notificationList, so
+			// the call keeps waiting for its update event and always runs into
+			// the deadline — with the ack landing somewhere around it.
+			err := kumaClient.DeleteNotification(callCtx, 1)
+			callCancel()
+
+			require.ErrorIs(t, err, context.DeadlineExceeded,
+				"ack delay %s should leave the call waiting on its update event", fake.currentAckDelay())
+		}
+	})
+
+	t.Run("sync_emit", func(t *testing.T) {
+		for i := range iterations {
+			fake.setAckDelay(base + time.Duration(i)*step)
+
+			callCtx, callCancel := context.WithTimeout(ctx, callTimeout)
+			msg, err := kumaClient.TestNotification(callCtx, notification.Generic{
+				Base:           notification.Base{Name: "ack race"},
+				GenericDetails: notification.GenericDetails{},
+				TypeName:       "generic",
+			})
+			callCancel()
+
+			// Whether the ack or the deadline won is a matter of scheduling and
+			// either outcome is correct. A panic, a hang, or a garbled response
+			// is not.
+			if err != nil {
+				require.ErrorIs(t, err, context.DeadlineExceeded)
+
+				continue
+			}
+
+			require.Equal(t, "ok", msg)
+		}
+	})
+}

--- a/notification.go
+++ b/notification.go
@@ -2,7 +2,9 @@ package kuma
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/breml/go-uptime-kuma-client/notification"
 )
@@ -69,12 +71,35 @@ func (c *Client) DeleteNotification(ctx context.Context, id int64) error {
 	return err
 }
 
+// ErrNotificationTypeNotSupported is returned by TestNotification if the server
+// has no notification provider registered for the given notification type.
+var ErrNotificationTypeNotSupported = errors.New("notification type is not supported")
+
+// serverMsgNotificationTypeNotSupported is the message the server reports when
+// the provider lookup for a notification type fails. It is matched here, in the
+// single place that knows about it, so callers can use
+// ErrNotificationTypeNotSupported instead of matching on the message themselves.
+const serverMsgNotificationTypeNotSupported = "Notification type is not supported"
+
 // TestNotification asks the server to dispatch a test message with the given
-// notification. It reports the error returned by the notification provider, so
-// a failure to reach the provider (e.g. invalid credentials or an unreachable
-// endpoint) is reported as an error as well. An unsupported notification type
-// is reported as "testNotification: Notification type is not supported".
-func (c *Client) TestNotification(ctx context.Context, notif notification.Notification) error {
-	_, err := c.syncEmit(ctx, "testNotification", notif)
-	return err
+// notification and returns the message the notification provider reported.
+//
+// If the server has no provider for the type of notif, the returned error wraps
+// ErrNotificationTypeNotSupported. A provider that fails while dispatching (e.g.
+// invalid credentials or an unreachable endpoint) is reported as an error too,
+// but only if it raises one: some providers report a delivery failure in their
+// message and let the server report success regardless. A nil error therefore
+// does not prove the notification was delivered, and callers that need to know
+// have to inspect the returned message.
+func (c *Client) TestNotification(ctx context.Context, notif notification.Notification) (string, error) {
+	response, err := c.syncEmit(ctx, "testNotification", notif)
+	if err != nil {
+		if strings.Contains(err.Error(), serverMsgNotificationTypeNotSupported) {
+			return "", fmt.Errorf("testNotification: %w", ErrNotificationTypeNotSupported)
+		}
+
+		return "", err
+	}
+
+	return response.Msg, nil
 }

--- a/notification.go
+++ b/notification.go
@@ -68,3 +68,13 @@ func (c *Client) DeleteNotification(ctx context.Context, id int64) error {
 	_, err := c.syncEmitWithUpdateEvent(ctx, "deleteNotification", "notificationList", id)
 	return err
 }
+
+// TestNotification asks the server to dispatch a test message with the given
+// notification. It reports the error returned by the notification provider, so
+// a failure to reach the provider (e.g. invalid credentials or an unreachable
+// endpoint) is reported as an error as well. An unsupported notification type
+// is reported as "testNotification: Notification type is not supported".
+func (c *Client) TestNotification(ctx context.Context, notif notification.Notification) error {
+	_, err := c.syncEmit(ctx, "testNotification", notif)
+	return err
+}

--- a/notification_test.go
+++ b/notification_test.go
@@ -3,6 +3,9 @@ package kuma_test
 
 import (
 	"context"
+	"errors"
+	"os"
+	"strconv"
 	"testing"
 	"time"
 
@@ -12,10 +15,15 @@ import (
 	"github.com/breml/go-uptime-kuma-client/notification"
 )
 
+// testNotificationTimeout bounds a single testNotification call. The server
+// dispatches the notification for real and some providers block until their
+// own outbound timeout, which would otherwise dominate the suite runtime.
+const testNotificationTimeout = 5 * time.Second
+
 // notificationTestCase defines a single notification type's CRUD test scenario.
 type notificationTestCase struct {
 	name              string                                                                                             // Test name (e.g., "Ntfy", "Slack")
-	expectedType      string                                                                                             // Expected type string from API
+	expectedType      string                                                                                             // Expected type string, round-tripped through the server config (see test_notification for the server side validation)
 	create            notification.Notification                                                                          // Notification to create
 	updateFunc        func(notification.Notification)                                                                    // Function to modify notification for update test
 	verifyCreatedFunc func(t *testing.T, actual notification.Notification, expected notification.Notification, id int64) // Function to verify created notification
@@ -5174,6 +5182,45 @@ func TestNotificationCRUD(t *testing.T) {
 				t.Logf("Initial notifications count: %d", len(notifications))
 			})
 
+			t.Run("test_notification", func(t *testing.T) {
+				// Dispatching all provider notifications for real costs about
+				// as much wall clock time as the rest of the suite, so this is
+				// limited to the end to end run.
+				e2eTest, _ := strconv.ParseBool(os.Getenv("E2E_TEST"))
+				if !e2eTest {
+					t.Skip(`skipping end to end test, "E2E_TEST" env var not set`)
+				}
+
+				// The server actually dispatches the notification, so the
+				// provider fails with a network or authentication error for
+				// the fake credentials used here. Such a failure is expected
+				// and must not be asserted on. The only assertion the server
+				// makes about the type is the provider lookup in
+				// Notification.send, which reports the message below and is
+				// the sole server side validation of Type().
+				testCtx, testCancel := context.WithTimeout(ctx, testNotificationTimeout)
+				defer testCancel()
+
+				err := client.TestNotification(testCtx, tc.create)
+				if err == nil {
+					return
+				}
+
+				// A provider blocking on an unroutable endpoint until the
+				// deadline tells us nothing about the type, so it is not a
+				// failure either.
+				if errors.Is(testCtx.Err(), context.DeadlineExceeded) {
+					t.Logf(
+						"test notification did not complete within %s, type %q not validated",
+						testNotificationTimeout,
+						tc.expectedType,
+					)
+					return
+				}
+
+				require.NotContains(t, err.Error(), "Notification type is not supported")
+			})
+
 			var id int64
 			t.Run("create", func(t *testing.T) {
 				initialNotifications := client.GetNotifications(ctx)
@@ -5321,4 +5368,28 @@ func TestWebhookNotificationVariants(t *testing.T) {
 		err = client.DeleteNotification(ctx, id)
 		require.NoError(t, err)
 	})
+}
+
+// TestNotificationUnsupportedType asserts that the server rejects a type it
+// cannot dispatch on. It guards the negative assertion made by the
+// test_notification subtest of TestNotificationCRUD: without it, that
+// assertion would also hold if the message ever changed upstream.
+func TestNotificationUnsupportedType(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), testNotificationTimeout)
+	defer cancel()
+
+	err := client.TestNotification(ctx, notification.Generic{
+		Base: notification.Base{
+			IsActive: true,
+			Name:     "Test Unsupported Type",
+		},
+		GenericDetails: notification.GenericDetails{},
+		TypeName:       "definitely-not-a-notification-provider",
+	})
+
+	require.ErrorContains(t, err, "Notification type is not supported")
 }

--- a/notification_test.go
+++ b/notification_test.go
@@ -11,19 +11,22 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	kuma "github.com/breml/go-uptime-kuma-client"
 	"github.com/breml/go-uptime-kuma-client/internal/ptr"
 	"github.com/breml/go-uptime-kuma-client/notification"
 )
 
 // testNotificationTimeout bounds a single testNotification call. The server
-// dispatches the notification for real and some providers block until their
-// own outbound timeout, which would otherwise dominate the suite runtime.
+// dispatches the notification for real and some providers block until their own
+// outbound timeout, which would otherwise dominate the suite runtime. It also
+// bounds TestNotificationUnsupportedType, which dispatches nothing and only
+// needs a deadline so a hung call fails instead of blocking the suite.
 const testNotificationTimeout = 5 * time.Second
 
 // notificationTestCase defines a single notification type's CRUD test scenario.
 type notificationTestCase struct {
 	name              string                                                                                             // Test name (e.g., "Ntfy", "Slack")
-	expectedType      string                                                                                             // Expected type string, round-tripped through the server config (see test_notification for the server side validation)
+	expectedType      string                                                                                             // Expected type string, round-tripped through the server config
 	create            notification.Notification                                                                          // Notification to create
 	updateFunc        func(notification.Notification)                                                                    // Function to modify notification for update test
 	verifyCreatedFunc func(t *testing.T, actual notification.Notification, expected notification.Notification, id int64) // Function to verify created notification
@@ -5170,6 +5173,15 @@ func TestNotificationCRUD(t *testing.T) {
 		},
 	}
 
+	// Dispatching all provider notifications for real costs about as much wall
+	// clock time as the rest of the suite, so this is limited to the end to end
+	// run.
+	e2eTest, _ := strconv.ParseBool(os.Getenv("E2E_TEST"))
+
+	// Counts the types that reached the server side type validation, so a run in
+	// which every provider timed out cannot pass as a run that validated them.
+	typesValidated := 0
+
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
@@ -5183,42 +5195,40 @@ func TestNotificationCRUD(t *testing.T) {
 			})
 
 			t.Run("test_notification", func(t *testing.T) {
-				// Dispatching all provider notifications for real costs about
-				// as much wall clock time as the rest of the suite, so this is
-				// limited to the end to end run.
-				e2eTest, _ := strconv.ParseBool(os.Getenv("E2E_TEST"))
 				if !e2eTest {
 					t.Skip(`skipping end to end test, "E2E_TEST" env var not set`)
 				}
 
-				// The server actually dispatches the notification, so the
-				// provider fails with a network or authentication error for
-				// the fake credentials used here. Such a failure is expected
-				// and must not be asserted on. The only assertion the server
-				// makes about the type is the provider lookup in
-				// Notification.send, which reports the message below and is
-				// the sole server side validation of Type().
 				testCtx, testCancel := context.WithTimeout(ctx, testNotificationTimeout)
 				defer testCancel()
 
-				err := client.TestNotification(testCtx, tc.create)
-				if err == nil {
-					return
-				}
+				_, err := client.TestNotification(testCtx, tc.create)
 
 				// A provider blocking on an unroutable endpoint until the
-				// deadline tells us nothing about the type, so it is not a
-				// failure either.
-				if errors.Is(testCtx.Err(), context.DeadlineExceeded) {
+				// deadline never reached the provider lookup, so it says
+				// nothing about the type and is not a failure. Checking the
+				// returned error rather than testCtx keeps a real error that
+				// happens to arrive around the deadline from taking this
+				// branch.
+				if errors.Is(err, context.DeadlineExceeded) {
 					t.Logf(
 						"test notification did not complete within %s, type %q not validated",
 						testNotificationTimeout,
 						tc.expectedType,
 					)
+
 					return
 				}
 
-				require.NotContains(t, err.Error(), "Notification type is not supported")
+				// The server dispatches the notification for real, so the
+				// provider fails with a network or authentication error for
+				// the fake credentials used here. Such a failure is expected
+				// and must not be asserted on. The provider lookup in
+				// Notification.send is the only thing the testNotification
+				// handler checks about the type.
+				require.NotErrorIs(t, err, kuma.ErrNotificationTypeNotSupported)
+
+				typesValidated++
 			})
 
 			var id int64
@@ -5275,6 +5285,15 @@ func TestNotificationCRUD(t *testing.T) {
 				require.Error(t, err)
 			})
 		})
+	}
+
+	// Every test_notification subtest tolerates a provider that blocks until
+	// the deadline, so in an environment without outbound network all of them
+	// tolerate their way to green without asserting anything. Requiring at
+	// least one validated type turns that silent degradation into a failure.
+	if e2eTest {
+		require.Positive(t, typesValidated,
+			"no notification type reached the server side type validation")
 	}
 }
 
@@ -5372,8 +5391,9 @@ func TestWebhookNotificationVariants(t *testing.T) {
 
 // TestNotificationUnsupportedType asserts that the server rejects a type it
 // cannot dispatch on. It guards the negative assertion made by the
-// test_notification subtest of TestNotificationCRUD: without it, that
-// assertion would also hold if the message ever changed upstream.
+// test_notification subtest of TestNotificationCRUD: without it, that assertion
+// would also hold if the message TestNotification matches on ever changed
+// upstream.
 func TestNotificationUnsupportedType(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
@@ -5382,7 +5402,7 @@ func TestNotificationUnsupportedType(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), testNotificationTimeout)
 	defer cancel()
 
-	err := client.TestNotification(ctx, notification.Generic{
+	_, err := client.TestNotification(ctx, notification.Generic{
 		Base: notification.Base{
 			IsActive: true,
 			Name:     "Test Unsupported Type",
@@ -5391,5 +5411,5 @@ func TestNotificationUnsupportedType(t *testing.T) {
 		TypeName:       "definitely-not-a-notification-provider",
 	})
 
-	require.ErrorContains(t, err, "Notification type is not supported")
+	require.ErrorIs(t, err, kuma.ErrNotificationTypeNotSupported)
 }


### PR DESCRIPTION
Adds `kuma.Client.TestNotification`, a wrapper around the upstream
`testNotification` socket event. It is the only server side check that a
notification type is actually dispatchable: `addNotification` stores the
config JSON verbatim, so the existing `expectedType` assertion only
round-trips the client's own output.

## Changes

- `kuma.Client.TestNotification` emits `testNotification` with the
  notification payload and returns `(string, error)`. The server acks
  `ok: true` even when a provider reports a delivery failure in its
  message instead of raising (`Opsgenie`, `JiraServiceManagement`,
  `Apprise`), so a nil error alone does not prove delivery and the
  provider message is returned next to it.
- `kuma.ErrNotificationTypeNotSupported` is returned when the server has
  no provider for the type. The upstream message is matched in one place
  so callers use `errors.Is` rather than a string.
- `TestNotificationCRUD` gains a `test_notification` subtest that calls
  the method for every provider case. A successful ack is not asserted:
  every case uses fake credentials, so a provider specific network or
  authentication failure is the expected outcome. A provider that blocks
  until the deadline is tolerated, so the table also requires that at
  least one type reached the server side validation — otherwise a run
  without outbound network tolerates its way to green.
- `TestNotificationUnsupportedType` asserts a bogus type does produce the
  sentinel, so the negative assertion above cannot pass vacuously.
- `kuma.Client.syncEmit` and `kuma.Client.syncEmitWithUpdateEvent` both
  use a buffered ack channel and no longer close it. Closing it while the
  ack callback is blocked sending panics with "send on closed channel",
  on a goroutine owned by the socket.io client where no caller can
  recover — it takes down the process. Guarding the send with `ctx.Err()`
  does not close the window, because the context can expire while the
  send is already blocked. `syncEmitWithUpdateEvent` also drops its
  update listener on every return path rather than only when it fires.
- `TestAckDeliveryAroundDeadline` sweeps an ack across the caller's
  deadline over a fake socket.io server. It pins the invariant that the
  channel is never closed; it does not reproduce the original
  guard-versus-send window, which is too narrow to hit through a real
  transport.

## Runtime

The subtest dispatches 94 notifications for real and is gated behind
`E2E_TEST`, like `TestEndToEndMonitorFailureNotification`: it adds ~25s,
which does not fit the 60s container expiry of the plain `task test` run.
Each call is bounded by a 5s context; a deadline is logged and not treated
as a type failure. Four providers (`HomeAssistant`, `FreeMobile`,
`Teltonika`, `whapi`) block on unroutable endpoints and hit it, leaving 90
types validated.

`task test-e2e` passes in 117s of the 240s budget, `task test` in 33s.

Closes #358
