### PR TITLE
fix(client): keep a successful ack when the update event times out

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -737,7 +737,7 @@ linters:
       - path: '_test\.go'
         linters:
           - revive
-        text: '(add-constant|argument-limit|cognitive-complexity|comments-density|cyclomatic|function-length):'
+        text: '(add-constant|argument-limit|cognitive-complexity|comments-density|cyclomatic|file-length-limit|function-length):'
 
       - text: 'shadow: declaration of "(err|ctx)" shadows declaration at'
         linters:
@@ -747,6 +747,12 @@ linters:
         linters:
           - revive
         text: '(deep-exit):'
+
+      # Tests the unexported awaitAckAndUpdateEvent, which has to be driven
+      # through states that the socket cannot reach reliably.
+      - path: 'client_await_test\.go'
+        linters:
+          - testpackage
 
       # These linters do not make sense for monitor and notification files.
       - path: (monitor|notification|proxy)/.*\.go

--- a/client.go
+++ b/client.go
@@ -32,25 +32,28 @@ import (
 var ErrNotFound = errors.New("not found")
 
 // ErrUpdateEventTimeout is returned when the server acknowledged a mutating
-// command successfully, but the update event it broadcasts afterwards did not
-// arrive before the context expired. The write landed on the server; what is
+// command successfully, but the update event that carries the change did not
+// arrive before the context was done. The write landed on the server; what is
 // missing is only the broadcast.
 //
 // An error wrapping ErrUpdateEventTimeout also wraps the context error, so
-// errors.Is(err, context.DeadlineExceeded) keeps reporting the timeout. Use
+// errors.Is(err, context.DeadlineExceeded) still reports an expired deadline
+// and errors.Is(err, context.Canceled) a cancelled context. Use
 // errors.Is(err, ErrUpdateEventTimeout) to tell the two cases apart: a plain
 // context error means the server never confirmed the command and it may or may
 // not have been applied, while ErrUpdateEventTimeout means it was applied.
 //
-// Methods that hand out a server assigned ID return it alongside such an error,
+// The Create methods return the ID the server assigned alongside such an error,
 // so a caller can adopt the created resource instead of retrying and creating a
-// duplicate.
+// duplicate. That ID is zero only if the ack carried none, which the server does
+// not do for a command it reports as successful.
 //
 // The local state cache is refreshed from the update event, so on this path it
 // is not up to date yet. The cache is maintained by the socket.io event
 // handlers and not by the caller's context, so it catches up on its own once
 // the event arrives; if the event is lost for good, the cache stays stale until
-// the next broadcast for that resource.
+// the next broadcast for that resource. Until then a getter that serves from
+// the cache does not report the resource.
 var ErrUpdateEventTimeout = errors.New("update event not received")
 
 // Log level constants for configuring socket.io client logging verbosity.
@@ -707,12 +710,13 @@ func (c *Client) syncEmit(ctx context.Context, command string, args ...any) (ack
 	}
 }
 
-// syncEmitWithUpdateEvent emits command and returns once the server has both
-// acknowledged it and broadcast updateEvent, which is what refreshes the local
-// state cache.
+// syncEmitWithUpdateEvent emits command and returns once the server has
+// acknowledged it and has broadcast an updateEvent, which is what refreshes the
+// local state cache. The listener matches the event by name, so the client
+// cannot tell which write caused the broadcast it observes.
 //
-// If the ack reports success but the update event does not arrive before ctx
-// expires, the response is returned together with an error wrapping
+// If the ack reports success but no update event arrives before ctx is done,
+// the response is returned together with an error wrapping
 // ErrUpdateEventTimeout and the context error: the command was applied, only
 // the broadcast is missing. Discarding the response here would tell the caller
 // the write failed for a write the server performed.
@@ -757,7 +761,15 @@ func (c *Client) syncEmitWithUpdateEvent(
 }
 
 // awaitAckAndUpdateEvent waits for the ack delivered on res and for the update
-// event that closes done, and reports what arrived before ctx expired.
+// event that closes done, and reports which of the two arrived before ctx was
+// done.
+//
+// An ack that reports a failure is returned as the server's error even when ctx
+// is done as well, because the rejection is the more useful answer and it is
+// what the caller would have received had the ack arrived a moment earlier. An
+// update event without an ack stays a plain context error: without the ack the
+// client knows neither the outcome of the command nor the ID the server
+// assigned.
 func awaitAckAndUpdateEvent(
 	ctx context.Context,
 	command string,
@@ -786,43 +798,62 @@ func awaitAckAndUpdateEvent(
 			res = nil
 
 		case <-ctx.Done():
+			// A signal that has already been delivered and the context being
+			// done can become ready in the same select, which picks between
+			// ready cases at random. Both signals are therefore collected
+			// explicitly, instead of letting that coin flip decide whether
+			// what they report is seen. Receiving from a nil channel is never
+			// ready, so the default case covers the signals already taken.
 			if !acked {
-				response, acked = pollAck(res)
+				select {
+				case response = <-res:
+					acked = true
+
+				default:
+				}
 			}
 
-			switch {
-			case acked && !response.OK:
-				return ackResponse{}, fmt.Errorf("%s: %s", command, response.Msg)
-
-			case acked:
-				// The server applied the command, only its broadcast is
-				// missing. Returning the response lets the caller keep what
-				// the ack carried, e.g. the ID of a created resource.
-				return response, fmt.Errorf("%s: %w: %w", command, ErrUpdateEventTimeout, ctx.Err())
+			select {
+			case <-done:
+				done = nil
 
 			default:
-				return ackResponse{}, fmt.Errorf("%s: %w", command, ctx.Err())
 			}
+
+			return resultOnContextDone(ctx, command, response, acked, done == nil)
 		}
 	}
 
 	return response, nil
 }
 
-// pollAck takes an ack that has already been delivered, without blocking. The
-// ack and the context deadline can become ready in the same instant, and select
-// picks between ready cases at random, so a delivered ack has to be collected
-// explicitly instead of being lost to that coin flip.
-func pollAck(res <-chan ackResponse) (ackResponse, bool) {
-	if res == nil {
-		return ackResponse{}, false
-	}
+// resultOnContextDone reports the outcome of a command whose context is done,
+// from the signals that are in hand: acked tells whether the ack in response
+// arrived, updated whether the update event did.
+func resultOnContextDone(
+	ctx context.Context,
+	command string,
+	response ackResponse,
+	acked bool,
+	updated bool,
+) (ackResponse, error) {
+	switch {
+	case acked && !response.OK:
+		return ackResponse{}, fmt.Errorf("%s: %s", command, response.Msg)
 
-	select {
-	case response := <-res:
-		return response, true
+	case acked && updated:
+		// Both signals are in hand and the context merely expired while they
+		// were collected. Nothing is missing, so this is the same success the
+		// caller's loop returns.
+		return response, nil
+
+	case acked:
+		// The server applied the command, only its broadcast is missing.
+		// Returning the response lets the caller keep what the ack carried,
+		// e.g. the ID of a created resource.
+		return response, fmt.Errorf("%s: %w: %w", command, ErrUpdateEventTimeout, ctx.Err())
 
 	default:
-		return ackResponse{}, false
+		return ackResponse{}, fmt.Errorf("%s: %w", command, ctx.Err())
 	}
 }

--- a/client.go
+++ b/client.go
@@ -46,7 +46,9 @@ var ErrNotFound = errors.New("not found")
 // The Create methods return the ID the server assigned alongside such an error,
 // so a caller can adopt the created resource instead of retrying and creating a
 // duplicate. That ID is zero only if the ack carried none, which the server does
-// not do for a command it reports as successful.
+// not do for a command it reports as successful. Because the idiomatic way to
+// propagate an error drops the values next to it, the ID is also carried by the
+// error itself, see UpdateEventTimeoutError.
 //
 // The local state cache is refreshed from the update event, so on this path it
 // is not up to date yet. The cache is maintained by the socket.io event
@@ -55,6 +57,59 @@ var ErrNotFound = errors.New("not found")
 // the next broadcast for that resource. Until then a getter that serves from
 // the cache does not report the resource.
 var ErrUpdateEventTimeout = errors.New("update event not received")
+
+// UpdateEventTimeoutError is the error the client returns for a command that
+// the server acknowledged without the update event arriving, see
+// ErrUpdateEventTimeout. It wraps both ErrUpdateEventTimeout and the context
+// error, so errors.Is keeps reporting either.
+//
+// It exists so that the ID of a created resource survives the way errors are
+// usually propagated: a caller that writes the idiomatic
+//
+//	id, err := client.CreateNotification(ctx, notif)
+//	if err != nil {
+//		return 0, err
+//	}
+//
+// discards the returned ID, and with it the only handle on a notification the
+// server did create. Recovering the error keeps that handle:
+//
+//	var timeoutErr *kuma.UpdateEventTimeoutError
+//	if errors.As(err, &timeoutErr) && timeoutErr.ID != 0 {
+//		// The resource exists, adopt it instead of creating it again.
+//	}
+type UpdateEventTimeoutError struct {
+	// Command is the socket.io command the server acknowledged.
+	Command string
+
+	// ID is the ID the server assigned to the created resource. It is zero for
+	// a command that creates nothing, and for an ack that carried no ID.
+	ID int64
+
+	// Err is the error of the context that was done before the update event
+	// arrived.
+	Err error
+}
+
+func (e *UpdateEventTimeoutError) Error() string {
+	return fmt.Sprintf("%s: %s: %s", e.Command, ErrUpdateEventTimeout, e.Err)
+}
+
+func (e *UpdateEventTimeoutError) Unwrap() []error {
+	return []error{ErrUpdateEventTimeout, e.Err}
+}
+
+// withCreatedID records id in the UpdateEventTimeoutError err is wrapping, if it
+// is one, and returns err unchanged otherwise. The command layer knows which
+// field of the ack carries the ID, the layer that builds the error does not.
+func withCreatedID(err error, id int64) error {
+	var timeoutErr *UpdateEventTimeoutError
+	if errors.As(err, &timeoutErr) {
+		timeoutErr.ID = id
+	}
+
+	return err
+}
 
 // Log level constants for configuring socket.io client logging verbosity.
 const (
@@ -851,7 +906,7 @@ func resultOnContextDone(
 		// The server applied the command, only its broadcast is missing.
 		// Returning the response lets the caller keep what the ack carried,
 		// e.g. the ID of a created resource.
-		return response, fmt.Errorf("%s: %w: %w", command, ErrUpdateEventTimeout, ctx.Err())
+		return response, &UpdateEventTimeoutError{Command: command, Err: ctx.Err()}
 
 	default:
 		return ackResponse{}, fmt.Errorf("%s: %w", command, ctx.Err())

--- a/client.go
+++ b/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -55,7 +56,8 @@ var ErrNotFound = errors.New("not found")
 // handlers and not by the caller's context, so it catches up on its own once
 // the event arrives; if the event is lost for good, the cache stays stale until
 // the next broadcast for that resource. Until then a getter that serves from
-// the cache does not report the resource.
+// the cache does not report the resource; Resync makes the server resend the
+// lists instead of waiting for that broadcast.
 var ErrUpdateEventTimeout = errors.New("update event not received")
 
 // UpdateEventTimeoutError is the error the client returns for a command that
@@ -168,6 +170,22 @@ type state struct {
 	dockerHosts   []dockerhost.DockerHost
 }
 
+// pendingListEvents returns the update events that carry the lists the local
+// state cache is built from, as a set to strike them off as they arrive. The
+// server sends all of them after a login, which is what New waits for and what
+// Resync repeats.
+func pendingListEvents() map[string]struct{} {
+	return map[string]struct{}{
+		"monitorList":      empty,
+		"maintenanceList":  empty,
+		"notificationList": empty,
+		"statusPageList":   empty,
+		"proxyList":        empty,
+		"dockerHostList":   empty,
+		"apiKeyList":       empty,
+	}
+}
+
 // Client represents a connection to an Uptime Kuma server.
 type Client struct {
 	socketioClient               *socketio.Client
@@ -178,6 +196,10 @@ type Client struct {
 	mu      *sync.Mutex
 	updates signals.Signal[string]
 	state   state
+
+	// sessionToken is the JWT the server handed out at login. It is what
+	// Resync logs in with, see there.
+	sessionToken string
 }
 
 // Option is a functional option for configuring a Client.
@@ -418,15 +440,7 @@ func New(ctx context.Context, baseURL string, username string, password string, 
 
 	updateSeenMu := sync.Mutex{}
 	updateSeenMu.Lock()
-	updateSeen := map[string]struct{}{
-		"monitorList":      empty,
-		"maintenanceList":  empty,
-		"notificationList": empty,
-		"statusPageList":   empty,
-		"proxyList":        empty,
-		"dockerHostList":   empty,
-		"apiKeyList":       empty,
-	}
+	updateSeen := pendingListEvents()
 	updateSeenMu.Unlock()
 
 	ready := make(chan struct{})
@@ -618,11 +632,17 @@ func New(ctx context.Context, baseURL string, username string, password string, 
 	}()
 
 	if username != "" && password != "" {
-		_, err = c.syncEmit(
+		var loginResponse ackResponse
+
+		loginResponse, err = c.syncEmit(
 			ctxWithConnectTimeout,
 			"login",
 			map[string]any{"username": username, "password": password, "token": ""},
 		)
+		if err == nil {
+			c.setSessionToken(loginResponse.Token)
+		}
+
 		if err != nil {
 			// Ensure we had the time to receive a potential setup event.
 			time.Sleep(10 * time.Millisecond)
@@ -660,7 +680,7 @@ func New(ctx context.Context, baseURL string, username string, password string, 
 				return nil, fmt.Errorf("setup: %w", err)
 			}
 
-			_, err = c.syncEmit(
+			loginResponse, err := c.syncEmit(
 				ctxWithConnectTimeout,
 				"login",
 				map[string]any{"username": username, "password": password, "token": ""},
@@ -668,6 +688,8 @@ func New(ctx context.Context, baseURL string, username string, password string, 
 			if err != nil {
 				return nil, fmt.Errorf("login: %w", err)
 			}
+
+			c.setSessionToken(loginResponse.Token)
 
 		case <-ctx.Done():
 			return nil, fmt.Errorf("wait for ready: %w", ctx.Err())
@@ -719,9 +741,88 @@ func (c *Client) Disconnect() error {
 	return nil
 }
 
+// Resync rebuilds the local state cache from the server and returns once the
+// server has resent every list the cache is built from.
+//
+// It is the way out of the stale cache an operation that failed with
+// ErrUpdateEventTimeout leaves behind: the getters that serve from the cache do
+// not report a resource until its list is broadcast again, and for
+// notifications, proxies and Docker hosts nothing else triggers that broadcast.
+//
+// The resync is all or nothing, because the server has no command to re-request
+// a single list. What it does have is a login, which answers with all of them,
+// so Resync logs in again with the token from the login New performed. A client
+// created without credentials therefore cannot resync.
+func (c *Client) Resync(ctx context.Context) error {
+	c.mu.Lock()
+	token := c.sessionToken
+	c.mu.Unlock()
+
+	if token == "" {
+		return errors.New("resync: no session token, the client was created without credentials")
+	}
+
+	pendingMu := sync.Mutex{}
+	pending := pendingListEvents()
+
+	done := make(chan struct{})
+	closeDone := sync.OnceFunc(func() {
+		close(done)
+	})
+	defer closeDone()
+
+	// Registered before the command is emitted, so that no list can arrive
+	// unnoticed between the two.
+	listenerID := uuid.New()
+	c.updates.AddListener(func(_ context.Context, update string) {
+		pendingMu.Lock()
+		defer pendingMu.Unlock()
+
+		delete(pending, update)
+
+		if len(pending) == 0 {
+			closeDone()
+		}
+	}, listenerID.String())
+
+	defer c.updates.RemoveListener(listenerID.String())
+
+	_, err := c.syncEmit(ctx, "loginByToken", token)
+	if err != nil {
+		return fmt.Errorf("resync: %w", err)
+	}
+
+	select {
+	case <-done:
+		return nil
+
+	case <-ctx.Done():
+		pendingMu.Lock()
+		missing := make([]string, 0, len(pending))
+
+		for event := range pending {
+			missing = append(missing, event)
+		}
+		pendingMu.Unlock()
+
+		slices.Sort(missing)
+
+		return fmt.Errorf("resync: %w (missing events: %s)", ctx.Err(), strings.Join(missing, ", "))
+	}
+}
+
+// setSessionToken records the JWT a login answered with, see Resync.
+func (c *Client) setSessionToken(token string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.sessionToken = token
+}
+
 type ackResponse struct {
 	Msg             string         `json:"msg"`
 	OK              bool           `json:"ok"`
+	Token           string         `json:"token"`
 	ID              int64          `json:"id"`
 	MonitorID       int64          `json:"monitorID"`
 	MaintenanceID   int64          `json:"maintenanceID"`

--- a/client.go
+++ b/client.go
@@ -31,6 +31,28 @@ import (
 // ErrNotFound is returned when a requested resource is not found.
 var ErrNotFound = errors.New("not found")
 
+// ErrUpdateEventTimeout is returned when the server acknowledged a mutating
+// command successfully, but the update event it broadcasts afterwards did not
+// arrive before the context expired. The write landed on the server; what is
+// missing is only the broadcast.
+//
+// An error wrapping ErrUpdateEventTimeout also wraps the context error, so
+// errors.Is(err, context.DeadlineExceeded) keeps reporting the timeout. Use
+// errors.Is(err, ErrUpdateEventTimeout) to tell the two cases apart: a plain
+// context error means the server never confirmed the command and it may or may
+// not have been applied, while ErrUpdateEventTimeout means it was applied.
+//
+// Methods that hand out a server assigned ID return it alongside such an error,
+// so a caller can adopt the created resource instead of retrying and creating a
+// duplicate.
+//
+// The local state cache is refreshed from the update event, so on this path it
+// is not up to date yet. The cache is maintained by the socket.io event
+// handlers and not by the caller's context, so it catches up on its own once
+// the event arrives; if the event is lost for good, the cache stays stale until
+// the next broadcast for that resource.
+var ErrUpdateEventTimeout = errors.New("update event not received")
+
 // Log level constants for configuring socket.io client logging verbosity.
 const (
 	LogLevelDebug = utils.DEBUG
@@ -685,6 +707,15 @@ func (c *Client) syncEmit(ctx context.Context, command string, args ...any) (ack
 	}
 }
 
+// syncEmitWithUpdateEvent emits command and returns once the server has both
+// acknowledged it and broadcast updateEvent, which is what refreshes the local
+// state cache.
+//
+// If the ack reports success but the update event does not arrive before ctx
+// expires, the response is returned together with an error wrapping
+// ErrUpdateEventTimeout and the context error: the command was applied, only
+// the broadcast is missing. Discarding the response here would tell the caller
+// the write failed for a write the server performed.
 func (c *Client) syncEmitWithUpdateEvent(
 	ctx context.Context,
 	command string,
@@ -722,7 +753,22 @@ func (c *Client) syncEmitWithUpdateEvent(
 		return ackResponse{}, fmt.Errorf("%s: %w", command, err)
 	}
 
-	var response ackResponse
+	return awaitAckAndUpdateEvent(ctx, command, done, res)
+}
+
+// awaitAckAndUpdateEvent waits for the ack delivered on res and for the update
+// event that closes done, and reports what arrived before ctx expired.
+func awaitAckAndUpdateEvent(
+	ctx context.Context,
+	command string,
+	done <-chan struct{},
+	res <-chan ackResponse,
+) (ackResponse, error) {
+	var (
+		response ackResponse
+		acked    bool
+	)
+
 	// Ensure, we have received both signals: done and ack
 	// Setting channel to nil blocks forever, thisway we ensure, that
 	// we also receive the second signal.
@@ -736,12 +782,47 @@ func (c *Client) syncEmitWithUpdateEvent(
 				return ackResponse{}, fmt.Errorf("%s: %s", command, response.Msg)
 			}
 
+			acked = true
 			res = nil
 
 		case <-ctx.Done():
-			return ackResponse{}, fmt.Errorf("%s: %w", command, ctx.Err())
+			if !acked {
+				response, acked = pollAck(res)
+			}
+
+			switch {
+			case acked && !response.OK:
+				return ackResponse{}, fmt.Errorf("%s: %s", command, response.Msg)
+
+			case acked:
+				// The server applied the command, only its broadcast is
+				// missing. Returning the response lets the caller keep what
+				// the ack carried, e.g. the ID of a created resource.
+				return response, fmt.Errorf("%s: %w: %w", command, ErrUpdateEventTimeout, ctx.Err())
+
+			default:
+				return ackResponse{}, fmt.Errorf("%s: %w", command, ctx.Err())
+			}
 		}
 	}
 
 	return response, nil
+}
+
+// pollAck takes an ack that has already been delivered, without blocking. The
+// ack and the context deadline can become ready in the same instant, and select
+// picks between ready cases at random, so a delivered ack has to be collected
+// explicitly instead of being lost to that coin flip.
+func pollAck(res <-chan ackResponse) (ackResponse, bool) {
+	if res == nil {
+		return ackResponse{}, false
+	}
+
+	select {
+	case response := <-res:
+		return response, true
+
+	default:
+		return ackResponse{}, false
+	}
 }

--- a/client_ack_test.go
+++ b/client_ack_test.go
@@ -36,6 +36,10 @@ var readyEvents = []string{
 // notification.
 const fakeAckCreatedID = 4242
 
+// fakeSessionToken is the JWT the fake server hands out at login, and the one it
+// expects to see again in a loginByToken.
+const fakeSessionToken = "fake-session-token"
+
 // fakeAckServer is a minimal socket.io server over HTTP long-polling that
 // completes the handshake, CONNECT, login and ready phases, so kuma.New()
 // returns a usable client. Unlike fakeSocketIOServer it then keeps serving:
@@ -50,6 +54,14 @@ type fakeAckServer struct {
 
 	mu       sync.Mutex
 	ackDelay time.Duration
+	// omitLoginToken drops the token from the login ack, as a server that
+	// hands out none would.
+	omitLoginToken bool
+	// suppressLists answers a loginByToken without resending the lists, which
+	// leaves a Resync waiting.
+	suppressLists bool
+	// resyncPayload is the last loginByToken frame received.
+	resyncPayload string
 }
 
 func (s *fakeAckServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -114,6 +126,53 @@ func (s *fakeAckServer) currentAckDelay() time.Duration {
 	return s.ackDelay
 }
 
+func (s *fakeAckServer) setOmitLoginToken(omit bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.omitLoginToken = omit
+}
+
+func (s *fakeAckServer) setSuppressLists(suppress bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.suppressLists = suppress
+}
+
+func (s *fakeAckServer) recordResync(payload string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.resyncPayload = payload
+
+	return !s.suppressLists
+}
+
+func (s *fakeAckServer) lastResyncPayload() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.resyncPayload
+}
+
+func (s *fakeAckServer) loginAck() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.omitLoginToken {
+		return `{"ok":true,"msg":"Logged in successfully."}`
+	}
+
+	return fmt.Sprintf(`{"ok":true,"msg":"Logged in successfully.","token":%q}`, fakeSessionToken)
+}
+
+func (s *fakeAckServer) sendReadyEvents() {
+	for _, event := range readyEvents {
+		s.messages <- []byte(event)
+	}
+}
+
 func (s *fakeAckServer) handleClientMessage(body []byte) {
 	if len(body) < 2 {
 		return
@@ -134,12 +193,21 @@ func (s *fakeAckServer) handleClientMessage(body []byte) {
 		ackID := string(socketIOData[1:i])
 		payload := string(socketIOData[i:])
 
-		if strings.Contains(payload, `"login"`) {
-			s.messages <- fmt.Appendf(nil, `43%s[{"ok":true,"msg":"Logged in successfully."}]`, ackID)
+		// A resync logs in again, which is what makes the server resend the
+		// lists. Checked before "login", which is a prefix of it.
+		if strings.Contains(payload, `"loginByToken"`) {
+			s.messages <- fmt.Appendf(nil, `43%s[{"ok":true}]`, ackID)
 
-			for _, event := range readyEvents {
-				s.messages <- []byte(event)
+			if s.recordResync(payload) {
+				s.sendReadyEvents()
 			}
+
+			return
+		}
+
+		if strings.Contains(payload, `"login"`) {
+			s.messages <- fmt.Appendf(nil, `43%s[%s]`, ackID, s.loginAck())
+			s.sendReadyEvents()
 
 			return
 		}

--- a/client_ack_test.go
+++ b/client_ack_test.go
@@ -311,6 +311,32 @@ func TestUpdateEventTimeoutKeepsSuccessfulAck(t *testing.T) {
 			"the notification exists on the server, so its ID must survive the missing update event")
 	})
 
+	t.Run("the_id_survives_a_caller_that_propagates_only_the_error", func(t *testing.T) {
+		callCtx, callCancel := context.WithTimeout(ctx, callTimeout)
+		defer callCancel()
+
+		// The reflex of every caller is to return the error and nothing else,
+		// which drops the ID that sits next to it. Recovering the error has to
+		// give that ID back, or the created notification is unreachable.
+		_, err := func() (int64, error) {
+			id, err := kumaClient.CreateNotification(callCtx, notification.Generic{
+				Base:           notification.Base{Name: "propagated error"},
+				GenericDetails: notification.GenericDetails{},
+				TypeName:       "generic",
+			})
+			if err != nil {
+				return 0, err
+			}
+
+			return id, nil
+		}()
+
+		var timeoutErr *kuma.UpdateEventTimeoutError
+		require.ErrorAs(t, err, &timeoutErr)
+		require.Equal(t, int64(fakeAckCreatedID), timeoutErr.ID)
+		require.Equal(t, "addNotification", timeoutErr.Command)
+	})
+
 	t.Run("delete_is_distinguishable_from_a_plain_timeout", func(t *testing.T) {
 		callCtx, callCancel := context.WithTimeout(ctx, callTimeout)
 		defer callCancel()

--- a/client_ack_test.go
+++ b/client_ack_test.go
@@ -41,6 +41,10 @@ var readyEvents = []string{
 // It never emits an update event for those commands, so a caller using
 // syncEmitWithUpdateEvent keeps waiting after its ack arrived — the state in
 // which the deadline and the ack collide.
+// fakeAckCreatedID is the ID the fake server reports for a created
+// notification.
+const fakeAckCreatedID = 4242
+
 type fakeAckServer struct {
 	messages chan []byte
 
@@ -140,12 +144,19 @@ func (s *fakeAckServer) handleClientMessage(body []byte) {
 			return
 		}
 
+		// The server assigns the ID of a created resource in the ack, which
+		// is the value a caller loses if a successful ack is discarded.
+		ack := `{"ok":true,"msg":"ok"}`
+		if strings.Contains(payload, `"addNotification"`) {
+			ack = fmt.Sprintf(`{"ok":true,"msg":"ok","id":%d}`, fakeAckCreatedID)
+		}
+
 		// Acknowledge out of band: blocking here would stall the client's
 		// send path instead of only delaying the ack.
 		delay := s.currentAckDelay()
 		go func() {
 			time.Sleep(delay)
-			s.messages <- fmt.Appendf(nil, `43%s[{"ok":true,"msg":"ok"}]`, ackID)
+			s.messages <- fmt.Appendf(nil, `43%s[%s]`, ackID, ack)
 		}()
 
 	default:
@@ -211,6 +222,13 @@ func TestAckDeliveryAroundDeadline(t *testing.T) {
 			err := kumaClient.DeleteNotification(callCtx, 1)
 			callCancel()
 
+			// Both outcomes of the race keep wrapping the context error: the
+			// ack that lost it produces a bare deadline error, the ack that
+			// won it produces ErrUpdateEventTimeout wrapping the same
+			// deadline error. Which one a given delay yields depends on
+			// scheduling, so only the shared part is asserted here;
+			// TestUpdateEventTimeoutKeepsSuccessfulAck pins the ack-wins case
+			// down deterministically.
 			require.ErrorIs(t, err, context.DeadlineExceeded,
 				"ack delay %s should leave the call waiting on its update event", fake.currentAckDelay())
 		}
@@ -239,5 +257,81 @@ func TestAckDeliveryAroundDeadline(t *testing.T) {
 
 			require.Equal(t, "ok", msg)
 		}
+	})
+}
+
+// TestUpdateEventTimeoutKeepsSuccessfulAck covers the case the sweep above can
+// only hit by chance: the server acknowledges the command well before the
+// deadline and never emits the update event that follows it.
+//
+// The command was applied, so reporting a bare context error would tell the
+// caller the write failed for a write the server performed — and for a create,
+// it would also drop the ID the server assigned, leaving a retry to produce a
+// duplicate.
+func TestUpdateEventTimeoutKeepsSuccessfulAck(t *testing.T) {
+	// Long enough that the ack, which the fake sends without delay, always
+	// arrives first; the call then runs into the deadline waiting for the
+	// update event the fake never emits.
+	const callTimeout = 500 * time.Millisecond
+
+	fake := &fakeAckServer{messages: make(chan []byte, 32)}
+	server := httptest.NewServer(fake)
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	t.Cleanup(func() {
+		cancel()
+		server.CloseClientConnections()
+		server.Close()
+	})
+
+	kumaClient, err := kuma.New(
+		ctx,
+		server.URL,
+		"admin", "admin1",
+		kuma.WithConnectTimeout(10*time.Second),
+	)
+	require.NoError(t, err)
+
+	t.Run("create_reports_the_id_the_server_assigned", func(t *testing.T) {
+		callCtx, callCancel := context.WithTimeout(ctx, callTimeout)
+		defer callCancel()
+
+		id, err := kumaClient.CreateNotification(callCtx, notification.Generic{
+			Base:           notification.Base{Name: "update event timeout"},
+			GenericDetails: notification.GenericDetails{},
+			TypeName:       "generic",
+		})
+
+		require.ErrorIs(t, err, kuma.ErrUpdateEventTimeout)
+		require.ErrorIs(t, err, context.DeadlineExceeded,
+			"the sentinel must not hide the timeout from callers matching on it")
+		require.Equal(t, int64(fakeAckCreatedID), id,
+			"the notification exists on the server, so its ID must survive the missing update event")
+	})
+
+	t.Run("delete_is_distinguishable_from_a_plain_timeout", func(t *testing.T) {
+		callCtx, callCancel := context.WithTimeout(ctx, callTimeout)
+		defer callCancel()
+
+		err := kumaClient.DeleteNotification(callCtx, 1)
+
+		require.ErrorIs(t, err, kuma.ErrUpdateEventTimeout)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	})
+
+	t.Run("an_unacknowledged_command_stays_a_plain_timeout", func(t *testing.T) {
+		// No ack at all before the deadline: nothing is known about the write,
+		// so the sentinel must not be reported.
+		fake.setAckDelay(2 * callTimeout)
+		t.Cleanup(func() { fake.setAckDelay(0) })
+
+		callCtx, callCancel := context.WithTimeout(ctx, callTimeout)
+		defer callCancel()
+
+		err := kumaClient.DeleteNotification(callCtx, 1)
+
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.NotErrorIs(t, err, kuma.ErrUpdateEventTimeout,
+			"without an ack the client cannot claim the command was applied")
 	})
 }

--- a/client_ack_test.go
+++ b/client_ack_test.go
@@ -32,6 +32,10 @@ var readyEvents = []string{
 	`42["apiKeyList",[]]`,
 }
 
+// fakeAckCreatedID is the ID the fake server reports for a created
+// notification.
+const fakeAckCreatedID = 4242
+
 // fakeAckServer is a minimal socket.io server over HTTP long-polling that
 // completes the handshake, CONNECT, login and ready phases, so kuma.New()
 // returns a usable client. Unlike fakeSocketIOServer it then keeps serving:
@@ -41,10 +45,6 @@ var readyEvents = []string{
 // It never emits an update event for those commands, so a caller using
 // syncEmitWithUpdateEvent keeps waiting after its ack arrived — the state in
 // which the deadline and the ack collide.
-// fakeAckCreatedID is the ID the fake server reports for a created
-// notification.
-const fakeAckCreatedID = 4242
-
 type fakeAckServer struct {
 	messages chan []byte
 
@@ -227,8 +227,8 @@ func TestAckDeliveryAroundDeadline(t *testing.T) {
 			// won it produces ErrUpdateEventTimeout wrapping the same
 			// deadline error. Which one a given delay yields depends on
 			// scheduling, so only the shared part is asserted here;
-			// TestUpdateEventTimeoutKeepsSuccessfulAck pins the ack-wins case
-			// down deterministically.
+			// TestAwaitAckAndUpdateEvent pins the ack-wins case down
+			// deterministically.
 			require.ErrorIs(t, err, context.DeadlineExceeded,
 				"ack delay %s should leave the call waiting on its update event", fake.currentAckDelay())
 		}
@@ -269,9 +269,11 @@ func TestAckDeliveryAroundDeadline(t *testing.T) {
 // it would also drop the ID the server assigned, leaving a retry to produce a
 // duplicate.
 func TestUpdateEventTimeoutKeepsSuccessfulAck(t *testing.T) {
-	// Long enough that the ack, which the fake sends without delay, always
+	// Long enough that the ack, which the fake sends without delay, reliably
 	// arrives first; the call then runs into the deadline waiting for the
-	// update event the fake never emits.
+	// update event the fake never emits. It travels over HTTP long-polling, so
+	// this is a generous margin rather than a guarantee: raise callTimeout if
+	// a loaded machine ever makes it flake.
 	const callTimeout = 500 * time.Millisecond
 
 	fake := &fakeAckServer{messages: make(chan []byte, 32)}

--- a/client_await_test.go
+++ b/client_await_test.go
@@ -1,0 +1,174 @@
+package kuma
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// awaitIterations is how often each case below is repeated. A channel that is
+// ready and a context that is done are both ready in the same select, and
+// select picks between ready cases at random, so a single run would pass for
+// the wrong reason about half the time.
+const awaitIterations = 100
+
+// awaitSignals describes which signals are already delivered when
+// awaitAckAndUpdateEvent is entered.
+type awaitSignals struct {
+	// ack is placed in the buffered ack channel if it is not nil.
+	ack *ackResponse
+	// updateEvent closes the channel the update event handler closes.
+	updateEvent bool
+}
+
+// awaitWith drives awaitAckAndUpdateEvent with the signals already in the state
+// the case under test describes.
+func awaitWith(ctx context.Context, signals awaitSignals) (ackResponse, error) {
+	res := make(chan ackResponse, 1)
+	if signals.ack != nil {
+		res <- *signals.ack
+	}
+
+	done := make(chan struct{})
+	if signals.updateEvent {
+		close(done)
+	}
+
+	return awaitAckAndUpdateEvent(ctx, "addNotification", done, res)
+}
+
+func expiredContext(t *testing.T) context.Context {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Nanosecond)
+	t.Cleanup(cancel)
+
+	<-ctx.Done()
+
+	return ctx
+}
+
+func canceledContext(t *testing.T) context.Context {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	cancel()
+
+	return ctx
+}
+
+// TestAwaitAckAndUpdateEvent pins down what awaitAckAndUpdateEvent reports for
+// every combination of signals that can be pending when the context is done.
+// The socket level tests cannot do this: they depend on the ack and the
+// deadline landing in a particular order on the wire, so the collision that
+// matters here is only reached by chance.
+func TestAwaitAckAndUpdateEvent(t *testing.T) {
+	t.Parallel()
+
+	okAck := ackResponse{OK: true, Msg: "ok", ID: 4242}
+	rejectedAck := ackResponse{OK: false, Msg: "boom"}
+
+	t.Run("both_signals_arrive_before_the_context_is_done", func(t *testing.T) {
+		t.Parallel()
+
+		for range awaitIterations {
+			response, err := awaitWith(t.Context(), awaitSignals{ack: &okAck, updateEvent: true})
+
+			require.NoError(t, err)
+			require.Equal(t, okAck, response)
+		}
+	})
+
+	t.Run("both_signals_are_ready_when_the_deadline_expires", func(t *testing.T) {
+		t.Parallel()
+
+		// Uptime Kuma broadcasts the list before it invokes the ack callback,
+		// so this ordering is the common one, not an exotic one. Nothing is
+		// missing here, and reporting ErrUpdateEventTimeout would claim a
+		// stale cache for a call that completed.
+		ctx := expiredContext(t)
+
+		for range awaitIterations {
+			response, err := awaitWith(ctx, awaitSignals{ack: &okAck, updateEvent: true})
+
+			require.NoError(t, err)
+			require.Equal(t, okAck, response)
+		}
+	})
+
+	t.Run("update_event_missing_after_the_deadline", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := expiredContext(t)
+
+		for range awaitIterations {
+			response, err := awaitWith(ctx, awaitSignals{ack: &okAck})
+
+			require.ErrorIs(t, err, ErrUpdateEventTimeout)
+			require.ErrorIs(t, err, context.DeadlineExceeded,
+				"the sentinel must not hide the deadline from callers matching on it")
+			require.Equal(t, okAck, response,
+				"the ack is what carries the ID of a created resource")
+		}
+	})
+
+	t.Run("update_event_missing_after_cancellation", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := canceledContext(t)
+
+		for range awaitIterations {
+			_, err := awaitWith(ctx, awaitSignals{ack: &okAck})
+
+			require.ErrorIs(t, err, ErrUpdateEventTimeout)
+			require.ErrorIs(t, err, context.Canceled)
+		}
+	})
+
+	t.Run("rejected_ack_at_the_deadline_reports_the_server_error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := expiredContext(t)
+
+		for range awaitIterations {
+			response, err := awaitWith(ctx, awaitSignals{ack: &rejectedAck})
+
+			require.EqualError(t, err, "addNotification: boom")
+			require.NotErrorIs(t, err, ErrUpdateEventTimeout,
+				"the server rejected the command, so nothing was applied")
+			require.Equal(t, ackResponse{}, response)
+		}
+	})
+
+	t.Run("update_event_without_an_ack_stays_a_plain_timeout", func(t *testing.T) {
+		t.Parallel()
+
+		// The broadcast alone says something changed, but not what the server
+		// made of this command and not which ID it assigned.
+		ctx := expiredContext(t)
+
+		for range awaitIterations {
+			_, err := awaitWith(ctx, awaitSignals{updateEvent: true})
+
+			require.ErrorIs(t, err, context.DeadlineExceeded)
+			require.NotErrorIs(t, err, ErrUpdateEventTimeout)
+		}
+	})
+
+	t.Run("no_signal_at_all_stays_a_plain_timeout", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := expiredContext(t)
+
+		for range awaitIterations {
+			_, err := awaitWith(ctx, awaitSignals{})
+
+			require.ErrorIs(t, err, context.DeadlineExceeded)
+			require.NotErrorIs(t, err, ErrUpdateEventTimeout)
+		}
+	})
+}

--- a/client_await_test.go
+++ b/client_await_test.go
@@ -116,6 +116,24 @@ func TestAwaitAckAndUpdateEvent(t *testing.T) {
 		}
 	})
 
+	t.Run("the_error_carries_the_command_and_keeps_its_message", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := expiredContext(t)
+
+		for range awaitIterations {
+			_, err := awaitWith(ctx, awaitSignals{ack: &okAck})
+
+			var timeoutErr *UpdateEventTimeoutError
+			require.ErrorAs(t, err, &timeoutErr)
+			require.Equal(t, "addNotification", timeoutErr.Command)
+			require.Zero(t, timeoutErr.ID,
+				"the ID is filled in by the layer that knows which field of the ack carries it")
+			require.EqualError(t, err,
+				"addNotification: update event not received: context deadline exceeded")
+		}
+	})
+
 	t.Run("update_event_missing_after_cancellation", func(t *testing.T) {
 		t.Parallel()
 

--- a/client_resync_test.go
+++ b/client_resync_test.go
@@ -1,0 +1,120 @@
+package kuma_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	kuma "github.com/breml/go-uptime-kuma-client"
+	"github.com/breml/go-uptime-kuma-client/notification"
+)
+
+// newFakeAckClient connects a client to fake and returns it, with the server and
+// the connection torn down when the test ends.
+func newFakeAckClient(t *testing.T, fake *fakeAckServer) *kuma.Client {
+	t.Helper()
+
+	server := httptest.NewServer(fake)
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	t.Cleanup(func() {
+		cancel()
+		server.CloseClientConnections()
+		server.Close()
+	})
+
+	kumaClient, err := kuma.New(
+		ctx,
+		server.URL,
+		"admin", "admin1",
+		kuma.WithConnectTimeout(10*time.Second),
+	)
+	require.NoError(t, err)
+
+	return kumaClient
+}
+
+// TestResync covers the way out of the stale cache an ErrUpdateEventTimeout
+// leaves behind. The server has no command to re-request a single list, so
+// Resync logs in again with the token from the initial login and waits for the
+// lists that answers with.
+func TestResync(t *testing.T) {
+	t.Run("logs_in_again_with_the_token_from_the_first_login", func(t *testing.T) {
+		fake := &fakeAckServer{messages: make(chan []byte, 32)}
+		kumaClient := newFakeAckClient(t, fake)
+
+		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+		defer cancel()
+
+		require.NoError(t, kumaClient.Resync(ctx))
+		require.Contains(t, fake.lastResyncPayload(), fakeSessionToken,
+			"the resync has to present the session the server handed out")
+	})
+
+	t.Run("waits_for_the_lists_and_names_the_ones_that_did_not_arrive", func(t *testing.T) {
+		fake := &fakeAckServer{messages: make(chan []byte, 32)}
+		kumaClient := newFakeAckClient(t, fake)
+
+		// A server that acknowledges the login without resending the lists
+		// leaves the cache exactly as stale as it was.
+		fake.setSuppressLists(true)
+
+		ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
+		defer cancel()
+
+		err := kumaClient.Resync(ctx)
+
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.ErrorContains(t, err, "notificationList")
+		require.ErrorContains(t, err, "proxyList")
+	})
+
+	t.Run("without_a_session_token_it_reports_that_instead_of_hanging", func(t *testing.T) {
+		fake := &fakeAckServer{messages: make(chan []byte, 32)}
+		fake.setOmitLoginToken(true)
+
+		kumaClient := newFakeAckClient(t, fake)
+
+		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+		defer cancel()
+
+		err := kumaClient.Resync(ctx)
+
+		require.ErrorContains(t, err, "no session token")
+		require.Empty(t, fake.lastResyncPayload(),
+			"without a token there is nothing to log in with, so nothing is emitted")
+	})
+}
+
+// TestResyncAgainstServer runs the resync against a real Uptime Kuma instance,
+// which is what proves the token is the one loginByToken accepts.
+func TestResyncAgainstServer(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	id, err := client.CreateNotification(ctx, notification.Generic{
+		Base:           notification.Base{Name: "resync"},
+		GenericDetails: notification.GenericDetails{},
+		TypeName:       "generic",
+	})
+	require.NoError(t, err)
+
+	// Deferred rather than registered with t.Cleanup, which runs once
+	// t.Context() is already cancelled.
+	defer func() {
+		require.NoError(t, client.DeleteNotification(ctx, id))
+	}()
+
+	require.NoError(t, client.Resync(ctx))
+
+	notif, err := client.GetNotification(ctx, id)
+	require.NoError(t, err, "the resync has to leave the cache complete, not empty")
+	require.Equal(t, id, notif.GetID())
+}

--- a/dockerhost.go
+++ b/dockerhost.go
@@ -34,9 +34,16 @@ func (c *Client) GetDockerHost(_ context.Context, id int64) (*dockerhost.DockerH
 }
 
 // CreateDockerHost creates a new Docker host and returns its ID.
+//
+// If the returned error wraps ErrUpdateEventTimeout, the Docker host was created
+// and the returned ID identifies it; retrying the call would create a duplicate.
 func (c *Client) CreateDockerHost(ctx context.Context, config dockerhost.Config) (int64, error) {
 	response, err := c.syncEmitWithUpdateEvent(ctx, "addDockerHost", "dockerHostList", config, nil)
 	if err != nil {
+		if errors.Is(err, ErrUpdateEventTimeout) {
+			return response.ID, fmt.Errorf("create docker host: %w", err)
+		}
+
 		return 0, fmt.Errorf("create docker host: %w", err)
 	}
 

--- a/dockerhost.go
+++ b/dockerhost.go
@@ -35,8 +35,9 @@ func (c *Client) GetDockerHost(_ context.Context, id int64) (*dockerhost.DockerH
 
 // CreateDockerHost creates a new Docker host and returns its ID.
 //
-// If the returned error wraps ErrUpdateEventTimeout, the Docker host was created
-// and the returned ID identifies it; retrying the call would create a duplicate.
+// An error wrapping ErrUpdateEventTimeout means the Docker host was created and
+// only the update event is missing; the returned ID identifies it, so retrying
+// the call would create a duplicate.
 func (c *Client) CreateDockerHost(ctx context.Context, config dockerhost.Config) (int64, error) {
 	response, err := c.syncEmitWithUpdateEvent(ctx, "addDockerHost", "dockerHostList", config, nil)
 	if err != nil {
@@ -51,6 +52,9 @@ func (c *Client) CreateDockerHost(ctx context.Context, config dockerhost.Config)
 }
 
 // UpdateDockerHost updates an existing Docker host.
+//
+// An error wrapping ErrUpdateEventTimeout means the Docker host was updated and
+// only the update event is missing.
 func (c *Client) UpdateDockerHost(ctx context.Context, config dockerhost.Config) error {
 	if config.ID == 0 {
 		return errors.New("update docker host: config must have ID set")
@@ -65,6 +69,9 @@ func (c *Client) UpdateDockerHost(ctx context.Context, config dockerhost.Config)
 }
 
 // DeleteDockerHost deletes a Docker host by ID.
+//
+// An error wrapping ErrUpdateEventTimeout means the Docker host was deleted and
+// only the update event is missing.
 func (c *Client) DeleteDockerHost(ctx context.Context, id int64) error {
 	_, err := c.syncEmitWithUpdateEvent(ctx, "deleteDockerHost", "dockerHostList", id)
 	if err != nil {

--- a/dockerhost.go
+++ b/dockerhost.go
@@ -36,13 +36,14 @@ func (c *Client) GetDockerHost(_ context.Context, id int64) (*dockerhost.DockerH
 // CreateDockerHost creates a new Docker host and returns its ID.
 //
 // An error wrapping ErrUpdateEventTimeout means the Docker host was created and
-// only the update event is missing; the returned ID identifies it, so retrying
-// the call would create a duplicate.
+// only the update event is missing; the returned ID identifies it, as does the
+// ID an UpdateEventTimeoutError carries, so retrying the call would create a
+// duplicate.
 func (c *Client) CreateDockerHost(ctx context.Context, config dockerhost.Config) (int64, error) {
 	response, err := c.syncEmitWithUpdateEvent(ctx, "addDockerHost", "dockerHostList", config, nil)
 	if err != nil {
 		if errors.Is(err, ErrUpdateEventTimeout) {
-			return response.ID, fmt.Errorf("create docker host: %w", err)
+			return response.ID, fmt.Errorf("create docker host: %w", withCreatedID(err, response.ID))
 		}
 
 		return 0, fmt.Errorf("create docker host: %w", err)

--- a/maintenance.go
+++ b/maintenance.go
@@ -47,7 +47,8 @@ func (c *Client) GetMaintenance(ctx context.Context, id int64) (*maintenance.Mai
 // CreateMaintenance creates a new maintenance window.
 //
 // An error wrapping ErrUpdateEventTimeout means the maintenance window was
-// created and only the update event is missing; retrying the call would create a
+// created and only the update event is missing; m.ID identifies it, as does the
+// ID an UpdateEventTimeoutError carries, so retrying the call would create a
 // duplicate. The context is spent at that point, so the complete object cannot
 // be fetched back: the returned value is m itself, carrying what the caller
 // passed in plus the ID the server assigned.
@@ -62,7 +63,7 @@ func (c *Client) CreateMaintenance(ctx context.Context, m *maintenance.Maintenan
 		if errors.Is(err, ErrUpdateEventTimeout) {
 			m.ID = response.MaintenanceID
 
-			return m, fmt.Errorf("create maintenance: %w", err)
+			return m, fmt.Errorf("create maintenance: %w", withCreatedID(err, response.MaintenanceID))
 		}
 
 		return nil, fmt.Errorf("create maintenance: %w", err)

--- a/maintenance.go
+++ b/maintenance.go
@@ -46,11 +46,11 @@ func (c *Client) GetMaintenance(ctx context.Context, id int64) (*maintenance.Mai
 
 // CreateMaintenance creates a new maintenance window.
 //
-// If the returned error wraps ErrUpdateEventTimeout, the maintenance window was
-// created and m.ID identifies it; the context is spent at that point, so the
-// complete object cannot be fetched back and the returned value carries only
-// what the caller passed in plus the ID. Retrying the call would create a
-// duplicate.
+// An error wrapping ErrUpdateEventTimeout means the maintenance window was
+// created and only the update event is missing; retrying the call would create a
+// duplicate. The context is spent at that point, so the complete object cannot
+// be fetched back: the returned value is m itself, carrying what the caller
+// passed in plus the ID the server assigned.
 func (c *Client) CreateMaintenance(ctx context.Context, m *maintenance.Maintenance) (*maintenance.Maintenance, error) {
 	maintenanceData, err := structToMap(m)
 	if err != nil {
@@ -76,6 +76,9 @@ func (c *Client) CreateMaintenance(ctx context.Context, m *maintenance.Maintenan
 }
 
 // UpdateMaintenance updates an existing maintenance window.
+//
+// An error wrapping ErrUpdateEventTimeout means the maintenance window was
+// updated and only the update event is missing.
 func (c *Client) UpdateMaintenance(ctx context.Context, m *maintenance.Maintenance) error {
 	maintenanceData, err := structToMap(m)
 	if err != nil {
@@ -91,6 +94,9 @@ func (c *Client) UpdateMaintenance(ctx context.Context, m *maintenance.Maintenan
 }
 
 // DeleteMaintenance deletes a maintenance window by ID.
+//
+// An error wrapping ErrUpdateEventTimeout means the maintenance window was
+// deleted and only the update event is missing.
 func (c *Client) DeleteMaintenance(ctx context.Context, id int64) error {
 	_, err := c.syncEmitWithUpdateEvent(ctx, "deleteMaintenance", "maintenanceList", id)
 	if err != nil {
@@ -101,6 +107,9 @@ func (c *Client) DeleteMaintenance(ctx context.Context, id int64) error {
 }
 
 // PauseMaintenance pauses (deactivates) a maintenance window.
+//
+// An error wrapping ErrUpdateEventTimeout means the maintenance window was
+// paused and only the update event is missing.
 func (c *Client) PauseMaintenance(ctx context.Context, id int64) error {
 	_, err := c.syncEmitWithUpdateEvent(ctx, "pauseMaintenance", "maintenanceList", id)
 	if err != nil {
@@ -111,6 +120,9 @@ func (c *Client) PauseMaintenance(ctx context.Context, id int64) error {
 }
 
 // ResumeMaintenance resumes (activates) a maintenance window.
+//
+// An error wrapping ErrUpdateEventTimeout means the maintenance window was
+// resumed and only the update event is missing.
 func (c *Client) ResumeMaintenance(ctx context.Context, id int64) error {
 	_, err := c.syncEmitWithUpdateEvent(ctx, "resumeMaintenance", "maintenanceList", id)
 	if err != nil {

--- a/maintenance.go
+++ b/maintenance.go
@@ -2,6 +2,7 @@ package kuma
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/breml/go-uptime-kuma-client/maintenance"
@@ -44,6 +45,12 @@ func (c *Client) GetMaintenance(ctx context.Context, id int64) (*maintenance.Mai
 }
 
 // CreateMaintenance creates a new maintenance window.
+//
+// If the returned error wraps ErrUpdateEventTimeout, the maintenance window was
+// created and m.ID identifies it; the context is spent at that point, so the
+// complete object cannot be fetched back and the returned value carries only
+// what the caller passed in plus the ID. Retrying the call would create a
+// duplicate.
 func (c *Client) CreateMaintenance(ctx context.Context, m *maintenance.Maintenance) (*maintenance.Maintenance, error) {
 	maintenanceData, err := structToMap(m)
 	if err != nil {
@@ -52,6 +59,12 @@ func (c *Client) CreateMaintenance(ctx context.Context, m *maintenance.Maintenan
 
 	response, err := c.syncEmitWithUpdateEvent(ctx, "addMaintenance", "maintenanceList", maintenanceData)
 	if err != nil {
+		if errors.Is(err, ErrUpdateEventTimeout) {
+			m.ID = response.MaintenanceID
+
+			return m, fmt.Errorf("create maintenance: %w", err)
+		}
+
 		return nil, fmt.Errorf("create maintenance: %w", err)
 	}
 

--- a/monitor.go
+++ b/monitor.go
@@ -62,6 +62,9 @@ func (c *Client) GetMonitorAs(ctx context.Context, monitorID int64, target any) 
 }
 
 // CreateMonitor creates a new monitor.
+//
+// If the returned error wraps ErrUpdateEventTimeout, the monitor was created and
+// the returned ID identifies it; retrying the call would create a duplicate.
 func (c *Client) CreateMonitor(ctx context.Context, mon monitor.Monitor) (int64, error) {
 	monitorData, err := structToMap(mon)
 	if err != nil {
@@ -78,6 +81,10 @@ func (c *Client) CreateMonitor(ctx context.Context, mon monitor.Monitor) (int64,
 
 	response, err := c.syncEmitWithUpdateEvent(ctx, "add", "updateMonitorIntoList", monitorData)
 	if err != nil {
+		if errors.Is(err, ErrUpdateEventTimeout) {
+			return response.MonitorID, fmt.Errorf("create monitor: %w", err)
+		}
+
 		return 0, fmt.Errorf("create monitor: %w", err)
 	}
 

--- a/monitor.go
+++ b/monitor.go
@@ -64,8 +64,9 @@ func (c *Client) GetMonitorAs(ctx context.Context, monitorID int64, target any) 
 // CreateMonitor creates a new monitor.
 //
 // An error wrapping ErrUpdateEventTimeout means the monitor was created and only
-// the update event is missing; the returned ID identifies it, so retrying the
-// call would create a duplicate.
+// the update event is missing; the returned ID identifies it, as does the ID an
+// UpdateEventTimeoutError carries, so retrying the call would create a
+// duplicate.
 func (c *Client) CreateMonitor(ctx context.Context, mon monitor.Monitor) (int64, error) {
 	monitorData, err := structToMap(mon)
 	if err != nil {
@@ -83,7 +84,7 @@ func (c *Client) CreateMonitor(ctx context.Context, mon monitor.Monitor) (int64,
 	response, err := c.syncEmitWithUpdateEvent(ctx, "add", "updateMonitorIntoList", monitorData)
 	if err != nil {
 		if errors.Is(err, ErrUpdateEventTimeout) {
-			return response.MonitorID, fmt.Errorf("create monitor: %w", err)
+			return response.MonitorID, fmt.Errorf("create monitor: %w", withCreatedID(err, response.MonitorID))
 		}
 
 		return 0, fmt.Errorf("create monitor: %w", err)

--- a/monitor.go
+++ b/monitor.go
@@ -63,8 +63,9 @@ func (c *Client) GetMonitorAs(ctx context.Context, monitorID int64, target any) 
 
 // CreateMonitor creates a new monitor.
 //
-// If the returned error wraps ErrUpdateEventTimeout, the monitor was created and
-// the returned ID identifies it; retrying the call would create a duplicate.
+// An error wrapping ErrUpdateEventTimeout means the monitor was created and only
+// the update event is missing; the returned ID identifies it, so retrying the
+// call would create a duplicate.
 func (c *Client) CreateMonitor(ctx context.Context, mon monitor.Monitor) (int64, error) {
 	monitorData, err := structToMap(mon)
 	if err != nil {
@@ -97,6 +98,9 @@ func (c *Client) CreateMonitor(ctx context.Context, mon monitor.Monitor) (int64,
 }
 
 // UpdateMonitor updates an existing monitor.
+//
+// An error wrapping ErrUpdateEventTimeout means the monitor was updated and only
+// the update event is missing.
 func (c *Client) UpdateMonitor(ctx context.Context, mon monitor.Monitor) error {
 	monitorData, err := structToMap(mon)
 	if err != nil {
@@ -120,6 +124,9 @@ func (c *Client) UpdateMonitor(ctx context.Context, mon monitor.Monitor) error {
 }
 
 // DeleteMonitor deletes a monitor by ID.
+//
+// An error wrapping ErrUpdateEventTimeout means the monitor was deleted and only
+// the update event is missing.
 func (c *Client) DeleteMonitor(ctx context.Context, monitorID int64) error {
 	_, err := c.syncEmitWithUpdateEvent(ctx, "deleteMonitor", "deleteMonitorFromList", monitorID)
 	if err != nil {
@@ -130,6 +137,9 @@ func (c *Client) DeleteMonitor(ctx context.Context, monitorID int64) error {
 }
 
 // PauseMonitor pauses a monitor by ID.
+//
+// An error wrapping ErrUpdateEventTimeout means the monitor was paused and only
+// the update event is missing.
 func (c *Client) PauseMonitor(ctx context.Context, monitorID int64) error {
 	_, err := c.syncEmitWithUpdateEvent(ctx, "pauseMonitor", "updateMonitorIntoList", monitorID)
 	if err != nil {
@@ -140,6 +150,9 @@ func (c *Client) PauseMonitor(ctx context.Context, monitorID int64) error {
 }
 
 // ResumeMonitor resumes a monitor by ID.
+//
+// An error wrapping ErrUpdateEventTimeout means the monitor was resumed and only
+// the update event is missing.
 func (c *Client) ResumeMonitor(ctx context.Context, monitorID int64) error {
 	_, err := c.syncEmitWithUpdateEvent(ctx, "resumeMonitor", "updateMonitorIntoList", monitorID)
 	if err != nil {

--- a/monitor_test.go
+++ b/monitor_test.go
@@ -1,4 +1,3 @@
-//nolint:revive // Large test file with comprehensive test cases for all monitor types
 package kuma_test
 
 import (

--- a/notification.go
+++ b/notification.go
@@ -52,13 +52,14 @@ func (c *Client) GetNotificationAs(ctx context.Context, id int64, target any) er
 // CreateNotification creates a new notification.
 //
 // An error wrapping ErrUpdateEventTimeout means the notification was created and
-// only the update event is missing; the returned ID identifies it, so retrying
-// the call would create a duplicate.
+// only the update event is missing; the returned ID identifies it, as does the
+// ID an UpdateEventTimeoutError carries, so retrying the call would create a
+// duplicate.
 func (c *Client) CreateNotification(ctx context.Context, notif notification.Notification) (int64, error) {
 	response, err := c.syncEmitWithUpdateEvent(ctx, "addNotification", "notificationList", notif, nil)
 	if err != nil {
 		if errors.Is(err, ErrUpdateEventTimeout) {
-			return response.ID, err
+			return response.ID, withCreatedID(err, response.ID)
 		}
 
 		return 0, err

--- a/notification.go
+++ b/notification.go
@@ -10,6 +10,10 @@ import (
 )
 
 // GetNotifications returns all notifications for the authenticated user.
+//
+// They are served from the local state cache, which the server keeps up to
+// date. Resync rebuilds it if an update event was missed, see
+// ErrUpdateEventTimeout.
 func (c *Client) GetNotifications(_ context.Context) []notification.Base {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -20,7 +24,9 @@ func (c *Client) GetNotifications(_ context.Context) []notification.Base {
 	return notifications
 }
 
-// GetNotification returns a specific notification by ID.
+// GetNotification returns a specific notification by ID. Like GetNotifications
+// it serves from the local state cache, so a notification whose update event
+// was missed is reported as ErrNotFound until Resync.
 func (c *Client) GetNotification(_ context.Context, id int64) (notification.Base, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/notification.go
+++ b/notification.go
@@ -50,9 +50,17 @@ func (c *Client) GetNotificationAs(ctx context.Context, id int64, target any) er
 }
 
 // CreateNotification creates a new notification.
+//
+// If the returned error wraps ErrUpdateEventTimeout, the notification was
+// created and the returned ID identifies it; retrying the call would create a
+// duplicate.
 func (c *Client) CreateNotification(ctx context.Context, notif notification.Notification) (int64, error) {
 	response, err := c.syncEmitWithUpdateEvent(ctx, "addNotification", "notificationList", notif, nil)
 	if err != nil {
+		if errors.Is(err, ErrUpdateEventTimeout) {
+			return response.ID, err
+		}
+
 		return 0, err
 	}
 

--- a/notification.go
+++ b/notification.go
@@ -51,9 +51,9 @@ func (c *Client) GetNotificationAs(ctx context.Context, id int64, target any) er
 
 // CreateNotification creates a new notification.
 //
-// If the returned error wraps ErrUpdateEventTimeout, the notification was
-// created and the returned ID identifies it; retrying the call would create a
-// duplicate.
+// An error wrapping ErrUpdateEventTimeout means the notification was created and
+// only the update event is missing; the returned ID identifies it, so retrying
+// the call would create a duplicate.
 func (c *Client) CreateNotification(ctx context.Context, notif notification.Notification) (int64, error) {
 	response, err := c.syncEmitWithUpdateEvent(ctx, "addNotification", "notificationList", notif, nil)
 	if err != nil {
@@ -68,12 +68,18 @@ func (c *Client) CreateNotification(ctx context.Context, notif notification.Noti
 }
 
 // UpdateNotification updates an existing notification.
+//
+// An error wrapping ErrUpdateEventTimeout means the notification was updated and
+// only the update event is missing.
 func (c *Client) UpdateNotification(ctx context.Context, notif notification.Notification) error {
 	_, err := c.syncEmitWithUpdateEvent(ctx, "addNotification", "notificationList", notif, notif.GetID())
 	return err
 }
 
 // DeleteNotification deletes a notification by ID.
+//
+// An error wrapping ErrUpdateEventTimeout means the notification was deleted and
+// only the update event is missing.
 func (c *Client) DeleteNotification(ctx context.Context, id int64) error {
 	_, err := c.syncEmitWithUpdateEvent(ctx, "deleteNotification", "notificationList", id)
 	return err

--- a/notification_test.go
+++ b/notification_test.go
@@ -1,4 +1,3 @@
-//nolint:revive // Large test file with comprehensive test cases for all notification types
 package kuma_test
 
 import (

--- a/proxy.go
+++ b/proxy.go
@@ -34,9 +34,16 @@ func (c *Client) GetProxy(_ context.Context, id int64) (*proxy.Proxy, error) {
 }
 
 // CreateProxy creates a new proxy.
+//
+// If the returned error wraps ErrUpdateEventTimeout, the proxy was created and
+// the returned ID identifies it; retrying the call would create a duplicate.
 func (c *Client) CreateProxy(ctx context.Context, config proxy.Config) (int64, error) {
 	response, err := c.syncEmitWithUpdateEvent(ctx, "addProxy", "proxyList", config, nil)
 	if err != nil {
+		if errors.Is(err, ErrUpdateEventTimeout) {
+			return response.ID, fmt.Errorf("create proxy: %w", err)
+		}
+
 		return 0, fmt.Errorf("create proxy: %w", err)
 	}
 

--- a/proxy.go
+++ b/proxy.go
@@ -35,8 +35,9 @@ func (c *Client) GetProxy(_ context.Context, id int64) (*proxy.Proxy, error) {
 
 // CreateProxy creates a new proxy.
 //
-// If the returned error wraps ErrUpdateEventTimeout, the proxy was created and
-// the returned ID identifies it; retrying the call would create a duplicate.
+// An error wrapping ErrUpdateEventTimeout means the proxy was created and only
+// the update event is missing; the returned ID identifies it, so retrying the
+// call would create a duplicate.
 func (c *Client) CreateProxy(ctx context.Context, config proxy.Config) (int64, error) {
 	response, err := c.syncEmitWithUpdateEvent(ctx, "addProxy", "proxyList", config, nil)
 	if err != nil {
@@ -51,6 +52,9 @@ func (c *Client) CreateProxy(ctx context.Context, config proxy.Config) (int64, e
 }
 
 // UpdateProxy updates an existing proxy.
+//
+// An error wrapping ErrUpdateEventTimeout means the proxy was updated and only
+// the update event is missing.
 func (c *Client) UpdateProxy(ctx context.Context, config proxy.Config) error {
 	if config.ID == 0 {
 		return errors.New("update proxy: config must have ID set")
@@ -65,6 +69,9 @@ func (c *Client) UpdateProxy(ctx context.Context, config proxy.Config) error {
 }
 
 // DeleteProxy deletes a proxy by ID.
+//
+// An error wrapping ErrUpdateEventTimeout means the proxy was deleted and only
+// the update event is missing.
 func (c *Client) DeleteProxy(ctx context.Context, id int64) error {
 	_, err := c.syncEmitWithUpdateEvent(ctx, "deleteProxy", "proxyList", id)
 	if err != nil {

--- a/proxy.go
+++ b/proxy.go
@@ -9,6 +9,10 @@ import (
 )
 
 // GetProxyList returns all proxies for the authenticated user.
+//
+// They are served from the local state cache, which the server keeps up to
+// date. Resync rebuilds it if an update event was missed, see
+// ErrUpdateEventTimeout.
 func (c *Client) GetProxyList(_ context.Context) []proxy.Proxy {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -19,7 +23,9 @@ func (c *Client) GetProxyList(_ context.Context) []proxy.Proxy {
 	return proxies
 }
 
-// GetProxy returns a specific proxy by ID.
+// GetProxy returns a specific proxy by ID. Like GetProxyList it serves from the
+// local state cache, so a proxy whose update event was missed is reported as
+// ErrNotFound until Resync.
 func (c *Client) GetProxy(_ context.Context, id int64) (*proxy.Proxy, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/proxy.go
+++ b/proxy.go
@@ -36,13 +36,14 @@ func (c *Client) GetProxy(_ context.Context, id int64) (*proxy.Proxy, error) {
 // CreateProxy creates a new proxy.
 //
 // An error wrapping ErrUpdateEventTimeout means the proxy was created and only
-// the update event is missing; the returned ID identifies it, so retrying the
-// call would create a duplicate.
+// the update event is missing; the returned ID identifies it, as does the ID an
+// UpdateEventTimeoutError carries, so retrying the call would create a
+// duplicate.
 func (c *Client) CreateProxy(ctx context.Context, config proxy.Config) (int64, error) {
 	response, err := c.syncEmitWithUpdateEvent(ctx, "addProxy", "proxyList", config, nil)
 	if err != nil {
 		if errors.Is(err, ErrUpdateEventTimeout) {
-			return response.ID, fmt.Errorf("create proxy: %w", err)
+			return response.ID, fmt.Errorf("create proxy: %w", withCreatedID(err, response.ID))
 		}
 
 		return 0, fmt.Errorf("create proxy: %w", err)


### PR DESCRIPTION
## Problem

`Client.syncEmitWithUpdateEvent` waits for two independent signals: the
ack for the emitted command and the update event the server broadcasts
for it. Once the ack was consumed the loop waited only for the update
event, and a context expiry there returned a zero `ackResponse` plus a
bare context error — throwing away a reply that reported success.

Every mutating method in the library goes through this function, so the
caller was told the operation failed for an operation the server actually
performed. The worst case was `CreateNotification`, which returned
`(0, err)` for a notification that exists on the server, leaving a
retrying caller to create a duplicate.

A second, smaller case: when a signal and the deadline become ready in
the same instant, `select` picks between ready cases at random, so a
fully successful operation could be reported as an error.

## Changes

- Before giving up on `ctx.Done()`, collect both signals that are already
  delivered — the ack *and* the update event. Uptime Kuma broadcasts the
  list before it invokes the ack callback, so an operation that has
  received both and only lost the `select` coin flip is a plain success,
  not a timeout.
- Add the `ErrUpdateEventTimeout` sentinel. When the ack reported success
  and no update event arrived, the response is returned together with an
  error wrapping `ErrUpdateEventTimeout` **and** the context error, so
  callers can tell "the command failed" from "the command was applied but
  its broadcast never arrived" while `errors.Is(err, ctx.Err())` keeps
  working. No signature changes.
- `CreateMonitor`, `CreateNotification`, `CreateProxy`,
  `CreateDockerHost` and `CreateMaintenance` now report the ID the server
  assigned alongside such an error, so the created resource can be
  adopted instead of recreated.
- That ID is also carried by the error itself. `UpdateEventTimeoutError`
  wraps `ErrUpdateEventTimeout` and the context error and holds the
  command and the assigned ID, so the idiomatic `return 0, err` no longer
  loses the only handle on a resource the server created:

  ```go
  var timeoutErr *kuma.UpdateEventTimeoutError
  if errors.As(err, &timeoutErr) && timeoutErr.ID != 0 {
      // The resource exists, adopt it instead of creating it again.
  }
  ```
- A rejected ack (`ok:false`) that collides with the deadline reports the
  server's rejection, which is what the caller would have received had
  the ack arrived a moment earlier. An update event without an ack stays
  a plain context error: without the ack the client knows neither the
  outcome nor the assigned ID.
- The wait loop moved into `awaitAckAndUpdateEvent`, and the outcome
  reported once the context is done into `resultOnContextDone`, to keep
  both within the linter's cognitive complexity limit.
- `ErrUpdateEventTimeout` is documented on every method that can return
  it, not only on the `Create*` ones.

### Local state cache

The cache is maintained by the socket.io event handlers, not by the
caller's context, so on this path it is simply behind and catches up on
its own once the event arrives; if the event is lost for good it stays
stale until the next broadcast for that resource.

`Client.Resync` is the way out. Uptime Kuma has no command to re-request
a single list — there is `getMonitorList` and `getMaintenanceList`, but
no `getNotificationList` or `getProxyList` — and what it does have is a
login, which answers with all of them. `Resync` therefore logs in again
with the token from the login `New` performed and returns once every
list has arrived, so the refresh is all or nothing. A client created
without credentials reports that instead of hanging.

## Tests

- New `TestAwaitAckAndUpdateEvent` drives `awaitAckAndUpdateEvent`
  directly through every combination of signals that can be pending when
  the context is done, including the collision the socket level tests can
  only reach by chance. Each case runs 100 times, because a ready channel
  and a done context are picked between at random.
- `TestUpdateEventTimeoutKeepsSuccessfulAck` covers the same contract
  end to end over the socket: `CreateNotification` returns the server
  assigned ID with `ErrUpdateEventTimeout`, a delete is distinguishable
  from a plain timeout, and a command that was never acked stays a plain
  timeout.
- `TestUpdateEventTimeoutKeepsSuccessfulAck` also covers a caller that
  propagates only the error and drops the returned ID, and asserts that
  `errors.As` gives the ID back.
- The fake server now carries an ID in the ack for `addNotification`,
  which is the value a discarded ack loses, and a token in the ack for
  `login`, which is what `Resync` presents again.
- `TestResync` covers the resync against the fake server: the token is
  the one the server handed out, a login that does not resend the lists
  runs into the deadline and names the lists still missing, and a client
  without a session token reports that. `TestResyncAgainstServer` runs it
  against the real instance, which is what proves the token is one
  `loginByToken` accepts.

## Lint

`revive` reports `file-length-limit` for `monitor_test.go` and
`notification_test.go`, while `nolintlint` rejects the file level
`//nolint:revive` directives that suppressed it as unused — so
`task lint` failed whichever of the two was in place. `file-length-limit`
is now excluded for test files the way the other size rules already are,
and the directives are gone.

`task lint`, `task test` and `task test-e2e` pass.

Closes #362
