### PR TITLE
feat(client): typed login errors and a connect-time auth barrier

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -754,6 +754,12 @@ linters:
         linters:
           - testpackage
 
+      # Tests the unexported authBarrier and the totp retry wait, both of which
+      # have to be driven through states the socket cannot reach reliably.
+      - path: 'auth_barrier_test\.go'
+        linters:
+          - testpackage
+
       # These linters do not make sense for monitor and notification files.
       - path: (monitor|notification|proxy)/.*\.go
         linters:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ real-time communication.
 - **IMPORTANT**: Assume Uptime Kuma is running when executing integration tests
 - Uses dockertest library with automatic container cleanup
 - Global `client` variable shared across test suite
-- Container expires after 300 seconds
+- Container expires after 300 seconds (600 with `E2E_TEST` set)
 - Test credentials: username="admin", password="admin1"
 
 ### Directory Structure
@@ -73,7 +73,7 @@ real-time communication.
 - **Formatting**: Use `gofumpt` (stricter than `gofmt`)
 - **Linting**: `golangci-lint` enforces style
 - **Documentation**: Self-documenting code preferred, minimal inline comments
-- **Go Version**: 1.24
+- **Go Version**: see the `go` directive in `go.mod`
 
 ## Working with Monitors
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ real-time communication.
 - **IMPORTANT**: Assume Uptime Kuma is running when executing integration tests
 - Uses dockertest library with automatic container cleanup
 - Global `client` variable shared across test suite
-- Container expires after 60 seconds
+- Container expires after 300 seconds
 - Test credentials: username="admin", password="admin1"
 
 ### Directory Structure

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ go get github.com/breml/go-uptime-kuma-client
 - **Maintenance Windows**: Schedule maintenance periods
 - **Status Pages**: Create and manage public status pages
 - **Real-time Updates**: Socket.IO-based event system for state synchronization
+- **Authentication**: Username and password, two-factor authentication without a
+  human at the keyboard, session token reuse, and servers with authentication
+  disabled
 
 ## Usage
 
@@ -92,6 +95,51 @@ func main() {
  log.Printf("Created monitor with ID: %d", monitorID)
 }
 ```
+
+## Authentication
+
+A username and password is the usual way in. An account with two-factor
+authentication enabled additionally needs the shared secret, which the client
+turns into the one-time code the server asks for:
+
+```go
+client, err := kuma.New(ctx, url, "username", "password",
+ kuma.WithTOTPSecret(secret))
+```
+
+`WithTOTPCode` takes a callback instead, for a secret the client cannot read
+itself.
+
+A successful login answers with a session token. Persisting it lets a later
+client connect with neither the password nor a one-time code:
+
+```go
+token := client.SessionToken()
+
+// ... later, in another process
+client, err := kuma.New(ctx, url, "", "", kuma.WithSessionToken(token))
+```
+
+This is also how several clients start at once against an account with
+two-factor authentication: the server refuses a one-time code it has already
+accepted, but takes the same token any number of times.
+
+The token does not expire. The server invalidates it only when the password
+changes or the user is deactivated, and for an account with two-factor
+authentication it is a stronger credential than the password, because it needs
+no second factor. Store it the way the password would be stored.
+
+A server with authentication disabled logs the client in by itself, so it takes
+no credentials at all:
+
+```go
+client, err := kuma.New(ctx, url, "", "")
+```
+
+Uptime Kuma API keys are not an option here: the server accepts them for HTTP
+basic auth on `/metrics` only, never for the Socket.IO API this client speaks.
+There is likewise no OIDC, SSO, LDAP or client-certificate login in any
+released Uptime Kuma version.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -124,10 +124,10 @@ This is also how several clients start at once against an account with
 two-factor authentication: the server refuses a one-time code it has already
 accepted, but takes the same token any number of times.
 
-The token does not expire. The server invalidates it only when the password
-changes or the user is deactivated, and for an account with two-factor
-authentication it is a stronger credential than the password, because it needs
-no second factor. Store it the way the password would be stored.
+The token is a bearer credential that does not expire, and for an account with
+two-factor authentication it is a stronger one than the password. Store it the
+way the password would be stored; `WithSessionToken` documents what invalidates
+it.
 
 A server with authentication disabled logs the client in by itself, so it takes
 no credentials at all:
@@ -136,10 +136,10 @@ no credentials at all:
 client, err := kuma.New(ctx, url, "", "")
 ```
 
-Uptime Kuma API keys are not an option here: the server accepts them for HTTP
-basic auth on `/metrics` only, never for the Socket.IO API this client speaks.
-There is likewise no OIDC, SSO, LDAP or client-certificate login in any
-released Uptime Kuma version.
+As of Uptime Kuma 2.5.0, these are the only ways in. API keys are not among
+them: the server accepts those for HTTP basic auth on `/metrics` only, never for
+the Socket.IO API this client speaks. There is likewise no OIDC, SSO, LDAP or
+client-certificate login.
 
 ## Documentation
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -33,7 +33,7 @@ tasks:
   test:
     desc: Run all tests
     cmds:
-      - go test -v -shuffle on -cover -timeout=120s -parallel=10 ./...
+      - go test -v -race -shuffle on -cover -timeout=180s -parallel=10 ./...
 
   test-debug:
     desc: Run all tests with verbose output
@@ -47,7 +47,7 @@ tasks:
     env:
       E2E_TEST: "true"
     cmds:
-      - go test -v -shuffle on -coverprofile coverage.out -timeout 240s ./...
+      - go test -v -race -shuffle on -coverprofile coverage.out -timeout 480s ./...
 
   test-e2e-cover-report:
     desc: Show coverage report for existing coverage.out or run end-to-end tests and generate coverage report

--- a/auth.go
+++ b/auth.go
@@ -102,8 +102,9 @@ func WithSessionToken(token string) Option {
 // The server records the last code it accepted and refuses to see it again,
 // see ErrInvalidTOTPCode, so two clients logging in with the same account
 // inside one 30 second step cannot both succeed. The client retries once in
-// the next step when the caller's deadline allows it, which is why starting
-// many clients for one account at once wants a deadline that can cover a step.
+// the next step when the caller's deadline allows it, so starting many clients
+// for one account at once wants a deadline that can cover a step, or
+// WithSessionToken, which needs no code and so meets no such guard.
 //
 // The server answers a wrong secret and a clock too far off with the same
 // rejection, so those cost the same retry: a login that can never succeed

--- a/auth.go
+++ b/auth.go
@@ -43,6 +43,30 @@ var ErrInvalidTOTPCode = errors.New("invalid two-factor authentication code")
 // changed password or a user that was deactivated or deleted.
 var ErrInvalidSessionToken = errors.New("session token rejected")
 
+// WithSessionToken authenticates with a session token from an earlier login
+// instead of a password, see Client.SessionToken.
+//
+// The token is what the server hands out on a successful login and what it
+// accepts in place of one. It bypasses two-factor authentication entirely, so
+// a client holding one needs neither the password nor the one-time code, which
+// also makes it the way to start many clients at once against an account with
+// two-factor authentication enabled, see WithTOTPSecret.
+//
+// If a username and password are given as well, the token is tried first and
+// the password login is the fallback for a token the server rejects. Without
+// them a rejected token fails New with ErrInvalidSessionToken.
+//
+// Security: the token is a bearer credential that does not expire. The server
+// invalidates it only when the password changes or the user is deactivated,
+// and it is a stronger credential than the password for an account with
+// two-factor authentication, because it needs no second factor. Store it the
+// way the password would be stored.
+func WithSessionToken(token string) Option {
+	return func(c *Client) {
+		c.sessionTokenPreset = token
+	}
+}
+
 // WithTOTPSecret configures the shared secret of an account with two-factor
 // authentication enabled, so the client can answer the server's request for a
 // one-time code itself and log in without a human at the keyboard.
@@ -152,6 +176,7 @@ type authBarrier struct {
 type credentials struct {
 	username string
 	password string
+	token    string
 }
 
 // loginError translates a rejected login ack into one of the package's sentinel
@@ -209,6 +234,11 @@ func (c credentials) isSet() bool {
 	return c.username != "" && c.password != ""
 }
 
+// hasAny reports whether there is anything at all to authenticate with.
+func (c credentials) hasAny() bool {
+	return c.isSet() || c.token != ""
+}
+
 // authenticate logs the client in the way the server asked for, and records the
 // session token a successful login answers with.
 //
@@ -227,12 +257,12 @@ func (c *Client) authenticate(ctx context.Context, creds credentials, barrier au
 		return nil
 
 	case authModeLoginRequired:
-		if !creds.isSet() {
+		if !creds.hasAny() {
 			return ErrAuthRequired
 		}
 
 	case authModeUnknown:
-		if !creds.isSet() {
+		if !creds.hasAny() {
 			// A server that never said it wants a login is not asked for one.
 			return nil
 		}
@@ -241,7 +271,41 @@ func (c *Client) authenticate(ctx context.Context, creds credentials, barrier au
 		// authMode has no other values.
 	}
 
+	if creds.token != "" {
+		err := c.loginWithToken(ctx, creds.token)
+		if err == nil {
+			return nil
+		}
+
+		if !errors.Is(err, ErrInvalidSessionToken) || !creds.isSet() {
+			return err
+		}
+
+		// A token the server no longer accepts is what a password change
+		// leaves behind, and the password is what recovers from it.
+		c.socketioLogger.Warnf("session token rejected, falling back to the password login")
+	}
+
 	return c.loginWithPassword(ctx, creds.username, creds.password)
+}
+
+// loginWithToken presents a session token from an earlier login, see
+// WithSessionToken.
+func (c *Client) loginWithToken(ctx context.Context, token string) error {
+	response, err := c.emitAck(ctx, "loginByToken", token)
+	if err != nil {
+		return err
+	}
+
+	if !response.OK {
+		return loginError("loginByToken", response)
+	}
+
+	// The server answers a loginByToken without a token of its own, so the one
+	// that worked is the one to keep, see Client.SessionToken.
+	c.setSessionToken(token)
+
+	return nil
 }
 
 // loginWithPassword logs in with a username and password, and answers the

--- a/auth.go
+++ b/auth.go
@@ -23,8 +23,9 @@ var ErrAuthRequired = errors.New("server requires authentication")
 var ErrInvalidCredentials = errors.New("incorrect username or password")
 
 // ErrTwoFactorRequired is returned when the account has two-factor
-// authentication enabled, which the client cannot answer yet: the server asks
-// for a one-time code and the client has none to give.
+// authentication enabled and the client has no code to answer with, because
+// neither WithTOTPSecret nor WithTOTPCode was configured or because the
+// configured callback produced nothing usable.
 //
 // It is the typed form of the server's tokenRequired answer to a login. That
 // answer carries neither an ok nor a message, so without this it surfaces as an
@@ -59,11 +60,15 @@ var ErrInvalidSessionToken = errors.New("session token rejected")
 // authentication disabled is verified against a secret that does not exist,
 // after the login has already been answered.
 //
-// The server records the last code it accepted and refuses to see it again, so
-// two clients logging in with the same account inside one 30 second step
-// cannot both succeed. The client retries once in the next step when the
-// caller's deadline allows it, but a caller starting many clients at once is
-// better served by WithSessionToken.
+// The server records the last code it accepted and refuses to see it again,
+// see ErrInvalidTOTPCode, so two clients logging in with the same account
+// inside one 30 second step cannot both succeed. The client retries once in
+// the next step when the caller's deadline allows it, which is why starting
+// many clients for one account at once wants a deadline that can cover a step.
+//
+// The server answers a wrong secret and a clock too far off with the same
+// rejection, so those cost the same retry: a login that can never succeed
+// takes up to one step to fail. WithConnectTimeout bounds it.
 //
 // WithTOTPSecret and WithTOTPCode are mutually exclusive.
 func WithTOTPSecret(secret string) Option {
@@ -88,18 +93,27 @@ func WithTOTPSecret(secret string) Option {
 // caller whose secret lives somewhere the client cannot read it, such as a
 // hardware token or an external authenticator.
 //
-// It is called only when the server asks for a code, and once more for the
-// single retry the client makes in the next time step, see ErrInvalidTOTPCode.
-// WithTOTPSecret is this option with the code computed from a secret, and the
-// two are mutually exclusive.
+// It is called at most twice per login: once when the server asks for a code,
+// and once more for the single retry the client makes in the next time step,
+// which happens only if the server rejected the first code and the caller's
+// deadline can cover the wait, see ErrInvalidTOTPCode. A callback that returns
+// an empty code fails the login with ErrTwoFactorRequired rather than sending
+// it, because the server reads an empty code as no code at all.
+//
+// A nil callback fails New, the way a secret WithTOTPSecret cannot decode
+// does. WithTOTPSecret is this option with the code computed from a secret,
+// and the two are mutually exclusive.
 func WithTOTPCode(code func(ctx context.Context) (string, error)) Option {
 	return func(c *Client) {
+		c.totpSources++
+
 		if code == nil {
+			c.totpErr = errors.New("totp: WithTOTPCode was given a nil callback")
+
 			return
 		}
 
 		c.totpCodeSet = true
-		c.totpSources++
 		c.totpCode = code
 	}
 }
@@ -275,41 +289,91 @@ func (c *Client) loginWithPassword(ctx context.Context, username string, passwor
 // secret, a clock too far off - produces the same answer again, so a single
 // retry is enough, and it is skipped altogether when the caller's deadline
 // cannot cover the wait.
+//
+// The ways this fails are kept apart in the error, because they call for
+// different fixes: no code source, a source that produced nothing usable, a
+// deadline too short to outlast the replay guard, and a code rejected in two
+// consecutive steps, which is what rules the replay guard out.
 func (c *Client) loginWithTOTP(ctx context.Context, username string, password string) error {
 	if !c.totpCodeSet {
 		return ErrTwoFactorRequired
 	}
 
 	for retry := range 2 {
-		if retry > 0 && !waitForNextTOTPStep(ctx) {
-			break
+		if retry > 0 {
+			waitErr := awaitTOTPRetry(ctx)
+			if waitErr != nil {
+				return waitErr
+			}
 		}
 
-		code, err := c.totpCode(ctx)
-		if err != nil {
-			return fmt.Errorf("login: totp code: %w", err)
-		}
-
-		response, err := c.login(ctx, username, password, code)
-		if err != nil {
+		err := c.loginOnceWithTOTP(ctx, username, password)
+		if !errors.Is(err, ErrInvalidTOTPCode) {
 			return err
-		}
-
-		if response.OK {
-			c.setSessionToken(response.Token)
-
-			return nil
-		}
-
-		if !errors.Is(loginError("login", response), ErrInvalidTOTPCode) {
-			return loginError("login", response)
 		}
 	}
 
 	return fmt.Errorf(
-		"%w: the server also rejects a code it has accepted before, "+
-			"so another login with this account may have just used this one",
+		"%w: rejected in two consecutive time steps, which rules out the server's replay "+
+			"guard, so what is left to check is the secret and this host's clock",
 		ErrInvalidTOTPCode,
+	)
+}
+
+// loginOnceWithTOTP makes one attempt at a login with a one-time code. A code
+// the server rejects comes back wrapping ErrInvalidTOTPCode, which is the only
+// outcome another attempt could change.
+func (c *Client) loginOnceWithTOTP(ctx context.Context, username string, password string) error {
+	code, err := c.totpCode(ctx)
+	if err != nil {
+		return fmt.Errorf("login: %w", err)
+	}
+
+	// The server reads an empty code as no code at all and asks again instead
+	// of rejecting it, in an ack carrying neither an ok nor a message, so
+	// sending one buys an error with nothing in it.
+	if code == "" {
+		return fmt.Errorf("%w: the configured code source produced an empty code", ErrTwoFactorRequired)
+	}
+
+	response, err := c.login(ctx, username, password, code)
+	if err != nil {
+		return err
+	}
+
+	if response.OK {
+		c.setSessionToken(response.Token)
+
+		return nil
+	}
+
+	if response.TokenRequired {
+		return fmt.Errorf(
+			"%w: the server asked for a code again instead of answering the one it was given",
+			ErrTwoFactorRequired,
+		)
+	}
+
+	return loginError("login", response)
+}
+
+// awaitTOTPRetry waits out the current time step, so the attempt after it has
+// a code the server has not seen before, and says why it could not.
+func awaitTOTPRetry(ctx context.Context) error {
+	waited, err := waitForNextTOTPStep(ctx)
+	if err != nil {
+		return fmt.Errorf("login: %w", err)
+	}
+
+	if waited {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"%w: recovering from a code the server has seen before needs a wait of up to %s "+
+			"for the next time step, which does not fit in the deadline",
+		ErrInvalidTOTPCode,
+		totpStep,
 	)
 }
 
@@ -337,15 +401,17 @@ func (c *Client) setAutoLoggedIn() {
 	c.autoLoggedIn = true
 }
 
-// waitForNextTOTPStep waits until the current time step is over, and reports
-// whether the wait completed inside the caller's budget. A deadline that
-// cannot cover the wait is left alone rather than run into.
-func waitForNextTOTPStep(ctx context.Context) bool {
+// waitForNextTOTPStep waits until the current time step is over and reports
+// whether it got there. A deadline that cannot cover the wait is left alone
+// rather than run into, which is the (false, nil) answer; a wait the context
+// cuts short returns that context's error, so a cancellation on the way is not
+// reported as a code the server disliked.
+func waitForNextTOTPStep(ctx context.Context) (bool, error) {
 	wait := time.Until(totpStepStart(time.Now()).Add(totpStep))
 
 	deadline, hasDeadline := ctx.Deadline()
 	if hasDeadline && time.Until(deadline) <= wait {
-		return false
+		return false, nil
 	}
 
 	timer := time.NewTimer(wait)
@@ -353,10 +419,10 @@ func waitForNextTOTPStep(ctx context.Context) bool {
 
 	select {
 	case <-timer.C:
-		return true
+		return true, nil
 
 	case <-ctx.Done():
-		return false
+		return false, fmt.Errorf("waiting for the next totp time step: %w", ctx.Err())
 	}
 }
 

--- a/auth.go
+++ b/auth.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 )
 
@@ -213,8 +214,15 @@ type credentials struct {
 // errors, so a caller can tell the cases apart with errors.Is instead of
 // matching on the message.
 func loginError(command string, response ackResponse) error {
+	// A server from before the login messages were translated sends the
+	// message itself, and sends it with a trailing period the translation key
+	// that replaced it has no equivalent of, so it is matched by its prefix.
+	if strings.HasPrefix(response.Msg, "Incorrect username or password") {
+		return ErrInvalidCredentials
+	}
+
 	switch response.Msg {
-	case "authIncorrectCreds", "Incorrect username or password":
+	case "authIncorrectCreds":
 		return ErrInvalidCredentials
 
 	case "authUserInactiveOrDeleted":
@@ -273,15 +281,25 @@ func (c credentials) hasAny() bool {
 // session token the connection ends up authenticated with, whether the server
 // handed it out or accepted the one the client presented.
 //
-// It returns nil without logging in for a server that authenticated the client
-// itself, for one that wants to be set up first, and for one that never stated
-// what it wants while the client has no credentials to offer anyway.
+// It returns nil without logging in for a server that wants to be set up first,
+// and for one that never stated what it wants while the client has no
+// credentials to offer anyway. A server that authenticated the client itself is
+// still logged in to when credentials were given, because that is what produces
+// a session token, see Resync.
 func (c *Client) authenticate(ctx context.Context, creds credentials, barrier authBarrier) error {
 	switch barrier.await(ctx) {
 	case authModeAutoLogin:
 		c.setAutoLoggedIn()
 
-		return nil
+		if !creds.hasAny() {
+			return nil
+		}
+
+		// The connection is authenticated already, but a server with
+		// authentication disabled keeps its login handler in place and a login
+		// is the only thing that hands out a session token, which Resync and
+		// Client.SessionToken need. Credentials given explicitly are therefore
+		// still used.
 
 	case authModeSetup:
 		// The caller runs the setup and logs in afterwards.

--- a/auth.go
+++ b/auth.go
@@ -1,0 +1,235 @@
+package kuma
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// ErrAuthRequired is returned when the server asks for a login and the client
+// has no credentials to offer.
+//
+// The server states what it expects right after the connect: it emits
+// loginRequired for a server that wants a login and autoLogin for one that has
+// authentication disabled and logged the client in itself.
+var ErrAuthRequired = errors.New("server requires authentication")
+
+// ErrInvalidCredentials is returned when the server rejects the username and
+// password. It is what the server reports as authIncorrectCreds, and as
+// "Incorrect username or password" on versions before the login messages were
+// translated.
+var ErrInvalidCredentials = errors.New("incorrect username or password")
+
+// ErrTwoFactorRequired is returned when the account has two-factor
+// authentication enabled, which the client cannot answer yet: the server asks
+// for a one-time code and the client has none to give.
+//
+// It is the typed form of the server's tokenRequired answer to a login. That
+// answer carries neither an ok nor a message, so without this it surfaces as an
+// error with an empty message.
+var ErrTwoFactorRequired = errors.New("two-factor authentication required")
+
+// ErrInvalidTOTPCode is returned when the server rejects the one-time code of a
+// login. Besides a wrong secret and a clock too far off, this is what the
+// server answers for a code it has accepted once already: it records the last
+// code it let through and refuses to see it again, so two logins inside the
+// same 30 second step cannot both succeed.
+var ErrInvalidTOTPCode = errors.New("invalid two-factor authentication code")
+
+// ErrInvalidSessionToken is returned when the server rejects a session token,
+// see Client.Resync. The token carries no expiry, so what invalidates it is a
+// changed password or a user that was deactivated or deleted.
+var ErrInvalidSessionToken = errors.New("session token rejected")
+
+// authBarrierWait bounds how long the client waits for the server to state how
+// it wants to be authenticated, see authBarrier.
+//
+// The server emits loginRequired or autoLogin as the last thing it does for a
+// new connection, so on a healthy server the wait is over in milliseconds. It
+// only elapses in full for a server too old to send either event, or behind a
+// proxy that drops it, and it must not be a hard failure for those.
+const authBarrierWait = 500 * time.Millisecond
+
+// authMode is how the server wants the connection to be authenticated, as the
+// events it emits right after the connect state it.
+type authMode int
+
+const (
+	// authModeUnknown means the server said nothing the client recognizes.
+	authModeUnknown authMode = iota
+
+	// authModeLoginRequired means the server wants a login.
+	authModeLoginRequired
+
+	// authModeAutoLogin means the server has authentication disabled and has
+	// logged the client in itself.
+	authModeAutoLogin
+
+	// authModeSetup means the server is not set up yet and wants that first.
+	authModeSetup
+)
+
+// authBarrier reports how the server wants the connection to be authenticated.
+//
+// It doubles as the point from which the socket.io API is known to be live. The
+// server registers its login and loginByToken handlers after an await in the
+// connection handler and emits loginRequired or autoLogin only once every
+// handler is in place, so a login emitted before that can land in the gap and
+// be dropped silently, leaving the client to wait out its timeout on a
+// connection that is otherwise healthy. Waiting for the barrier closes that
+// window.
+type authBarrier struct {
+	loginRequired <-chan struct{}
+	autoLogin     <-chan struct{}
+	setupRequired <-chan struct{}
+}
+
+// credentials are the ways New was given to authenticate, gathered from its
+// arguments and options so the login path has a single thing to read.
+type credentials struct {
+	username string
+	password string
+}
+
+// loginError translates a rejected login ack into one of the package's sentinel
+// errors, so a caller can tell the cases apart with errors.Is instead of
+// matching on the message.
+func loginError(command string, response ackResponse) error {
+	switch response.Msg {
+	case "authIncorrectCreds", "Incorrect username or password":
+		return ErrInvalidCredentials
+
+	case "authUserInactiveOrDeleted":
+		return fmt.Errorf("%w: user inactive or deleted", ErrInvalidSessionToken)
+
+	case "authInvalidToken":
+		// The server answers two different rejections with this one message: a
+		// one-time code it does not accept for a login, and a session token it
+		// does not accept for a loginByToken.
+		if command == "loginByToken" {
+			return ErrInvalidSessionToken
+		}
+
+		return ErrInvalidTOTPCode
+
+	default:
+		return fmt.Errorf("%s: %s", command, response.Msg)
+	}
+}
+
+// await reports how the server wants the connection to be authenticated, or
+// authModeUnknown once it is clear that it will not say.
+func (b authBarrier) await(ctx context.Context) authMode {
+	timer := time.NewTimer(authBarrierWait)
+	defer timer.Stop()
+
+	select {
+	case <-b.autoLogin:
+		return authModeAutoLogin
+
+	case <-b.loginRequired:
+		return authModeLoginRequired
+
+	case <-b.setupRequired:
+		return authModeSetup
+
+	case <-timer.C:
+		return authModeUnknown
+
+	case <-ctx.Done():
+		return authModeUnknown
+	}
+}
+
+// isSet reports whether a username and password were given.
+func (c credentials) isSet() bool {
+	return c.username != "" && c.password != ""
+}
+
+// authenticate logs the client in the way the server asked for, and records the
+// session token a successful login answers with.
+//
+// It returns nil without logging in for a server that authenticated the client
+// itself, for one that wants to be set up first, and for one that never stated
+// what it wants while the client has no credentials to offer anyway.
+func (c *Client) authenticate(ctx context.Context, creds credentials, barrier authBarrier) error {
+	switch barrier.await(ctx) {
+	case authModeAutoLogin:
+		c.setAutoLoggedIn()
+
+		return nil
+
+	case authModeSetup:
+		// The caller runs the setup and logs in afterwards.
+		return nil
+
+	case authModeLoginRequired:
+		if !creds.isSet() {
+			return ErrAuthRequired
+		}
+
+	case authModeUnknown:
+		if !creds.isSet() {
+			// A server that never said it wants a login is not asked for one.
+			return nil
+		}
+
+	default:
+		// authMode has no other values.
+	}
+
+	return c.loginWithPassword(ctx, creds.username, creds.password)
+}
+
+// loginWithPassword logs in with a username and password.
+func (c *Client) loginWithPassword(ctx context.Context, username string, password string) error {
+	response, err := c.emitAck(
+		ctx,
+		"login",
+		map[string]any{"username": username, "password": password, "token": ""},
+	)
+	if err != nil {
+		return err
+	}
+
+	if response.OK {
+		c.setSessionToken(response.Token)
+
+		return nil
+	}
+
+	// An ack asking for a one-time code carries neither an ok nor a message,
+	// so it has to be recognized before the message is looked at.
+	if response.TokenRequired {
+		return ErrTwoFactorRequired
+	}
+
+	return loginError("login", response)
+}
+
+// setAutoLoggedIn records that the server logged the client in itself, see
+// Client.Resync.
+func (c *Client) setAutoLoggedIn() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.autoLoggedIn = true
+}
+
+// setupPending reports whether the server asked to be set up.
+//
+// The setup event and the ack of a login the server rejects because it has no
+// users yet race each other, so the check is made after a moment rather than
+// straight away.
+func setupPending(setupRequired <-chan struct{}) bool {
+	time.Sleep(10 * time.Millisecond)
+
+	select {
+	case <-setupRequired:
+		return true
+
+	default:
+		return false
+	}
+}

--- a/auth.go
+++ b/auth.go
@@ -165,7 +165,9 @@ func WithTOTPCode(code func(ctx context.Context) (string, error)) Option {
 // The server emits loginRequired or autoLogin as the last thing it does for a
 // new connection, so on a healthy server the wait is over in milliseconds. It
 // only elapses in full for a server too old to send either event, or behind a
-// proxy that drops it, and it must not be a hard failure for those.
+// proxy that drops it, and it must not be a hard failure for those - which is
+// also why it never takes more than half of what is left of the caller's
+// deadline, see barrierWaitWithin.
 const authBarrierWait = 500 * time.Millisecond
 
 // authMode is how the server wants the connection to be authenticated, as the
@@ -246,18 +248,20 @@ func loginError(command string, response ackResponse) error {
 // await reports how the server wants the connection to be authenticated, or
 // authModeUnknown once it is clear that it will not say.
 func (b authBarrier) await(ctx context.Context) authMode {
-	timer := time.NewTimer(authBarrierWait)
+	timer := time.NewTimer(barrierWaitWithin(ctx))
 	defer timer.Stop()
 
+	var mode authMode
+
 	select {
-	case <-b.autoLogin:
-		return authModeAutoLogin
-
-	case <-b.loginRequired:
-		return authModeLoginRequired
-
 	case <-b.setupRequired:
 		return authModeSetup
+
+	case <-b.autoLogin:
+		mode = authModeAutoLogin
+
+	case <-b.loginRequired:
+		mode = authModeLoginRequired
 
 	case <-timer.C:
 		return authModeUnknown
@@ -265,6 +269,42 @@ func (b authBarrier) await(ctx context.Context) authMode {
 	case <-ctx.Done():
 		return authModeUnknown
 	}
+
+	// A server that wants to be set up emits setup before it states how it
+	// wants to be authenticated, so by the time either of those events is in,
+	// a setup that is coming has been delivered too. Answering it here rather
+	// than from the select above is what keeps a server that sent both from
+	// being read one way or the other at random.
+	if isRequested(b.setupRequired) {
+		return authModeSetup
+	}
+
+	return mode
+}
+
+// isRequested reports whether an event of the barrier has been delivered,
+// without waiting for one that has not.
+func isRequested(event <-chan struct{}) bool {
+	select {
+	case <-event:
+		return true
+
+	default:
+		return false
+	}
+}
+
+// barrierWaitWithin is how long the barrier may wait for a server that states
+// nothing: authBarrierWait, but never more than half of what is left of the
+// caller's deadline, so that such a server cannot spend the whole budget
+// before the login it does answer is even sent.
+func barrierWaitWithin(ctx context.Context) time.Duration {
+	deadline, hasDeadline := ctx.Deadline()
+	if !hasDeadline {
+		return authBarrierWait
+	}
+
+	return min(authBarrierWait, max(time.Until(deadline)/2, 0))
 }
 
 // isSet reports whether a username and password were given.
@@ -409,12 +449,13 @@ func (c *Client) loginWithPassword(ctx context.Context, username string, passwor
 
 // loginWithTOTP answers the server's request for a one-time code.
 //
-// A code the server rejects is retried once in the next time step, because the
-// server refuses a code it has accepted before and the next step is what
-// produces a different one. Every other reason for the rejection - a wrong
-// secret, a clock too far off - produces the same answer again, so a single
-// retry is enough, and it is skipped altogether when the caller's deadline
-// cannot cover the wait.
+// A code the server rejects is retried once in the step after the one it was
+// generated in, because the server refuses a code it has accepted before and a
+// later step is what produces a different one. Every other reason for the
+// rejection - a wrong secret, a clock too far off - produces the same answer
+// again, so a single retry is enough. The wait is skipped when the round trip
+// already crossed into the next step, and the retry is given up on when the
+// caller's deadline cannot cover the wait.
 //
 // The ways this fails are kept apart in the error, because they call for
 // different fixes: no code source, a source that produced nothing usable, a
@@ -425,18 +466,22 @@ func (c *Client) loginWithTOTP(ctx context.Context, username string, password st
 		return ErrTwoFactorRequired
 	}
 
+	var rejectedStep time.Time
+
 	for retry := range 2 {
 		if retry > 0 {
-			waitErr := awaitTOTPRetry(ctx)
+			waitErr := awaitTOTPRetry(ctx, rejectedStep)
 			if waitErr != nil {
 				return waitErr
 			}
 		}
 
-		err := c.loginOnceWithTOTP(ctx, username, password)
+		step, err := c.loginOnceWithTOTP(ctx, username, password)
 		if !errors.Is(err, ErrInvalidTOTPCode) {
 			return err
 		}
+
+		rejectedStep = step
 	}
 
 	return fmt.Errorf(
@@ -449,43 +494,65 @@ func (c *Client) loginWithTOTP(ctx context.Context, username string, password st
 // loginOnceWithTOTP makes one attempt at a login with a one-time code. A code
 // the server rejects comes back wrapping ErrInvalidTOTPCode, which is the only
 // outcome another attempt could change.
-func (c *Client) loginOnceWithTOTP(ctx context.Context, username string, password string) error {
+//
+// It also reports the time step the code it sent belongs to, which is what
+// tells a retry whether there is still a step to wait out. The step is read
+// after the code was produced, so a code generated just before a step boundary
+// counts as belonging to the later one - the reading that at worst waits when
+// it did not have to, rather than sending the same code twice.
+func (c *Client) loginOnceWithTOTP(
+	ctx context.Context,
+	username string,
+	password string,
+) (time.Time, error) {
 	code, err := c.totpCode(ctx)
+
+	codeStep := totpStepStart(time.Now())
+
 	if err != nil {
-		return fmt.Errorf("login: %w", err)
+		return codeStep, fmt.Errorf("login: %w", err)
 	}
 
 	// The server reads an empty code as no code at all and asks again instead
 	// of rejecting it, in an ack carrying neither an ok nor a message, so
 	// sending one buys an error with nothing in it.
 	if code == "" {
-		return fmt.Errorf("%w: the configured code source produced an empty code", ErrTwoFactorRequired)
+		return codeStep, fmt.Errorf(
+			"%w: the configured code source produced an empty code",
+			ErrTwoFactorRequired,
+		)
 	}
 
 	response, err := c.login(ctx, username, password, code)
 	if err != nil {
-		return err
+		return codeStep, err
 	}
 
 	if response.OK {
 		c.setSessionToken(response.Token)
 
-		return nil
+		return codeStep, nil
 	}
 
 	if response.TokenRequired {
-		return fmt.Errorf(
+		return codeStep, fmt.Errorf(
 			"%w: the server asked for a code again instead of answering the one it was given",
 			ErrTwoFactorRequired,
 		)
 	}
 
-	return loginError("login", response)
+	return codeStep, loginError("login", response)
 }
 
-// awaitTOTPRetry waits out the current time step, so the attempt after it has
-// a code the server has not seen before, and says why it could not.
-func awaitTOTPRetry(ctx context.Context) error {
+// awaitTOTPRetry waits out the time step the rejected code belongs to, so the
+// attempt after it has a code the server has not seen before, and says why it
+// could not. A login whose round trip already crossed into a later step has
+// nothing left to wait for.
+func awaitTOTPRetry(ctx context.Context, rejectedStep time.Time) error {
+	if totpStepStart(time.Now()).After(rejectedStep) {
+		return nil
+	}
+
 	waited, err := waitForNextTOTPStep(ctx)
 	if err != nil {
 		return fmt.Errorf("login: %w", err)

--- a/auth.go
+++ b/auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"time"
 )
 
@@ -41,6 +42,67 @@ var ErrInvalidTOTPCode = errors.New("invalid two-factor authentication code")
 // see Client.Resync. The token carries no expiry, so what invalidates it is a
 // changed password or a user that was deactivated or deleted.
 var ErrInvalidSessionToken = errors.New("session token rejected")
+
+// WithTOTPSecret configures the shared secret of an account with two-factor
+// authentication enabled, so the client can answer the server's request for a
+// one-time code itself and log in without a human at the keyboard.
+//
+// The secret is the base32 string from the otpauth:// URI Uptime Kuma shows
+// when two-factor authentication is set up. Spaces, hyphens, lower case and
+// the missing base32 padding the server strips are all accepted; a secret that
+// cannot be decoded fails New rather than the login it would be needed for.
+//
+// The code is generated only once the server asks for one, so configuring a
+// secret for an account without two-factor authentication changes nothing. It
+// is generated then and not before because the server evaluates the fields of
+// a login independently: a code sent to an account that has two-factor
+// authentication disabled is verified against a secret that does not exist,
+// after the login has already been answered.
+//
+// The server records the last code it accepted and refuses to see it again, so
+// two clients logging in with the same account inside one 30 second step
+// cannot both succeed. The client retries once in the next step when the
+// caller's deadline allows it, but a caller starting many clients at once is
+// better served by WithSessionToken.
+//
+// WithTOTPSecret and WithTOTPCode are mutually exclusive.
+func WithTOTPSecret(secret string) Option {
+	return func(c *Client) {
+		c.totpSources++
+
+		normalized, err := normalizeTOTPSecret(secret)
+		if err != nil {
+			c.totpErr = err
+
+			return
+		}
+
+		c.totpCodeSet = true
+		c.totpCode = func(_ context.Context) (string, error) {
+			return totpCodeAt(normalized, time.Now())
+		}
+	}
+}
+
+// WithTOTPCode configures a callback that produces the one-time code, for a
+// caller whose secret lives somewhere the client cannot read it, such as a
+// hardware token or an external authenticator.
+//
+// It is called only when the server asks for a code, and once more for the
+// single retry the client makes in the next time step, see ErrInvalidTOTPCode.
+// WithTOTPSecret is this option with the code computed from a secret, and the
+// two are mutually exclusive.
+func WithTOTPCode(code func(ctx context.Context) (string, error)) Option {
+	return func(c *Client) {
+		if code == nil {
+			return
+		}
+
+		c.totpCodeSet = true
+		c.totpSources++
+		c.totpCode = code
+	}
+}
 
 // authBarrierWait bounds how long the client waits for the server to state how
 // it wants to be authenticated, see authBarrier.
@@ -182,13 +244,10 @@ func (c *Client) authenticate(ctx context.Context, creds credentials, barrier au
 	return c.loginWithPassword(ctx, creds.username, creds.password)
 }
 
-// loginWithPassword logs in with a username and password.
+// loginWithPassword logs in with a username and password, and answers the
+// server's request for a one-time code if it makes one.
 func (c *Client) loginWithPassword(ctx context.Context, username string, password string) error {
-	response, err := c.emitAck(
-		ctx,
-		"login",
-		map[string]any{"username": username, "password": password, "token": ""},
-	)
+	response, err := c.login(ctx, username, password, "")
 	if err != nil {
 		return err
 	}
@@ -202,10 +261,71 @@ func (c *Client) loginWithPassword(ctx context.Context, username string, passwor
 	// An ack asking for a one-time code carries neither an ok nor a message,
 	// so it has to be recognized before the message is looked at.
 	if response.TokenRequired {
-		return ErrTwoFactorRequired
+		return c.loginWithTOTP(ctx, username, password)
 	}
 
 	return loginError("login", response)
+}
+
+// loginWithTOTP answers the server's request for a one-time code.
+//
+// A code the server rejects is retried once in the next time step, because the
+// server refuses a code it has accepted before and the next step is what
+// produces a different one. Every other reason for the rejection - a wrong
+// secret, a clock too far off - produces the same answer again, so a single
+// retry is enough, and it is skipped altogether when the caller's deadline
+// cannot cover the wait.
+func (c *Client) loginWithTOTP(ctx context.Context, username string, password string) error {
+	if !c.totpCodeSet {
+		return ErrTwoFactorRequired
+	}
+
+	for retry := range 2 {
+		if retry > 0 && !waitForNextTOTPStep(ctx) {
+			break
+		}
+
+		code, err := c.totpCode(ctx)
+		if err != nil {
+			return fmt.Errorf("login: totp code: %w", err)
+		}
+
+		response, err := c.login(ctx, username, password, code)
+		if err != nil {
+			return err
+		}
+
+		if response.OK {
+			c.setSessionToken(response.Token)
+
+			return nil
+		}
+
+		if !errors.Is(loginError("login", response), ErrInvalidTOTPCode) {
+			return loginError("login", response)
+		}
+	}
+
+	return fmt.Errorf(
+		"%w: the server also rejects a code it has accepted before, "+
+			"so another login with this account may have just used this one",
+		ErrInvalidTOTPCode,
+	)
+}
+
+// login emits the login command with an optional one-time code and returns the
+// ack, whether it reports success or not.
+func (c *Client) login(
+	ctx context.Context,
+	username string,
+	password string,
+	code string,
+) (ackResponse, error) {
+	return c.emitAck(
+		ctx,
+		"login",
+		map[string]any{"username": username, "password": password, "token": code},
+	)
 }
 
 // setAutoLoggedIn records that the server logged the client in itself, see
@@ -215,6 +335,29 @@ func (c *Client) setAutoLoggedIn() {
 	defer c.mu.Unlock()
 
 	c.autoLoggedIn = true
+}
+
+// waitForNextTOTPStep waits until the current time step is over, and reports
+// whether the wait completed inside the caller's budget. A deadline that
+// cannot cover the wait is left alone rather than run into.
+func waitForNextTOTPStep(ctx context.Context) bool {
+	wait := time.Until(totpStepStart(time.Now()).Add(totpStep))
+
+	deadline, hasDeadline := ctx.Deadline()
+	if hasDeadline && time.Until(deadline) <= wait {
+		return false
+	}
+
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+		return true
+
+	case <-ctx.Done():
+		return false
+	}
 }
 
 // setupPending reports whether the server asked to be set up.
@@ -232,4 +375,55 @@ func setupPending(setupRequired <-chan struct{}) bool {
 	default:
 		return false
 	}
+}
+
+// prepare2FA asks the server for a new two-factor secret and returns it.
+//
+// The server stores the secret right away, before it has been confirmed, and
+// only starts requiring a code once save2FA ran. currentPassword is the
+// password of the logged in account, which the server checks again for this
+// command even though the connection is already authenticated.
+func (c *Client) prepare2FA(ctx context.Context, currentPassword string) (string, error) {
+	response, err := c.syncEmit(ctx, "prepare2FA", currentPassword)
+	if err != nil {
+		return "", err
+	}
+
+	uri, err := url.Parse(response.URI)
+	if err != nil {
+		return "", fmt.Errorf("prepare2FA: parse otpauth uri: %w", err)
+	}
+
+	secret := uri.Query().Get("secret")
+	if secret == "" {
+		return "", errors.New("prepare2FA: otpauth uri carries no secret")
+	}
+
+	return secret, nil
+}
+
+// save2FA turns two-factor authentication on for the logged in account, using
+// the secret prepare2FA handed out.
+func (c *Client) save2FA(ctx context.Context, currentPassword string) error {
+	_, err := c.syncEmit(ctx, "save2FA", currentPassword)
+
+	return err
+}
+
+// disable2FA turns two-factor authentication off for the logged in account.
+func (c *Client) disable2FA(ctx context.Context, currentPassword string) error {
+	_, err := c.syncEmit(ctx, "disable2FA", currentPassword)
+
+	return err
+}
+
+// twoFAStatus reports whether two-factor authentication is on for the logged
+// in account.
+func (c *Client) twoFAStatus(ctx context.Context) (bool, error) {
+	response, err := c.syncEmit(ctx, "twoFAStatus")
+	if err != nil {
+		return false, err
+	}
+
+	return response.Status, nil
 }

--- a/auth.go
+++ b/auth.go
@@ -43,6 +43,16 @@ var ErrInvalidTOTPCode = errors.New("invalid two-factor authentication code")
 // changed password or a user that was deactivated or deleted.
 var ErrInvalidSessionToken = errors.New("session token rejected")
 
+// ErrUserInactive is returned when the server rejects a session token because
+// the account it names is deactivated or deleted. It wraps
+// ErrInvalidSessionToken as well, so a caller that only cares that the token is
+// gone keeps matching on that one.
+//
+// It is the token rejection a password cannot recover from: the server requires
+// an active user for a password login too, so New reports it instead of falling
+// back, see WithSessionToken.
+var ErrUserInactive = errors.New("user inactive or deleted")
+
 // WithSessionToken authenticates with a session token from an earlier login
 // instead of a password, see Client.SessionToken.
 //
@@ -53,8 +63,13 @@ var ErrInvalidSessionToken = errors.New("session token rejected")
 // two-factor authentication enabled, see WithTOTPSecret.
 //
 // If a username and password are given as well, the token is tried first and
-// the password login is the fallback for a token the server rejects. Without
-// them a rejected token fails New with ErrInvalidSessionToken.
+// the password login is the fallback for a token the server refuses.
+// Client.SessionTokenRejected reports that this happened, because the login
+// succeeds either way and the stored token is dead. The fallback is skipped
+// where the password cannot help: for a deactivated or deleted user, see
+// ErrUserInactive, and for a failure that is not a rejection at all, such as a
+// transport error. Without a username and password a rejected token fails New
+// with ErrInvalidSessionToken.
 //
 // Security: the token is a bearer credential that does not expire. The server
 // invalidates it only when the password changes or the user is deactivated,
@@ -188,7 +203,7 @@ func loginError(command string, response ackResponse) error {
 		return ErrInvalidCredentials
 
 	case "authUserInactiveOrDeleted":
-		return fmt.Errorf("%w: user inactive or deleted", ErrInvalidSessionToken)
+		return fmt.Errorf("%w: %w", ErrInvalidSessionToken, ErrUserInactive)
 
 	case "authInvalidToken":
 		// The server answers two different rejections with this one message: a
@@ -240,7 +255,8 @@ func (c credentials) hasAny() bool {
 }
 
 // authenticate logs the client in the way the server asked for, and records the
-// session token a successful login answers with.
+// session token the connection ends up authenticated with, whether the server
+// handed it out or accepted the one the client presented.
 //
 // It returns nil without logging in for a server that authenticated the client
 // itself, for one that wants to be set up first, and for one that never stated
@@ -272,21 +288,48 @@ func (c *Client) authenticate(ctx context.Context, creds credentials, barrier au
 	}
 
 	if creds.token != "" {
-		err := c.loginWithToken(ctx, creds.token)
-		if err == nil {
+		tokenErr := c.loginWithToken(ctx, creds.token)
+		if tokenErr == nil {
 			return nil
 		}
 
-		if !errors.Is(err, ErrInvalidSessionToken) || !creds.isSet() {
-			return err
+		if !recoverableWithPassword(tokenErr, creds) {
+			return tokenErr
 		}
 
 		// A token the server no longer accepts is what a password change
 		// leaves behind, and the password is what recovers from it.
-		c.socketioLogger.Warnf("session token rejected, falling back to the password login")
+		c.socketioLogger.Warnf(
+			"session token rejected (%v), falling back to the password login for %q",
+			tokenErr,
+			creds.username,
+		)
+
+		err := c.loginWithPassword(ctx, creds.username, creds.password)
+		if err != nil {
+			// The rejected token is what sent the login down this path, which
+			// the password failure on its own does not say.
+			return fmt.Errorf("%w, and the password login that followed: %w", tokenErr, err)
+		}
+
+		c.setSessionTokenRejected()
+
+		return nil
 	}
 
 	return c.loginWithPassword(ctx, creds.username, creds.password)
+}
+
+// recoverableWithPassword reports whether a rejected session token is worth
+// following with a password login: only a token the server refuses, and only
+// when there is a password to offer. A deactivated or deleted user is the
+// rejection the server answers the same way for both credentials, and anything
+// that is not a rejection - a transport failure, a message the client does not
+// know - says nothing about the password either way.
+func recoverableWithPassword(err error, creds credentials) bool {
+	return errors.Is(err, ErrInvalidSessionToken) &&
+		!errors.Is(err, ErrUserInactive) &&
+		creds.isSet()
 }
 
 // loginWithToken presents a session token from an earlier login, see

--- a/auth.go
+++ b/auth.go
@@ -24,9 +24,13 @@ var ErrAuthRequired = errors.New("server requires authentication")
 var ErrInvalidCredentials = errors.New("incorrect username or password")
 
 // ErrTwoFactorRequired is returned when the account has two-factor
-// authentication enabled and the client has no code to answer with, because
-// neither WithTOTPSecret nor WithTOTPCode was configured or because the
-// configured callback produced nothing usable.
+// authentication enabled and the login could not answer the server's request
+// for a code: neither WithTOTPSecret nor WithTOTPCode was configured, the
+// configured source produced an empty code, or the server asked for a code
+// again instead of answering the one it was given.
+//
+// A code source that fails outright reports its own error instead, because what
+// went wrong there is not that a code was missing.
 //
 // It is the typed form of the server's tokenRequired answer to a login. That
 // answer carries neither an ok nor a message, so without this it surfaces as an
@@ -47,13 +51,22 @@ var ErrInvalidSessionToken = errors.New("session token rejected")
 
 // ErrUserInactive is returned when the server rejects a session token because
 // the account it names is deactivated or deleted. It wraps
-// ErrInvalidSessionToken as well, so a caller that only cares that the token is
-// gone keeps matching on that one.
+// ErrInvalidSessionToken, so a caller that only cares that the token is gone
+// keeps matching on that one.
 //
 // It is the token rejection a password cannot recover from: the server requires
 // an active user for a password login too, so New reports it instead of falling
 // back, see WithSessionToken.
-var ErrUserInactive = errors.New("user inactive or deleted")
+var ErrUserInactive = fmt.Errorf("%w: user inactive or deleted", ErrInvalidSessionToken)
+
+// ErrRateLimited is returned when the server refuses a login because too many
+// were attempted in a short time. The server allows 20 per minute and answers
+// the ones beyond that with an untranslated sentence rather than a key.
+//
+// A login that answers a one-time code costs two of those attempts, because the
+// server asks for the code in the ack of a first login, so an account with
+// two-factor authentication enabled reaches the limit in half as many logins.
+var ErrRateLimited = errors.New("too many login attempts, rate limited by the server")
 
 // WithSessionToken authenticates with a session token from an earlier login
 // instead of a password, see Client.SessionToken.
@@ -84,6 +97,21 @@ func WithSessionToken(token string) Option {
 	}
 }
 
+// WithSessionTokenRejectedCallback registers a function New calls when the
+// server refused the token WithSessionToken configured and the password login
+// took over, with the error the token was refused with.
+//
+// It is the pushed form of Client.SessionTokenRejected, for a caller that
+// persists tokens and would otherwise have to remember to ask: the fallback
+// leaves New succeeding, so nothing about the returned client says that the
+// stored token is dead. The callback runs on the goroutine that called New,
+// before it returns, and a client whose token was accepted never calls it.
+func WithSessionTokenRejectedCallback(callback func(err error)) Option {
+	return func(c *Client) {
+		c.sessionTokenRejectedCallback = callback
+	}
+}
+
 // WithTOTPSecret configures the shared secret of an account with two-factor
 // authentication enabled, so the client can answer the server's request for a
 // one-time code itself and log in without a human at the keyboard.
@@ -103,9 +131,11 @@ func WithSessionToken(token string) Option {
 // The server records the last code it accepted and refuses to see it again,
 // see ErrInvalidTOTPCode, so two clients logging in with the same account
 // inside one 30 second step cannot both succeed. The client retries once in
-// the next step when the caller's deadline allows it, so starting many clients
-// for one account at once wants a deadline that can cover a step, or
-// WithSessionToken, which needs no code and so meets no such guard.
+// the next step when the caller's deadline allows it, which settles a collision
+// between two clients and no more: of three or more meeting in one step, the
+// ones that lose the retry as well have spent both attempts, however generous
+// the deadline. WithSessionToken is the answer that scales, because it needs no
+// code and so meets no such guard.
 //
 // The server answers a wrong secret and a clock too far off with the same
 // rejection, so those cost the same retry: a login that can never succeed
@@ -123,7 +153,6 @@ func WithTOTPSecret(secret string) Option {
 			return
 		}
 
-		c.totpCodeSet = true
 		c.totpCode = func(_ context.Context) (string, error) {
 			return totpCodeAt(normalized, time.Now())
 		}
@@ -154,7 +183,6 @@ func WithTOTPCode(code func(ctx context.Context) (string, error)) Option {
 			return
 		}
 
-		c.totpCodeSet = true
 		c.totpCode = code
 	}
 }
@@ -169,6 +197,15 @@ func WithTOTPCode(code func(ctx context.Context) (string, error)) Option {
 // also why it never takes more than half of what is left of the caller's
 // deadline, see barrierWaitWithin.
 const authBarrierWait = 500 * time.Millisecond
+
+// setupEventGrace is how long setupPending waits for a setup event that has not
+// arrived yet, to settle its race with the ack of the login the server rejects
+// because it has no users to match against.
+//
+// It is a variable so the tests can widen it, see export_test.go.
+//
+//nolint:gochecknoglobals // widened by the tests, constant everywhere else.
+var setupEventGrace = 10 * time.Millisecond
 
 // authMode is how the server wants the connection to be authenticated, as the
 // events it emits right after the connect state it.
@@ -212,6 +249,17 @@ type credentials struct {
 	token    string
 }
 
+// newCredentials gathers what New was given to authenticate with, and rejects a
+// username without a password (or the other way round): the server has no login
+// that takes one without the other, so it can only ever be a caller mistake.
+func newCredentials(username string, password string, token string) (credentials, error) {
+	if (username == "") != (password == "") {
+		return credentials{}, errors.New("credentials: username and password have to be set together")
+	}
+
+	return credentials{username: username, password: password, token: token}, nil
+}
+
 // loginError translates a rejected login ack into one of the package's sentinel
 // errors, so a caller can tell the cases apart with errors.Is instead of
 // matching on the message.
@@ -219,8 +267,16 @@ func loginError(command string, response ackResponse) error {
 	// A server from before the login messages were translated sends the
 	// message itself, and sends it with a trailing period the translation key
 	// that replaced it has no equivalent of, so it is matched by its prefix.
-	if strings.HasPrefix(response.Msg, "Incorrect username or password") {
-		return ErrInvalidCredentials
+	// The rate limiter's answer is a sentence on every version, because it was
+	// never given a key of its own.
+	if !response.MsgI18n {
+		if strings.HasPrefix(response.Msg, "Incorrect username or password") {
+			return ErrInvalidCredentials
+		}
+
+		if strings.HasPrefix(response.Msg, "Too frequently") {
+			return ErrRateLimited
+		}
 	}
 
 	switch response.Msg {
@@ -228,7 +284,7 @@ func loginError(command string, response ackResponse) error {
 		return ErrInvalidCredentials
 
 	case "authUserInactiveOrDeleted":
-		return fmt.Errorf("%w: %w", ErrInvalidSessionToken, ErrUserInactive)
+		return ErrUserInactive
 
 	case "authInvalidToken":
 		// The server answers two different rejections with this one message: a
@@ -239,6 +295,22 @@ func loginError(command string, response ackResponse) error {
 		}
 
 		return ErrInvalidTOTPCode
+
+	default:
+		return unclassifiedLoginError(command, response)
+	}
+}
+
+// unclassifiedLoginError reports a rejection this client version has no
+// sentinel for, without passing a translation key off as a sentence and without
+// producing an error with nothing in it when the server named no reason at all.
+func unclassifiedLoginError(command string, response ackResponse) error {
+	switch {
+	case response.Msg == "":
+		return fmt.Errorf("%s: the server rejected it without saying why", command)
+
+	case response.MsgI18n:
+		return fmt.Errorf("%s: the server reported the untranslated reason %q", command, response.Msg)
 
 	default:
 		return fmt.Errorf("%s: %s", command, response.Msg)
@@ -307,14 +379,14 @@ func barrierWaitWithin(ctx context.Context) time.Duration {
 	return min(authBarrierWait, max(time.Until(deadline)/2, 0))
 }
 
-// isSet reports whether a username and password were given.
-func (c credentials) isSet() bool {
+// hasPassword reports whether a username and password were given.
+func (c credentials) hasPassword() bool {
 	return c.username != "" && c.password != ""
 }
 
 // hasAny reports whether there is anything at all to authenticate with.
 func (c credentials) hasAny() bool {
-	return c.isSet() || c.token != ""
+	return c.hasPassword() || c.token != ""
 }
 
 // authenticate logs the client in the way the server asked for, and records the
@@ -327,7 +399,20 @@ func (c credentials) hasAny() bool {
 // still logged in to when credentials were given, because that is what produces
 // a session token, see Resync.
 func (c *Client) authenticate(ctx context.Context, creds credentials, barrier authBarrier) error {
-	switch barrier.await(ctx) {
+	mode := barrier.await(ctx)
+
+	// await answers authModeUnknown both for a server that stated nothing and
+	// for a wait the caller cut short. Only the context can tell those apart,
+	// and reading it here keeps a cancellation from being reported as a server
+	// that wants no login - which for a client without credentials would be a
+	// successful New, and for one with them a login emitted into a connection
+	// that is already being torn down.
+	err := ctx.Err()
+	if err != nil {
+		return fmt.Errorf("waiting for the server's auth mode: %w", err)
+	}
+
+	switch mode {
 	case authModeAutoLogin:
 		c.setAutoLoggedIn()
 
@@ -387,6 +472,10 @@ func (c *Client) authenticate(ctx context.Context, creds credentials, barrier au
 
 		c.setSessionTokenRejected()
 
+		if c.sessionTokenRejectedCallback != nil {
+			c.sessionTokenRejectedCallback(tokenErr)
+		}
+
 		return nil
 	}
 
@@ -402,7 +491,7 @@ func (c *Client) authenticate(ctx context.Context, creds credentials, barrier au
 func recoverableWithPassword(err error, creds credentials) bool {
 	return errors.Is(err, ErrInvalidSessionToken) &&
 		!errors.Is(err, ErrUserInactive) &&
-		creds.isSet()
+		creds.hasPassword()
 }
 
 // loginWithToken presents a session token from an earlier login, see
@@ -433,9 +522,7 @@ func (c *Client) loginWithPassword(ctx context.Context, username string, passwor
 	}
 
 	if response.OK {
-		c.setSessionToken(response.Token)
-
-		return nil
+		return c.keepSessionToken(response)
 	}
 
 	// An ack asking for a one-time code carries neither an ok nor a message,
@@ -462,7 +549,7 @@ func (c *Client) loginWithPassword(ctx context.Context, username string, passwor
 // deadline too short to outlast the replay guard, and a code rejected in two
 // consecutive steps, which is what rules the replay guard out.
 func (c *Client) loginWithTOTP(ctx context.Context, username string, password string) error {
-	if !c.totpCodeSet {
+	if c.totpCode == nil {
 		return ErrTwoFactorRequired
 	}
 
@@ -529,9 +616,7 @@ func (c *Client) loginOnceWithTOTP(
 	}
 
 	if response.OK {
-		c.setSessionToken(response.Token)
-
-		return codeStep, nil
+		return codeStep, c.keepSessionToken(response)
 	}
 
 	if response.TokenRequired {
@@ -542,6 +627,21 @@ func (c *Client) loginOnceWithTOTP(
 	}
 
 	return codeStep, loginError("login", response)
+}
+
+// keepSessionToken records the token an accepted login handed out.
+//
+// A success without one would leave the client authenticated but unable to
+// resync, and would surface far from here as Resync reporting a client that was
+// created without credentials, so it is reported where it happens instead.
+func (c *Client) keepSessionToken(response ackResponse) error {
+	if response.Token == "" {
+		return errors.New("login: the server accepted the login but handed out no session token")
+	}
+
+	c.setSessionToken(response.Token)
+
+	return nil
 }
 
 // awaitTOTPRetry waits out the time step the rejected code belongs to, so the
@@ -622,16 +722,21 @@ func waitForNextTOTPStep(ctx context.Context) (bool, error) {
 // setupPending reports whether the server asked to be set up.
 //
 // The setup event and the ack of a login the server rejects because it has no
-// users yet race each other, so the check is made after a moment rather than
-// straight away.
-func setupPending(setupRequired <-chan struct{}) bool {
-	time.Sleep(10 * time.Millisecond)
+// users yet race each other, so an event that has not arrived is given a moment
+// rather than being read as absent straight away. One that is already in costs
+// no wait, and a cancelled caller is not made to sit out the grace period.
+func setupPending(ctx context.Context, setupRequired <-chan struct{}) bool {
+	timer := time.NewTimer(setupEventGrace)
+	defer timer.Stop()
 
 	select {
 	case <-setupRequired:
 		return true
 
-	default:
+	case <-timer.C:
+		return false
+
+	case <-ctx.Done():
 		return false
 	}
 }

--- a/auth_barrier_test.go
+++ b/auth_barrier_test.go
@@ -1,0 +1,158 @@
+package kuma
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// barrierIterations is how often the cases below are repeated. Several of the
+// barrier's channels are ready in the same select, and select picks between
+// ready cases at random, so a single run would pass for the wrong reason about
+// half the time.
+const barrierIterations = 100
+
+// closedChan is a barrier event that has been delivered.
+func closedChan() <-chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+
+	return ch
+}
+
+// TestAuthBarrierSetupWins covers the server that is not set up yet: it emits
+// setup before it states how it wants to be authenticated, so both events are
+// in by the time the barrier is read. The setup has to win every time, or the
+// client sends a login that cannot succeed and the answer to the same
+// connection differs from run to run.
+func TestAuthBarrierSetupWins(t *testing.T) {
+	tests := map[string]authBarrier{
+		"with loginRequired": {
+			loginRequired: closedChan(),
+			autoLogin:     make(chan struct{}),
+			setupRequired: closedChan(),
+		},
+		"with autoLogin": {
+			loginRequired: make(chan struct{}),
+			autoLogin:     closedChan(),
+			setupRequired: closedChan(),
+		},
+	}
+
+	for name, barrier := range tests {
+		t.Run(name, func(t *testing.T) {
+			for range barrierIterations {
+				require.Equal(t, authModeSetup, barrier.await(t.Context()))
+			}
+		})
+	}
+}
+
+// TestAuthBarrierWithoutSetup covers the servers that ask for nothing of the
+// kind, which must not be answered with a setup they never requested.
+func TestAuthBarrierWithoutSetup(t *testing.T) {
+	tests := map[string]struct {
+		barrier authBarrier
+		want    authMode
+	}{
+		"login required": {
+			barrier: authBarrier{
+				loginRequired: closedChan(),
+				autoLogin:     make(chan struct{}),
+				setupRequired: make(chan struct{}),
+			},
+			want: authModeLoginRequired,
+		},
+		"auto login": {
+			barrier: authBarrier{
+				loginRequired: make(chan struct{}),
+				autoLogin:     closedChan(),
+				setupRequired: make(chan struct{}),
+			},
+			want: authModeAutoLogin,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			for range barrierIterations {
+				require.Equal(t, test.want, test.barrier.await(t.Context()))
+			}
+		})
+	}
+}
+
+// TestBarrierWaitWithin covers the budget the wait for a server that states
+// nothing is allowed to spend: a server too old to send either event must not
+// leave the login it does answer with no time at all.
+func TestBarrierWaitWithin(t *testing.T) {
+	t.Run("without deadline", func(t *testing.T) {
+		require.Equal(t, authBarrierWait, barrierWaitWithin(t.Context()))
+	})
+
+	t.Run("ample deadline", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+		defer cancel()
+
+		require.Equal(t, authBarrierWait, barrierWaitWithin(ctx))
+	})
+
+	t.Run("short deadline", func(t *testing.T) {
+		budget := authBarrierWait
+		ctx, cancel := context.WithTimeout(t.Context(), budget)
+		defer cancel()
+
+		wait := barrierWaitWithin(ctx)
+
+		require.Positive(t, wait)
+		require.LessOrEqual(t, wait, budget/2)
+	})
+
+	t.Run("expired deadline", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(t.Context(), 0)
+		defer cancel()
+
+		require.Equal(t, time.Duration(0), barrierWaitWithin(ctx))
+	})
+}
+
+// TestAwaitTOTPRetryStepAlreadyOver covers the login whose round trip crossed a
+// time step boundary: the code the server rejected belongs to a step that is
+// over, so the next code differs already and there is nothing left to wait for.
+func TestAwaitTOTPRetryStepAlreadyOver(t *testing.T) {
+	rejectedStep := totpStepStart(time.Now().Add(-totpStep))
+
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := awaitTOTPRetry(ctx, rejectedStep)
+
+	require.NoError(t, err)
+	require.Less(t, time.Since(start), 50*time.Millisecond)
+}
+
+// TestAwaitTOTPRetryDeadlineTooShort covers the caller whose deadline cannot
+// cover the wait for the next step, which is reported instead of run into.
+func TestAwaitTOTPRetryDeadlineTooShort(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), time.Millisecond)
+	defer cancel()
+
+	err := awaitTOTPRetry(ctx, totpStepStart(time.Now()))
+
+	require.ErrorIs(t, err, ErrInvalidTOTPCode)
+	require.Contains(t, err.Error(), "does not fit in the deadline")
+}
+
+// TestAwaitTOTPRetryCancelled covers the context that ends while the wait is
+// running, which says so rather than blaming the code.
+func TestAwaitTOTPRetryCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	err := awaitTOTPRetry(ctx, totpStepStart(time.Now()))
+
+	require.ErrorIs(t, err, context.Canceled)
+}

--- a/auth_e2e_test.go
+++ b/auth_e2e_test.go
@@ -1,0 +1,192 @@
+package kuma_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/ory/dockertest/v3"
+	"github.com/ory/dockertest/v3/docker"
+	"github.com/stretchr/testify/require"
+
+	kuma "github.com/breml/go-uptime-kuma-client"
+)
+
+// newKumaContainer starts an Uptime Kuma of its own and returns its base URL.
+//
+// The tests below turn two-factor authentication on for the admin account,
+// which every other test in this package logs in as, so they cannot share the
+// server TestMain brings up.
+func newKumaContainer(t *testing.T) string {
+	t.Helper()
+
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+	require.NoError(t, pool.Client.Ping())
+
+	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
+		Name:       fmt.Sprintf("uptime-kuma-auth-%s", randomString(8)),
+		Repository: "louislam/uptime-kuma",
+		Tag:        "2.5.0",
+		ExtraHosts: []string{"host.docker.internal:host-gateway"},
+	}, func(config *docker.HostConfig) {
+		config.AutoRemove = true
+		config.RestartPolicy = docker.RestartPolicy{Name: "no"}
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, resource.Expire(600))
+
+	t.Cleanup(func() {
+		purgeErr := pool.Purge(resource)
+		if purgeErr != nil {
+			log.Printf("Could not purge resource: %v", purgeErr)
+		}
+	})
+
+	baseURL := "http://localhost:" + resource.GetPort("3001/tcp")
+
+	// The server needs a moment before it accepts connections, and the first
+	// client is the one that runs the setup.
+	err = pool.Retry(func() error {
+		setupClient, setupErr := kuma.New(
+			t.Context(),
+			baseURL,
+			"admin", "admin1",
+			kuma.WithAutosetup(),
+			kuma.WithLogLevel(kuma.LogLevel(os.Getenv("SOCKETIO_LOG_LEVEL"))),
+			kuma.WithConnectTimeout(10*time.Second),
+		)
+		if setupErr != nil {
+			return setupErr
+		}
+
+		return setupClient.Disconnect()
+	})
+	require.NoError(t, err)
+
+	return baseURL
+}
+
+// TestAuthenticationAgainstServer covers the authentication paths that only a
+// real server can show: it turns two-factor authentication on for the admin
+// account and then logs in the ways a client without a human at the keyboard
+// has.
+//
+// Note the server's login rate limit of 20 per minute and the 30 per minute for
+// the two-factor commands. The sequence below stays inside both, a repeated run
+// against the same server would not.
+func TestAuthenticationAgainstServer(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	baseURL := newKumaContainer(t)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Minute)
+	defer cancel()
+
+	admin, err := kuma.New(ctx, baseURL, "admin", "admin1", kuma.WithConnectTimeout(10*time.Second))
+	require.NoError(t, err)
+
+	defer func() { _ = admin.Disconnect() }()
+
+	// The server checks the current password again for these commands, even
+	// though the connection is already authenticated.
+	secret, err := kuma.Prepare2FA(admin, ctx, "admin1")
+	require.NoError(t, err)
+	require.NotEmpty(t, secret)
+
+	normalized, err := kuma.NormalizeTOTPSecret(secret)
+	require.NoError(t, err)
+
+	require.NoError(t, kuma.Save2FA(admin, ctx, "admin1"))
+
+	// Deferred rather than registered as cleanup: the test context is already
+	// cancelled by the time cleanups run.
+	defer func() { _ = kuma.Disable2FA(admin, ctx, "admin1") }()
+
+	enabled, err := kuma.TwoFAStatus(admin, ctx)
+	require.NoError(t, err)
+	require.True(t, enabled)
+
+	t.Run("a login without a code is told what is missing", func(t *testing.T) {
+		client, newErr := kuma.New(
+			ctx,
+			baseURL,
+			"admin",
+			"admin1",
+			kuma.WithConnectTimeout(10*time.Second),
+		)
+
+		require.ErrorIs(t, newErr, kuma.ErrTwoFactorRequired)
+		require.Nil(t, client)
+	})
+
+	t.Run("the secret answers the request for a code", func(t *testing.T) {
+		client, newErr := kuma.New(
+			ctx,
+			baseURL,
+			"admin",
+			"admin1",
+			kuma.WithTOTPSecret(normalized),
+			kuma.WithConnectTimeout(10*time.Second),
+		)
+
+		require.NoError(t, newErr)
+		require.NotNil(t, client)
+
+		t.Cleanup(func() { _ = client.Disconnect() })
+	})
+
+	t.Run("a code the server has seen is refused", func(t *testing.T) {
+		// Line the two logins up inside one time step, which is what the
+		// server's replay guard reacts to. Without the alignment the second
+		// login could fall into the next step and succeed.
+		waitForFreshTOTPStep(t)
+
+		first, newErr := kuma.New(
+			ctx,
+			baseURL,
+			"admin",
+			"admin1",
+			kuma.WithTOTPSecret(normalized),
+			kuma.WithConnectTimeout(10*time.Second),
+		)
+		require.NoError(t, newErr)
+
+		t.Cleanup(func() { _ = first.Disconnect() })
+
+		// A connect timeout shorter than what is left of the step keeps the
+		// client from waiting the step out and retrying.
+		second, newErr := kuma.New(
+			ctx,
+			baseURL,
+			"admin",
+			"admin1",
+			kuma.WithTOTPSecret(normalized),
+			kuma.WithConnectTimeout(5*time.Second),
+		)
+
+		require.ErrorIs(t, newErr, kuma.ErrInvalidTOTPCode)
+		require.Nil(t, second)
+	})
+}
+
+// waitForFreshTOTPStep blocks until the current time step has ended, so that a
+// pair of logins made right afterwards falls into one step the server has not
+// seen a code from yet.
+//
+// Waiting for the boundary rather than for some headroom is what makes this
+// reliable: an earlier login in this test has already used the current step's
+// code, and the server refuses to see it again.
+func waitForFreshTOTPStep(t *testing.T) {
+	t.Helper()
+
+	const step = 30 * time.Second
+
+	time.Sleep(time.Until(time.Now().Truncate(step).Add(step)) + 100*time.Millisecond)
+}

--- a/auth_e2e_test.go
+++ b/auth_e2e_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strconv"
 	"testing"
 	"time"
 
@@ -82,6 +83,14 @@ func newKumaContainer(t *testing.T) string {
 func TestAuthenticationAgainstServer(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
+	}
+
+	// This one brings up a second Uptime Kuma of its own and waits out real
+	// time steps, so it is gated the way the other end-to-end tests are rather
+	// than run on every task test.
+	e2eTest, _ := strconv.ParseBool(os.Getenv("E2E_TEST"))
+	if !e2eTest {
+		t.Skip(`skipping end to end test, "E2E_TEST" env var not set`)
 	}
 
 	baseURL := newKumaContainer(t)

--- a/auth_e2e_test.go
+++ b/auth_e2e_test.go
@@ -113,6 +113,8 @@ func TestAuthenticationAgainstServer(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, enabled)
 
+	var sessionToken string
+
 	t.Run("a login without a code is told what is missing", func(t *testing.T) {
 		client, newErr := kuma.New(
 			ctx,
@@ -140,6 +142,30 @@ func TestAuthenticationAgainstServer(t *testing.T) {
 		require.NotNil(t, client)
 
 		t.Cleanup(func() { _ = client.Disconnect() })
+
+		sessionToken = client.SessionToken()
+		require.NotEmpty(t, sessionToken, "a login answers with the token it can be repeated with")
+	})
+
+	t.Run("the session token needs neither password nor code", func(t *testing.T) {
+		client, newErr := kuma.New(
+			ctx,
+			baseURL,
+			"",
+			"",
+			kuma.WithSessionToken(sessionToken),
+			kuma.WithConnectTimeout(10*time.Second),
+		)
+
+		require.NoError(t, newErr)
+		require.NotNil(t, client)
+
+		t.Cleanup(func() { _ = client.Disconnect() })
+
+		require.Equal(t, sessionToken, client.SessionToken())
+
+		// The lists come from a login, and the token is what repeats one.
+		require.NoError(t, client.Resync(ctx))
 	})
 
 	t.Run("a code the server has seen is refused", func(t *testing.T) {

--- a/auth_test.go
+++ b/auth_test.go
@@ -2,6 +2,7 @@ package kuma_test
 
 import (
 	"context"
+	"errors"
 	"net/http/httptest"
 	"os"
 	"strconv"
@@ -221,6 +222,10 @@ func TestResyncRejectedToken(t *testing.T) {
 // enabled against a client that holds the shared secret: the server asks for a
 // one-time code and the client answers it without a human at the keyboard.
 func TestNewWithTOTPSecret(t *testing.T) {
+	// The code is compared against one generated after New returned, so both
+	// have to fall into the same step for the comparison to mean anything.
+	requireTOTPStepHeadroom(t, 5*time.Second)
+
 	fake, url := newAuthFake(t)
 	fake.setTwoFactorSecret(false)
 
@@ -290,6 +295,13 @@ func TestNewWithTOTPCode(t *testing.T) {
 // current time step, so a caller whose deadline cannot cover that wait has to
 // be told promptly instead of being run into it.
 func TestNewTOTPReplayGuardTightDeadline(t *testing.T) {
+	// The deadline has to be shorter than the wait for the next step for this
+	// to cover anything, and how long that wait is depends on the time of day,
+	// so the step is given room for both before either is measured.
+	const tightDeadline = 3 * time.Second
+
+	requireTOTPStepHeadroom(t, 2*tightDeadline)
+
 	fake, url := newAuthFake(t)
 	fake.setTwoFactorSecret(true)
 
@@ -299,7 +311,7 @@ func TestNewTOTPReplayGuardTightDeadline(t *testing.T) {
 	require.NoError(t, err)
 	fake.useCode(code)
 
-	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), tightDeadline)
 	defer cancel()
 
 	start := time.Now()
@@ -315,7 +327,27 @@ func TestNewTOTPReplayGuardTightDeadline(t *testing.T) {
 
 	require.ErrorIs(t, err, kuma.ErrInvalidTOTPCode)
 	require.Nil(t, client)
-	require.Less(t, elapsed, 3*time.Second, "must not run into the deadline waiting for the next step")
+	require.Less(t, elapsed, tightDeadline, "must not run into the deadline waiting for the next step")
+}
+
+// requireTOTPStepHeadroom leaves at least want of the current time step, by
+// sleeping out a step that is nearly over.
+//
+// A test that says something about the wait for the next step otherwise says
+// it only for the time of day it happens to run at: near the end of a step
+// that wait is short, and a deadline meant to be too small to cover it covers
+// it after all.
+func requireTOTPStepHeadroom(t *testing.T, want time.Duration) {
+	t.Helper()
+
+	const step = 30 * time.Second
+
+	remaining := time.Until(time.Now().Truncate(step).Add(step))
+	if remaining > want {
+		return
+	}
+
+	time.Sleep(remaining + 100*time.Millisecond)
 }
 
 // TestNewTOTPSecretRejected covers the secret the client cannot decode, which
@@ -346,7 +378,157 @@ func TestNewTOTPOptionsConflict(t *testing.T) {
 	)
 
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "mutually exclusive")
+	require.Contains(t, err.Error(), "at most one")
+	require.Nil(t, client)
+}
+
+// TestNewTOTPCodeNil covers the nil callback, which is a caller who meant to
+// configure a code source and did not. It fails the connect rather than
+// leaving the client to report at login time that nothing was configured.
+func TestNewTOTPCodeNil(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	client, err := kuma.New(ctx, "http://127.0.0.1:1", "admin", "admin1", kuma.WithTOTPCode(nil))
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "nil callback")
+	require.Nil(t, client)
+}
+
+// TestNewTOTPOptionsConflictReportsTheConflictFirst covers both options given
+// with a secret that also fails to decode: the conflict is the caller's first
+// mistake, so fixing the secret must not be what uncovers it.
+func TestNewTOTPOptionsConflictReportsTheConflictFirst(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	client, err := kuma.New(
+		ctx,
+		"http://127.0.0.1:1",
+		"admin",
+		"admin1",
+		kuma.WithTOTPSecret("!!!"),
+		kuma.WithTOTPCode(func(context.Context) (string, error) { return "000000", nil }),
+	)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "at most one")
+	require.Nil(t, client)
+}
+
+// TestNewTOTPEmptyCode covers the callback that produces nothing, such as a
+// hardware token prompt the user dismissed. The server reads an empty code as
+// no code and asks again, in an ack carrying neither an ok nor a message, so
+// sending it would buy an error with nothing in it.
+func TestNewTOTPEmptyCode(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setTwoFactorSecret(false)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(
+		ctx,
+		url,
+		"admin",
+		"admin1",
+		kuma.WithTOTPCode(func(context.Context) (string, error) { return "", nil }),
+		kuma.WithConnectTimeout(5*time.Second),
+	)
+
+	require.ErrorIs(t, err, kuma.ErrTwoFactorRequired)
+	require.Nil(t, client)
+	require.Empty(t, fake.receivedLoginCodes()[1:], "an empty code is not worth sending")
+}
+
+// TestNewTOTPCodeFails covers the callback that reports an error, which is the
+// caller's own failure and has to reach them as one rather than as a rejected
+// code.
+func TestNewTOTPCodeFails(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setTwoFactorSecret(false)
+
+	wantErr := errors.New("hardware token unplugged")
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(
+		ctx,
+		url,
+		"admin",
+		"admin1",
+		kuma.WithTOTPCode(func(context.Context) (string, error) { return "", wantErr }),
+		kuma.WithConnectTimeout(5*time.Second),
+	)
+
+	require.ErrorIs(t, err, wantErr)
+	require.NotErrorIs(t, err, kuma.ErrInvalidTOTPCode)
+	require.Nil(t, client)
+}
+
+// TestNewTOTPRejectedForAnotherReason covers the coded login the server
+// rejects for something other than the code. Only a rejected code is worth the
+// retry, so anything else has to reach the caller as itself rather than as the
+// replay guard the retry would end in.
+func TestNewTOTPRejectedForAnotherReason(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setTwoFactorSecret(false)
+	fake.setRejectCodedLogin(true)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(
+		ctx,
+		url,
+		"admin",
+		"admin1",
+		kuma.WithTOTPSecret(rfc6238Secret),
+		kuma.WithConnectTimeout(5*time.Second),
+	)
+
+	require.ErrorIs(t, err, kuma.ErrInvalidCredentials)
+	require.NotErrorIs(t, err, kuma.ErrInvalidTOTPCode)
+	require.Nil(t, client)
+	require.Len(t, fake.receivedLoginCodes(), 2, "a rejection the retry cannot change is not retried")
+}
+
+// TestNewTOTPWaitCancelled covers the caller who gives up while the client is
+// waiting out the time step: the cancellation is what happened, and reporting
+// it as a rejected code would send them looking for a second client that used
+// the same one.
+func TestNewTOTPWaitCancelled(t *testing.T) {
+	requireTOTPStepHeadroom(t, 5*time.Second)
+
+	fake, url := newAuthFake(t)
+	fake.setTwoFactorSecret(true)
+
+	code, err := kuma.TOTPCodeAt(rfc6238Secret, time.Now())
+	require.NoError(t, err)
+	fake.useCode(code)
+
+	// No deadline, so the client commits to the wait instead of skipping it.
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	go func() {
+		for range 100 {
+			if len(fake.receivedLoginCodes()) > 1 {
+				break
+			}
+
+			time.Sleep(20 * time.Millisecond)
+		}
+
+		cancel()
+	}()
+
+	client, err := kuma.New(ctx, url, "admin", "admin1", kuma.WithTOTPSecret(rfc6238Secret))
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.NotErrorIs(t, err, kuma.ErrInvalidTOTPCode)
 	require.Nil(t, client)
 }
 
@@ -355,8 +537,8 @@ func TestNewTOTPOptionsConflict(t *testing.T) {
 // server has not seen, so the login goes through without the caller doing
 // anything.
 //
-// Waiting for the step boundary takes up to 30 seconds, so this runs only in
-// the end-to-end suite.
+// Waiting for the step boundary takes up to 30 seconds, so this runs only when
+// E2E_TEST is set, even though it drives the fake rather than a real server.
 func TestNewTOTPReplayGuardRecovers(t *testing.T) {
 	e2eTest, _ := strconv.ParseBool(os.Getenv("E2E_TEST"))
 	if !e2eTest {

--- a/auth_test.go
+++ b/auth_test.go
@@ -1,0 +1,216 @@
+package kuma_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	kuma "github.com/breml/go-uptime-kuma-client"
+)
+
+// newAuthFake starts a fakeAckServer and returns it together with its URL, so
+// each test can set the auth behaviour it needs before connecting.
+func newAuthFake(t *testing.T) (fake *fakeAckServer, url string) {
+	t.Helper()
+
+	fake = &fakeAckServer{messages: make(chan []byte, 32)}
+	server := httptest.NewServer(fake)
+
+	t.Cleanup(func() {
+		server.CloseClientConnections()
+		server.Close()
+	})
+
+	return fake, server.URL
+}
+
+// TestNewTwoFactorRequired covers the account with two-factor authentication
+// enabled. The server answers such a login with an ack that carries neither an
+// ok nor a message, which without the typed error surfaces as an error with an
+// empty message.
+func TestNewTwoFactorRequired(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setTwoFactorRequired(true)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(ctx, url, "admin", "admin1", kuma.WithConnectTimeout(5*time.Second))
+
+	require.ErrorIs(t, err, kuma.ErrTwoFactorRequired)
+	require.Nil(t, client)
+	require.Equal(t, 1, fake.loginFrameCount())
+}
+
+// TestNewInvalidCredentials covers the server that rejects the username and
+// password, without ever asking to be set up.
+func TestNewInvalidCredentials(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setRejectCreds(true)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(ctx, url, "admin", "wrong", kuma.WithConnectTimeout(5*time.Second))
+
+	require.ErrorIs(t, err, kuma.ErrInvalidCredentials)
+	require.Nil(t, client)
+}
+
+// TestNewAuthRequiredWithoutCredentials covers the caller that offers no
+// credentials to a server that asks for a login. Before the client observed
+// that request it had nothing to react to and waited out its connect timeout
+// instead.
+func TestNewAuthRequiredWithoutCredentials(t *testing.T) {
+	_, url := newAuthFake(t)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	client, err := kuma.New(ctx, url, "", "", kuma.WithConnectTimeout(5*time.Second))
+	elapsed := time.Since(start)
+
+	require.ErrorIs(t, err, kuma.ErrAuthRequired)
+	require.Nil(t, client)
+	require.Less(t, elapsed, 3*time.Second, "must not wait out the connect timeout")
+}
+
+// TestNewAutoLogin covers the server with authentication disabled: it logs the
+// client in itself and broadcasts the lists unprompted, so the client must not
+// send a login at all.
+func TestNewAutoLogin(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setAutoLogin(true)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(ctx, url, "", "", kuma.WithConnectTimeout(5*time.Second))
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	t.Cleanup(func() { _ = client.Disconnect() })
+
+	require.Equal(t, 0, fake.loginFrameCount())
+
+	// The server hands out no session token on this path, and has no command
+	// that resends every list, so a resync cannot work.
+	err = client.Resync(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "authentication disabled")
+}
+
+// TestNewWithoutLoginRequiredEvent covers the server that never states how it
+// wants to be authenticated, as a version too old to send the event or a proxy
+// dropping it does. The client falls back to logging in anyway.
+func TestNewWithoutLoginRequiredEvent(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setOmitLoginRequired(true)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(ctx, url, "admin", "admin1", kuma.WithConnectTimeout(5*time.Second))
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	t.Cleanup(func() { _ = client.Disconnect() })
+
+	require.Equal(t, 1, fake.loginFrameCount())
+}
+
+// TestNewLoginWaitsForLoginRequired covers the ordering the barrier exists for:
+// the server registers its login handler after an await and only then says it
+// wants a login, so a login sent before that can be dropped without a trace.
+func TestNewLoginWaitsForLoginRequired(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setLoginRequiredDelay(200 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(ctx, url, "admin", "admin1", kuma.WithConnectTimeout(5*time.Second))
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	t.Cleanup(func() { _ = client.Disconnect() })
+
+	require.True(
+		t,
+		fake.firstLoginAfterLoginRequired(),
+		"the login must not be sent before the server asked for one",
+	)
+}
+
+// TestNewSetupFallbackAfterRejectedCredentials covers the server that is not
+// set up yet: it has no user to match the credentials against, so it rejects
+// them and asks to be set up instead. Running the setup is what makes the same
+// credentials work, so the rejection must not end the connect.
+//
+// This is the regression guard for classifying that rejection by the message
+// the server sent rather than by matching on a formatted error string.
+func TestNewSetupFallbackAfterRejectedCredentials(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setSetupRequired(true)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(
+		ctx,
+		url,
+		"admin",
+		"admin1",
+		kuma.WithAutosetup(),
+		kuma.WithConnectTimeout(5*time.Second),
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	t.Cleanup(func() { _ = client.Disconnect() })
+}
+
+// TestNewRejectsHalfCredentials covers the caller that sets only one of the two
+// credentials, which used to reach the server as a login that could not
+// succeed.
+func TestNewRejectsHalfCredentials(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	client, err := kuma.New(ctx, "http://127.0.0.1:1", "admin", "")
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "have to be set together")
+	require.Nil(t, client)
+}
+
+// TestResyncRejectedToken covers the session token the server no longer
+// accepts, which is what a password change leaves behind.
+func TestResyncRejectedToken(t *testing.T) {
+	fake, url := newAuthFake(t)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(ctx, url, "admin", "admin1", kuma.WithConnectTimeout(5*time.Second))
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = client.Disconnect() })
+
+	fake.setRejectToken(true)
+
+	resyncCtx, resyncCancel := context.WithTimeout(ctx, 2*time.Second)
+	defer resyncCancel()
+
+	err = client.Resync(resyncCtx)
+
+	require.ErrorIs(t, err, kuma.ErrInvalidSessionToken)
+}

--- a/auth_test.go
+++ b/auth_test.go
@@ -181,6 +181,81 @@ func TestNewSetupFallbackAfterRejectedCredentials(t *testing.T) {
 	t.Cleanup(func() { _ = client.Disconnect() })
 }
 
+// untranslatedCredsRejection is what a server from before the login messages
+// were translated answers a rejected login with, trailing period included.
+const untranslatedCredsRejection = "Incorrect username or password."
+
+// TestNewSetupFallbackUntranslatedRejection covers the same setup fallback
+// against a server too old to send the translation key: it rejects the
+// credentials with the message itself, which the client has to recognize just
+// as well or the autosetup never runs.
+func TestNewSetupFallbackUntranslatedRejection(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setSetupRequired(true)
+	fake.setCredsRejectionMsg(untranslatedCredsRejection)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(
+		ctx,
+		url,
+		"admin",
+		"admin1",
+		kuma.WithAutosetup(),
+		kuma.WithConnectTimeout(5*time.Second),
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	t.Cleanup(func() { _ = client.Disconnect() })
+}
+
+// TestNewInvalidCredentialsUntranslated covers the wrong password against that
+// same older server, which has to reach the caller as ErrInvalidCredentials
+// rather than as the server's message.
+func TestNewInvalidCredentialsUntranslated(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setRejectCreds(true)
+	fake.setCredsRejectionMsg(untranslatedCredsRejection)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(ctx, url, "admin", "wrong", kuma.WithConnectTimeout(5*time.Second))
+
+	require.ErrorIs(t, err, kuma.ErrInvalidCredentials)
+	require.Nil(t, client)
+}
+
+// TestNewAutoLoginWithCredentials covers the server with authentication
+// disabled that is given credentials anyway: its login handler still works and
+// the login is the only thing that hands out a session token, so the client
+// has to send one to keep Resync working.
+func TestNewAutoLoginWithCredentials(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setAutoLogin(true)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(ctx, url, "admin", "admin1", kuma.WithConnectTimeout(5*time.Second))
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	t.Cleanup(func() { _ = client.Disconnect() })
+
+	require.Equal(t, 1, fake.loginFrameCount())
+	require.NotEmpty(t, client.SessionToken())
+
+	resyncCtx, resyncCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer resyncCancel()
+
+	require.NoError(t, client.Resync(resyncCtx))
+}
+
 // TestNewRejectsHalfCredentials covers the caller that sets only one of the two
 // credentials, which used to reach the server as a login that could not
 // succeed.

--- a/auth_test.go
+++ b/auth_test.go
@@ -391,3 +391,124 @@ func TestNewTOTPReplayGuardRecovers(t *testing.T) {
 	require.Len(t, codes, 3, "the login without a code, the rejected one and the retry")
 	require.NotEqual(t, codes[1], codes[2], "the retry has to fall into a later time step")
 }
+
+// TestNewWithSessionToken covers the client that holds a token from an earlier
+// login: it authenticates with no password and no one-time code at all.
+func TestNewWithSessionToken(t *testing.T) {
+	fake, url := newAuthFake(t)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(
+		ctx,
+		url,
+		"",
+		"",
+		kuma.WithSessionToken(fakeSessionToken),
+		kuma.WithConnectTimeout(5*time.Second),
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	t.Cleanup(func() { _ = client.Disconnect() })
+
+	require.Equal(t, 0, fake.loginFrameCount(), "a token login sends no password login")
+	require.Equal(t, fakeSessionToken, client.SessionToken())
+}
+
+// TestNewSessionTokenBypassesTwoFactor covers the reason a token is worth
+// keeping for an account with two-factor authentication: the server accepts it
+// without ever asking for a one-time code.
+func TestNewSessionTokenBypassesTwoFactor(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setTwoFactorSecret(false)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(
+		ctx,
+		url,
+		"",
+		"",
+		kuma.WithSessionToken(fakeSessionToken),
+		kuma.WithConnectTimeout(5*time.Second),
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	t.Cleanup(func() { _ = client.Disconnect() })
+
+	require.Empty(t, fake.receivedLoginCodes())
+}
+
+// TestNewRejectedSessionTokenFallsBack covers the token the server no longer
+// accepts, which is what a password change leaves behind. A caller that also
+// gave a username and password recovers with it.
+func TestNewRejectedSessionTokenFallsBack(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setRejectToken(true)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(
+		ctx,
+		url,
+		"admin",
+		"admin1",
+		kuma.WithSessionToken("stale-token"),
+		kuma.WithConnectTimeout(5*time.Second),
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	t.Cleanup(func() { _ = client.Disconnect() })
+
+	require.Equal(t, 1, fake.loginFrameCount(), "the password login is the fallback")
+	require.Equal(t, fakeSessionToken, client.SessionToken(), "the fresh token replaces the stale one")
+}
+
+// TestNewRejectedSessionTokenWithoutPassword covers the same rejection for a
+// caller that has nothing to fall back to.
+func TestNewRejectedSessionTokenWithoutPassword(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setRejectToken(true)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(
+		ctx,
+		url,
+		"",
+		"",
+		kuma.WithSessionToken("stale-token"),
+		kuma.WithConnectTimeout(5*time.Second),
+	)
+
+	require.ErrorIs(t, err, kuma.ErrInvalidSessionToken)
+	require.Nil(t, client)
+	require.Equal(t, 0, fake.loginFrameCount())
+}
+
+// TestSessionTokenAfterAutoLogin covers the server with authentication
+// disabled, which logs the client in without handing out a token.
+func TestSessionTokenAfterAutoLogin(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setAutoLogin(true)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(ctx, url, "", "", kuma.WithConnectTimeout(5*time.Second))
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = client.Disconnect() })
+
+	require.Empty(t, client.SessionToken())
+}

--- a/auth_test.go
+++ b/auth_test.go
@@ -207,7 +207,7 @@ func TestResyncRejectedToken(t *testing.T) {
 
 	t.Cleanup(func() { _ = client.Disconnect() })
 
-	fake.setRejectToken(true)
+	fake.setRejectToken()
 
 	resyncCtx, resyncCancel := context.WithTimeout(ctx, 2*time.Second)
 	defer resyncCancel()
@@ -405,7 +405,7 @@ func TestNewWithSessionToken(t *testing.T) {
 		url,
 		"",
 		"",
-		kuma.WithSessionToken(fakeSessionToken),
+		kuma.WithSessionToken(fakePresetToken),
 		kuma.WithConnectTimeout(5*time.Second),
 	)
 
@@ -415,7 +415,11 @@ func TestNewWithSessionToken(t *testing.T) {
 	t.Cleanup(func() { _ = client.Disconnect() })
 
 	require.Equal(t, 0, fake.loginFrameCount(), "a token login sends no password login")
-	require.Equal(t, fakeSessionToken, client.SessionToken())
+	require.Equal(t, []string{fakePresetToken}, fake.receivedTokens(),
+		"the configured token is what goes on the wire")
+	require.Equal(t, fakePresetToken, client.SessionToken(),
+		"a loginByToken is answered without a token, so the one that worked is kept")
+	require.False(t, client.SessionTokenRejected())
 }
 
 // TestNewSessionTokenBypassesTwoFactor covers the reason a token is worth
@@ -433,7 +437,7 @@ func TestNewSessionTokenBypassesTwoFactor(t *testing.T) {
 		url,
 		"",
 		"",
-		kuma.WithSessionToken(fakeSessionToken),
+		kuma.WithSessionToken(fakePresetToken),
 		kuma.WithConnectTimeout(5*time.Second),
 	)
 
@@ -442,6 +446,7 @@ func TestNewSessionTokenBypassesTwoFactor(t *testing.T) {
 
 	t.Cleanup(func() { _ = client.Disconnect() })
 
+	require.Equal(t, 0, fake.loginFrameCount(), "the token login never asks for a code")
 	require.Empty(t, fake.receivedLoginCodes())
 }
 
@@ -450,7 +455,7 @@ func TestNewSessionTokenBypassesTwoFactor(t *testing.T) {
 // gave a username and password recovers with it.
 func TestNewRejectedSessionTokenFallsBack(t *testing.T) {
 	fake, url := newAuthFake(t)
-	fake.setRejectToken(true)
+	fake.setRejectToken()
 
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
@@ -469,15 +474,19 @@ func TestNewRejectedSessionTokenFallsBack(t *testing.T) {
 
 	t.Cleanup(func() { _ = client.Disconnect() })
 
+	require.Equal(t, []string{"stale-token"}, fake.receivedTokens(), "the token is tried first")
 	require.Equal(t, 1, fake.loginFrameCount(), "the password login is the fallback")
+	require.True(t, fake.loginAfterToken(), "the password login follows the rejected token")
 	require.Equal(t, fakeSessionToken, client.SessionToken(), "the fresh token replaces the stale one")
+	require.True(t, client.SessionTokenRejected(),
+		"the caller has no other way to learn that the token it stored is dead")
 }
 
 // TestNewRejectedSessionTokenWithoutPassword covers the same rejection for a
 // caller that has nothing to fall back to.
 func TestNewRejectedSessionTokenWithoutPassword(t *testing.T) {
 	fake, url := newAuthFake(t)
-	fake.setRejectToken(true)
+	fake.setRejectToken()
 
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
@@ -493,7 +502,84 @@ func TestNewRejectedSessionTokenWithoutPassword(t *testing.T) {
 
 	require.ErrorIs(t, err, kuma.ErrInvalidSessionToken)
 	require.Nil(t, client)
+	require.Equal(t, []string{"stale-token"}, fake.receivedTokens())
 	require.Equal(t, 0, fake.loginFrameCount())
+}
+
+// TestNewRejectedSessionTokenAndPassword covers the caller whose stored token
+// and stored password are both stale: the rejected token has to survive in the
+// error, because the password failure alone sends the caller after the wrong
+// credential.
+func TestNewRejectedSessionTokenAndPassword(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setRejectToken()
+	fake.setRejectCreds(true)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(
+		ctx,
+		url,
+		"admin",
+		"outdated",
+		kuma.WithSessionToken("stale-token"),
+		kuma.WithConnectTimeout(5*time.Second),
+	)
+
+	require.Nil(t, client)
+	require.ErrorIs(t, err, kuma.ErrInvalidCredentials)
+	require.ErrorIs(t, err, kuma.ErrInvalidSessionToken,
+		"the rejected token is what sent the login to the password")
+}
+
+// TestNewSessionTokenUserInactive covers the rejection a password cannot
+// recover from, because the server requires an active user for that login too.
+func TestNewSessionTokenUserInactive(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setRejectTokenWith("authUserInactiveOrDeleted")
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(
+		ctx,
+		url,
+		"admin",
+		"admin1",
+		kuma.WithSessionToken("token-of-a-deactivated-user"),
+		kuma.WithConnectTimeout(5*time.Second),
+	)
+
+	require.Nil(t, client)
+	require.ErrorIs(t, err, kuma.ErrUserInactive)
+	require.ErrorIs(t, err, kuma.ErrInvalidSessionToken, "the token is gone either way")
+	require.Equal(t, 0, fake.loginFrameCount(),
+		"a password login for a deactivated user fails just the same")
+}
+
+// TestNewSessionTokenUnknownRejection covers a refusal the client does not
+// recognize, which says nothing about the password and is reported as it is.
+func TestNewSessionTokenUnknownRejection(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setRejectTokenWith("somethingElseEntirely")
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(
+		ctx,
+		url,
+		"admin",
+		"admin1",
+		kuma.WithSessionToken("stale-token"),
+		kuma.WithConnectTimeout(5*time.Second),
+	)
+
+	require.Nil(t, client)
+	require.ErrorContains(t, err, "somethingElseEntirely")
+	require.NotErrorIs(t, err, kuma.ErrInvalidSessionToken)
+	require.Equal(t, 0, fake.loginFrameCount(), "only a rejected token falls back to the password")
 }
 
 // TestSessionTokenAfterAutoLogin covers the server with authentication

--- a/auth_test.go
+++ b/auth_test.go
@@ -179,6 +179,12 @@ func TestNewSetupFallbackAfterRejectedCredentials(t *testing.T) {
 	require.NotNil(t, client)
 
 	t.Cleanup(func() { _ = client.Disconnect() })
+
+	// The server sends the setup event and loginRequired in one payload, and
+	// answering the setup is what makes the credentials work, so the only
+	// login is the one the setup ends with. A client that answers the
+	// loginRequired instead sends a doomed one before it.
+	require.Equal(t, 1, fake.loginFrameCount())
 }
 
 // untranslatedCredsRejection is what a server from before the login messages
@@ -254,6 +260,58 @@ func TestNewAutoLoginWithCredentials(t *testing.T) {
 	defer resyncCancel()
 
 	require.NoError(t, client.Resync(resyncCtx))
+}
+
+// TestNewSetupWithoutCredentials covers the server that is not set up yet and
+// is given nothing to set it up with: the setup it asks for is what the client
+// has to report as unanswerable, not the login the same payload also asks for.
+// Which of the two events wins when both are in is settled in
+// TestAuthBarrierSetupWins.
+func TestNewSetupWithoutCredentials(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setSetupRequired(true)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(
+		ctx,
+		url,
+		"",
+		"",
+		kuma.WithAutosetup(),
+		kuma.WithConnectTimeout(5*time.Second),
+	)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "needs a username and password")
+	require.Nil(t, client)
+	require.Equal(t, 0, fake.loginFrameCount())
+}
+
+// TestNewShortConnectTimeoutWithoutLoginRequired covers the short connect
+// timeout against a server that never states how it wants to be authenticated.
+// The wait for that statement is bounded by what is left of the caller's
+// budget, so the login that follows still has time to run.
+func TestNewShortConnectTimeoutWithoutLoginRequired(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setOmitLoginRequired(true)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(
+		ctx,
+		url,
+		"admin",
+		"admin1",
+		kuma.WithConnectTimeout(400*time.Millisecond),
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	t.Cleanup(func() { _ = client.Disconnect() })
 }
 
 // TestNewRejectsHalfCredentials covers the caller that sets only one of the two

--- a/auth_test.go
+++ b/auth_test.go
@@ -52,7 +52,7 @@ func TestNewTwoFactorRequired(t *testing.T) {
 // password, without ever asking to be set up.
 func TestNewInvalidCredentials(t *testing.T) {
 	fake, url := newAuthFake(t)
-	fake.setRejectCreds(true)
+	fake.setRejectCreds()
 
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
@@ -113,7 +113,7 @@ func TestNewAutoLogin(t *testing.T) {
 // dropping it does. The client falls back to logging in anyway.
 func TestNewWithoutLoginRequiredEvent(t *testing.T) {
 	fake, url := newAuthFake(t)
-	fake.setOmitLoginRequired(true)
+	fake.setOmitLoginRequired()
 
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
@@ -157,8 +157,10 @@ func TestNewLoginWaitsForLoginRequired(t *testing.T) {
 // them and asks to be set up instead. Running the setup is what makes the same
 // credentials work, so the rejection must not end the connect.
 //
-// This is the regression guard for classifying that rejection by the message
-// the server sent rather than by matching on a formatted error string.
+// This is the case where the setup event is already in when the barrier reads
+// it, so the client never sends the doomed login at all. The other ordering,
+// where it arrives only after the rejection, is
+// TestNewSetupFallbackAfterLateSetupEvent.
 func TestNewSetupFallbackAfterRejectedCredentials(t *testing.T) {
 	fake, url := newAuthFake(t)
 	fake.setSetupRequired(true)
@@ -187,6 +189,65 @@ func TestNewSetupFallbackAfterRejectedCredentials(t *testing.T) {
 	require.Equal(t, 1, fake.loginFrameCount())
 }
 
+// TestNewSetupFallbackAfterLateSetupEvent covers the ordering the fallback
+// exists for: the server states that it wants a login, rejects the credentials
+// it has no user for, and only then does the setup event arrive.
+//
+// Nothing guarantees the barrier sees the setup event first - a real client
+// dispatches every handler on its own goroutine, so two events of one payload
+// have no delivery order - which is why the rejection is re-examined instead of
+// being handed to the caller. This is the regression guard for classifying that
+// rejection by the message the server sent rather than by matching on a
+// formatted error string.
+func TestNewSetupFallbackAfterLateSetupEvent(t *testing.T) {
+	t.Cleanup(kuma.SetSetupEventGrace(2 * time.Second))
+
+	fake, url := newAuthFake(t)
+	fake.setLateSetup(50 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(
+		ctx,
+		url,
+		"admin",
+		"admin1",
+		kuma.WithAutosetup(),
+		kuma.WithConnectTimeout(5*time.Second),
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	t.Cleanup(func() { _ = client.Disconnect() })
+
+	// The doomed login the client answered loginRequired with, and the one the
+	// setup ends with. A client that gave up on the rejection sends only the
+	// first and never reaches this.
+	require.Equal(t, 2, fake.loginFrameCount())
+}
+
+// TestNewSetupRequiredWithoutAutosetup covers the same server for a caller that
+// did not ask for the setup to be run: the rejection it gets has to say that
+// the server wants to be set up, not that the password is wrong.
+func TestNewSetupRequiredWithoutAutosetup(t *testing.T) {
+	t.Cleanup(kuma.SetSetupEventGrace(2 * time.Second))
+
+	fake, url := newAuthFake(t)
+	fake.setLateSetup(50 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(ctx, url, "admin", "admin1", kuma.WithConnectTimeout(5*time.Second))
+
+	require.Error(t, err)
+	require.Nil(t, client)
+	require.NotErrorIs(t, err, kuma.ErrInvalidCredentials)
+	require.Contains(t, err.Error(), "autosetup is disabled")
+}
+
 // untranslatedCredsRejection is what a server from before the login messages
 // were translated answers a rejected login with, trailing period included.
 const untranslatedCredsRejection = "Incorrect username or password."
@@ -196,8 +257,10 @@ const untranslatedCredsRejection = "Incorrect username or password."
 // credentials with the message itself, which the client has to recognize just
 // as well or the autosetup never runs.
 func TestNewSetupFallbackUntranslatedRejection(t *testing.T) {
+	t.Cleanup(kuma.SetSetupEventGrace(2 * time.Second))
+
 	fake, url := newAuthFake(t)
-	fake.setSetupRequired(true)
+	fake.setLateSetup(50 * time.Millisecond)
 	fake.setCredsRejectionMsg(untranslatedCredsRejection)
 
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
@@ -216,6 +279,10 @@ func TestNewSetupFallbackUntranslatedRejection(t *testing.T) {
 	require.NotNil(t, client)
 
 	t.Cleanup(func() { _ = client.Disconnect() })
+
+	// The untranslated rejection had to be recognized for the setup to run at
+	// all, which the second login is the evidence of.
+	require.Equal(t, 2, fake.loginFrameCount())
 }
 
 // TestNewInvalidCredentialsUntranslated covers the wrong password against that
@@ -223,7 +290,7 @@ func TestNewSetupFallbackUntranslatedRejection(t *testing.T) {
 // rather than as the server's message.
 func TestNewInvalidCredentialsUntranslated(t *testing.T) {
 	fake, url := newAuthFake(t)
-	fake.setRejectCreds(true)
+	fake.setRejectCreds()
 	fake.setCredsRejectionMsg(untranslatedCredsRejection)
 
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
@@ -295,7 +362,7 @@ func TestNewSetupWithoutCredentials(t *testing.T) {
 // budget, so the login that follows still has time to run.
 func TestNewShortConnectTimeoutWithoutLoginRequired(t *testing.T) {
 	fake, url := newAuthFake(t)
-	fake.setOmitLoginRequired(true)
+	fake.setOmitLoginRequired()
 
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
@@ -828,7 +895,7 @@ func TestNewRejectedSessionTokenWithoutPassword(t *testing.T) {
 func TestNewRejectedSessionTokenAndPassword(t *testing.T) {
 	fake, url := newAuthFake(t)
 	fake.setRejectToken()
-	fake.setRejectCreds(true)
+	fake.setRejectCreds()
 
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
@@ -912,4 +979,197 @@ func TestSessionTokenAfterAutoLogin(t *testing.T) {
 	t.Cleanup(func() { _ = client.Disconnect() })
 
 	require.Empty(t, client.SessionToken())
+}
+
+// TestNewCancelledDuringAuthBarrier covers the caller that gives up while the
+// client is still waiting for the server to state how it wants to be
+// authenticated.
+//
+// The barrier answers that wait and a server that stated nothing with the same
+// value, so without reading the context back a cancellation would be reported
+// as a server that wants no login: a successful New for a client with no
+// credentials, and for one with them a login emitted into a connection that is
+// already being torn down.
+func TestNewCancelledDuringAuthBarrier(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		username string
+		password string
+	}{
+		{name: "without_credentials"},
+		{name: "with_credentials", username: "admin", password: "admin1"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fake, url := newAuthFake(t)
+
+			// A server that states nothing is what makes the barrier wait at
+			// all, so the cancellation below lands inside that wait rather
+			// than in the connect before it.
+			fake.setOmitLoginRequired()
+
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+
+			go func() {
+				time.Sleep(250 * time.Millisecond)
+				cancel()
+			}()
+
+			client, err := kuma.New(
+				ctx, url, tc.username, tc.password,
+				// Long enough that only the cancellation can end the wait.
+				kuma.WithConnectTimeout(30*time.Second),
+			)
+
+			require.Nil(t, client)
+			require.ErrorIs(t, err, context.Canceled)
+
+			// Naming the barrier is what distinguishes the fix from a
+			// cancellation merely caught later, by the ready wait or by a
+			// login sent into a connection already being torn down.
+			require.ErrorContains(t, err, "auth mode")
+		})
+	}
+}
+
+// TestNewLoginWithoutSessionToken covers the server that accepts a login and
+// hands out no token with it. The client is authenticated but cannot resync,
+// which is reported where it happens rather than surfacing much later as a
+// Resync claiming the client was created without credentials.
+func TestNewLoginWithoutSessionToken(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setOmitLoginToken(true)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(ctx, url, "admin", "admin1", kuma.WithConnectTimeout(5*time.Second))
+
+	require.Nil(t, client)
+	require.ErrorContains(t, err, "handed out no session token")
+}
+
+// TestNewRateLimited covers the server refusing a login because too many were
+// attempted in a short time. It says so in a sentence rather than a translation
+// key, and a caller has to be able to tell it from a wrong password: one is
+// worth retrying later, the other never is.
+func TestNewRateLimited(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setRejectCreds()
+	fake.setCredsRejectionMsg("Too frequently, try again later.")
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(ctx, url, "admin", "admin1", kuma.WithConnectTimeout(5*time.Second))
+
+	require.Nil(t, client)
+	require.ErrorIs(t, err, kuma.ErrRateLimited)
+	require.NotErrorIs(t, err, kuma.ErrInvalidCredentials)
+}
+
+// TestNewUnclassifiedRejection covers the two rejections this client version
+// has no sentinel for: a translation key it does not know, which must not be
+// passed off as a sentence, and a rejection naming no reason at all, which
+// without this reaches the caller as an error with nothing in it.
+func TestNewUnclassifiedRejection(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		ack  string
+		want string
+	}{
+		{
+			name: "unknown_translation_key",
+			ack:  `{"ok":false,"msg":"authSomethingNew","msgi18n":true}`,
+			want: `untranslated reason "authSomethingNew"`,
+		},
+		{
+			name: "no_reason_at_all",
+			ack:  `{"ok":false,"msg":""}`,
+			want: "rejected it without saying why",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fake, url := newAuthFake(t)
+			fake.setCredsRejectionAck(tc.ack)
+
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+			defer cancel()
+
+			client, err := kuma.New(ctx, url, "admin", "admin1", kuma.WithConnectTimeout(5*time.Second))
+
+			require.Nil(t, client)
+			require.ErrorContains(t, err, tc.want)
+			require.NotErrorIs(t, err, kuma.ErrInvalidCredentials)
+		})
+	}
+}
+
+// TestErrUserInactiveWrapsInvalidSessionToken covers the relationship the
+// sentinel documents. It is what recoverableWithPassword reads to skip the
+// password fallback, so it has to hold for the sentinel itself and not only for
+// the error one particular call site builds.
+func TestErrUserInactiveWrapsInvalidSessionToken(t *testing.T) {
+	require.ErrorIs(t, kuma.ErrUserInactive, kuma.ErrInvalidSessionToken)
+}
+
+// TestNewSessionTokenRejectedCallback covers the pushed form of
+// SessionTokenRejected: the fallback leaves New succeeding, so a caller that
+// persists tokens is told as it happens instead of having to remember to ask.
+func TestNewSessionTokenRejectedCallback(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setRejectToken()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	var rejected []error
+
+	client, err := kuma.New(
+		ctx,
+		url,
+		"admin",
+		"admin1",
+		kuma.WithSessionToken("stale-token"),
+		kuma.WithSessionTokenRejectedCallback(func(err error) { rejected = append(rejected, err) }),
+		kuma.WithConnectTimeout(5*time.Second),
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	t.Cleanup(func() { _ = client.Disconnect() })
+
+	require.Len(t, rejected, 1, "the callback reports the one token that was refused")
+	require.ErrorIs(t, rejected[0], kuma.ErrInvalidSessionToken)
+	require.True(t, client.SessionTokenRejected())
+}
+
+// TestNewSessionTokenAcceptedSkipsCallback covers the other half: a client
+// whose token the server took never calls the callback, so a caller can treat
+// it as the signal to rewrite what it stored.
+func TestNewSessionTokenAcceptedSkipsCallback(t *testing.T) {
+	_, url := newAuthFake(t)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	called := false
+
+	client, err := kuma.New(
+		ctx,
+		url,
+		"admin",
+		"admin1",
+		kuma.WithSessionToken(fakePresetToken),
+		kuma.WithSessionTokenRejectedCallback(func(error) { called = true }),
+		kuma.WithConnectTimeout(5*time.Second),
+	)
+
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = client.Disconnect() })
+
+	require.False(t, called)
+	require.False(t, client.SessionTokenRejected())
 }

--- a/auth_test.go
+++ b/auth_test.go
@@ -3,6 +3,8 @@ package kuma_test
 import (
 	"context"
 	"net/http/httptest"
+	"os"
+	"strconv"
 	"testing"
 	"time"
 
@@ -213,4 +215,179 @@ func TestResyncRejectedToken(t *testing.T) {
 	err = client.Resync(resyncCtx)
 
 	require.ErrorIs(t, err, kuma.ErrInvalidSessionToken)
+}
+
+// TestNewWithTOTPSecret covers the account with two-factor authentication
+// enabled against a client that holds the shared secret: the server asks for a
+// one-time code and the client answers it without a human at the keyboard.
+func TestNewWithTOTPSecret(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setTwoFactorSecret(false)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(
+		ctx,
+		url,
+		"admin",
+		"admin1",
+		kuma.WithTOTPSecret(rfc6238Secret),
+		kuma.WithConnectTimeout(5*time.Second),
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	t.Cleanup(func() { _ = client.Disconnect() })
+
+	// The code is generated only once the server asks for one, because the
+	// server evaluates the fields of a login independently and would verify a
+	// code it never asked for against a secret that does not exist.
+	codes := fake.receivedLoginCodes()
+	require.Len(t, codes, 2)
+	require.Empty(t, codes[0])
+
+	want, err := kuma.TOTPCodeAt(rfc6238Secret, time.Now())
+	require.NoError(t, err)
+	require.Equal(t, want, codes[1])
+}
+
+// TestNewWithTOTPCode covers the caller whose secret lives somewhere the client
+// cannot read it, so it hands over a callback instead.
+func TestNewWithTOTPCode(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setTwoFactorSecret(false)
+
+	calls := 0
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(
+		ctx,
+		url,
+		"admin",
+		"admin1",
+		kuma.WithTOTPCode(func(context.Context) (string, error) {
+			calls++
+
+			return kuma.TOTPCodeAt(rfc6238Secret, time.Now())
+		}),
+		kuma.WithConnectTimeout(5*time.Second),
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	t.Cleanup(func() { _ = client.Disconnect() })
+
+	require.Equal(t, 1, calls, "the code is asked for only once the server wants one")
+}
+
+// TestNewTOTPReplayGuardTightDeadline covers the code the server has accepted
+// before, which it refuses to see again. Recovering means waiting out the
+// current time step, so a caller whose deadline cannot cover that wait has to
+// be told promptly instead of being run into it.
+func TestNewTOTPReplayGuardTightDeadline(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setTwoFactorSecret(true)
+
+	// Use up the code of the current step, the way another client logging in
+	// with the same account just before would have.
+	code, err := kuma.TOTPCodeAt(rfc6238Secret, time.Now())
+	require.NoError(t, err)
+	fake.useCode(code)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	client, err := kuma.New(
+		ctx,
+		url,
+		"admin",
+		"admin1",
+		kuma.WithTOTPSecret(rfc6238Secret),
+		kuma.WithConnectTimeout(3*time.Second),
+	)
+	elapsed := time.Since(start)
+
+	require.ErrorIs(t, err, kuma.ErrInvalidTOTPCode)
+	require.Nil(t, client)
+	require.Less(t, elapsed, 3*time.Second, "must not run into the deadline waiting for the next step")
+}
+
+// TestNewTOTPSecretRejected covers the secret the client cannot decode, which
+// fails the connect rather than the login it would be needed for.
+func TestNewTOTPSecretRejected(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	client, err := kuma.New(ctx, "http://127.0.0.1:1", "admin", "admin1", kuma.WithTOTPSecret("!!!"))
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "totp secret")
+	require.Nil(t, client)
+}
+
+// TestNewTOTPOptionsConflict covers configuring both ways of producing a code.
+func TestNewTOTPOptionsConflict(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	client, err := kuma.New(
+		ctx,
+		"http://127.0.0.1:1",
+		"admin",
+		"admin1",
+		kuma.WithTOTPSecret(rfc6238Secret),
+		kuma.WithTOTPCode(func(context.Context) (string, error) { return "000000", nil }),
+	)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "mutually exclusive")
+	require.Nil(t, client)
+}
+
+// TestNewTOTPReplayGuardRecovers covers the same rejection with a deadline
+// generous enough to wait the time step out: the next step produces a code the
+// server has not seen, so the login goes through without the caller doing
+// anything.
+//
+// Waiting for the step boundary takes up to 30 seconds, so this runs only in
+// the end-to-end suite.
+func TestNewTOTPReplayGuardRecovers(t *testing.T) {
+	e2eTest, _ := strconv.ParseBool(os.Getenv("E2E_TEST"))
+	if !e2eTest {
+		t.Skip("skipping test that waits out a TOTP time step")
+	}
+
+	fake, url := newAuthFake(t)
+	fake.setTwoFactorSecret(true)
+
+	code, err := kuma.TOTPCodeAt(rfc6238Secret, time.Now())
+	require.NoError(t, err)
+	fake.useCode(code)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 90*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(
+		ctx,
+		url,
+		"admin",
+		"admin1",
+		kuma.WithTOTPSecret(rfc6238Secret),
+		kuma.WithConnectTimeout(60*time.Second),
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	t.Cleanup(func() { _ = client.Disconnect() })
+
+	codes := fake.receivedLoginCodes()
+	require.Len(t, codes, 3, "the login without a code, the rejected one and the retry")
+	require.NotEqual(t, codes[1], codes[2], "the retry has to fall into a later time step")
 }

--- a/client.go
+++ b/client.go
@@ -224,6 +224,16 @@ type Client struct {
 	// see Resync.
 	autoLoggedIn bool
 
+	// totpCode produces the one-time code for an account with two-factor
+	// authentication enabled, see WithTOTPSecret and WithTOTPCode.
+	// totpCodeSet tells a configured callback from none, totpSources counts
+	// how many of the two options set one, and totpErr carries a secret New
+	// has to reject.
+	totpCode    func(ctx context.Context) (string, error)
+	totpCodeSet bool
+	totpSources int
+	totpErr     error
+
 	// readyEventsMissing are the best-effort ready events the server did not
 	// emit while New was connecting, see MissingReadyEvents.
 	readyEventsMissing []string
@@ -473,6 +483,14 @@ func New(ctx context.Context, baseURL string, username string, password string, 
 
 	if (username == "") != (password == "") {
 		return nil, errors.New("credentials: username and password have to be set together")
+	}
+
+	if c.totpErr != nil {
+		return nil, c.totpErr
+	}
+
+	if c.totpSources > 1 {
+		return nil, errors.New("totp: WithTOTPSecret and WithTOTPCode are mutually exclusive")
 	}
 
 	ctxWithConnectTimeout := ctx
@@ -1204,6 +1222,12 @@ type ackResponse struct {
 
 	// MsgI18n reports that Msg is a translation key rather than a sentence.
 	MsgI18n bool `json:"msgi18n"`
+
+	// URI is the otpauth:// URI a prepare2FA answers with.
+	URI string `json:"uri"`
+
+	// Status is whether two-factor authentication is on, from a twoFAStatus.
+	Status bool `json:"status"`
 
 	Token           string         `json:"token"`
 	ID              int64          `json:"id"`

--- a/client.go
+++ b/client.go
@@ -219,6 +219,11 @@ type Client struct {
 	// Resync logs in with, see there.
 	sessionToken string
 
+	// autoLoggedIn records that the server has authentication disabled and
+	// logged the client in itself, which leaves it without a session token,
+	// see Resync.
+	autoLoggedIn bool
+
 	// readyEventsMissing are the best-effort ready events the server did not
 	// emit while New was connecting, see MissingReadyEvents.
 	readyEventsMissing []string
@@ -466,6 +471,10 @@ func New(ctx context.Context, baseURL string, username string, password string, 
 		return nil, fmt.Errorf("ready events: unknown: %s", strings.Join(unknown, ", "))
 	}
 
+	if (username == "") != (password == "") {
+		return nil, errors.New("credentials: username and password have to be set together")
+	}
+
 	ctxWithConnectTimeout := ctx
 
 	// connectTimeoutDone is non-nil only when WithConnectTimeout is
@@ -632,6 +641,35 @@ func New(ctx context.Context, baseURL string, username string, password string, 
 		})
 	}
 
+	// The server states how it wants the connection to be authenticated as the
+	// last thing it does for it, so these are registered before the connect and
+	// unconditionally, see authBarrier.
+	loginRequired := make(chan struct{})
+	closeLoginRequired := sync.OnceFunc(func() {
+		close(loginRequired)
+	})
+	defer closeLoginRequired()
+
+	client.On("loginRequired", func() {
+		closeLoginRequired()
+	})
+
+	autoLogin := make(chan struct{})
+	closeAutoLogin := sync.OnceFunc(func() {
+		close(autoLogin)
+	})
+	defer closeAutoLogin()
+
+	client.On("autoLogin", func() {
+		closeAutoLogin()
+	})
+
+	barrier := authBarrier{
+		loginRequired: loginRequired,
+		autoLogin:     autoLogin,
+		setupRequired: setupRequired,
+	}
+
 	client.OnAny(func(s string, _ []any) {
 		if s != "notificationList" && s != "monitorList" && s != "statusPageList" && s != "maintenanceList" &&
 			s != "proxyList" &&
@@ -701,34 +739,17 @@ connectLoop:
 		}
 	}()
 
-	if username != "" && password != "" {
-		var loginResponse ackResponse
-
-		loginResponse, err = c.syncEmit(
-			ctxWithConnectTimeout,
-			"login",
-			map[string]any{"username": username, "password": password, "token": ""},
-		)
-		if err == nil {
-			c.setSessionToken(loginResponse.Token)
-		}
-
-		if err != nil {
-			// Ensure we had the time to receive a potential setup event.
-			time.Sleep(10 * time.Millisecond)
-
-			wantSetup := false
-			select {
-			case <-setupRequired:
-				wantSetup = true
-
-			default:
-			}
-
-			if (!strings.Contains(err.Error(), "Incorrect username or password") && !strings.Contains(err.Error(), "authIncorrectCreds")) ||
-				!wantSetup {
-				return nil, fmt.Errorf("login: %w", err)
-			}
+	err = c.authenticate(
+		ctxWithConnectTimeout,
+		credentials{username: username, password: password},
+		barrier,
+	)
+	if err != nil {
+		// A server that is not set up yet rejects the credentials it does not
+		// have a user for; running the setup is what makes them work, so that
+		// is not a failure when the server asked for one.
+		if !errors.Is(err, ErrInvalidCredentials) || !setupPending(setupRequired) {
+			return nil, err
 		}
 	}
 
@@ -834,9 +855,20 @@ func (c *Client) Disconnect() error {
 func (c *Client) Resync(ctx context.Context) error {
 	c.mu.Lock()
 	token := c.sessionToken
+	autoLoggedIn := c.autoLoggedIn
 	c.mu.Unlock()
 
 	if token == "" {
+		if autoLoggedIn {
+			// The server hands a session token only to a login it performed
+			// for a client that asked for one, and the commands it does have
+			// resend some of the lists but not all of them.
+			return errors.New(
+				"resync: the server logged the client in itself (authentication disabled) " +
+					"and offers no command to resend the lists",
+			)
+		}
+
 		return errors.New("resync: no session token, the client was created without credentials")
 	}
 
@@ -851,9 +883,16 @@ func (c *Client) Resync(ctx context.Context) error {
 
 	defer c.updates.RemoveListener(listenerID.String())
 
-	_, err := c.syncEmit(ctx, "loginByToken", token)
+	response, err := c.emitAck(ctx, "loginByToken", token)
 	if err != nil {
 		return fmt.Errorf("resync: %w", err)
+	}
+
+	if !response.OK {
+		// A token the server no longer accepts is the one failure a caller can
+		// act on: it means the password was changed or the user was removed,
+		// and a new login is the only way back.
+		return fmt.Errorf("resync: %w", loginError("loginByToken", response))
 	}
 
 	select {
@@ -939,21 +978,21 @@ func (c *Client) disconnectOrphan() {
 // runSetup sets the server up and logs in again afterwards, which is what a
 // server that answers the connect with a setup event asks for.
 func (c *Client) runSetup(ctx context.Context, username string, password string) error {
+	if username == "" || password == "" {
+		return errors.New("setup: the server requires setup, which needs a username and password")
+	}
+
 	_, err := c.syncEmit(ctx, "setup", username, password)
 	if err != nil {
 		return fmt.Errorf("setup: %w", err)
 	}
 
-	loginResponse, err := c.syncEmit(
-		ctx,
-		"login",
-		map[string]any{"username": username, "password": password, "token": ""},
-	)
+	// The user the setup just created has no two-factor authentication, so
+	// this login is answered without the server ever asking for a code.
+	err = c.loginWithPassword(ctx, username, password)
 	if err != nil {
 		return fmt.Errorf("login: %w", err)
 	}
-
-	c.setSessionToken(loginResponse.Token)
 
 	return nil
 }
@@ -1155,8 +1194,17 @@ func sortedEvents(events map[string]struct{}) []string {
 }
 
 type ackResponse struct {
-	Msg             string         `json:"msg"`
-	OK              bool           `json:"ok"`
+	Msg string `json:"msg"`
+	OK  bool   `json:"ok"`
+
+	// TokenRequired is how a login for an account with two-factor
+	// authentication enabled is answered. Such an ack carries neither an ok
+	// nor a message, so it has to be recognized by this field alone.
+	TokenRequired bool `json:"tokenRequired"`
+
+	// MsgI18n reports that Msg is a translation key rather than a sentence.
+	MsgI18n bool `json:"msgi18n"`
+
 	Token           string         `json:"token"`
 	ID              int64          `json:"id"`
 	MonitorID       int64          `json:"monitorID"`
@@ -1173,7 +1221,14 @@ type ackResponse struct {
 	Incident        map[string]any `json:"incident"`
 }
 
-func (c *Client) syncEmit(ctx context.Context, command string, args ...any) (ackResponse, error) {
+// emitAck emits command and returns the ack the server answered with, whether
+// it reports success or not.
+//
+// Unlike syncEmit it leaves the interpretation of the ack to the caller, which
+// is what the login path needs: a login that wants a one-time code is answered
+// with neither an ok nor a message, so there is nothing for syncEmit to report.
+// The returned error is reserved for an ack that never arrived.
+func (c *Client) emitAck(ctx context.Context, command string, args ...any) (ackResponse, error) {
 	// Buffered and never closed, so a late ack (e.g. after the context
 	// expired) neither leaks the ack goroutine forever nor panics sending on
 	// a closed channel.
@@ -1190,15 +1245,24 @@ func (c *Client) syncEmit(ctx context.Context, command string, args ...any) (ack
 
 	select {
 	case response := <-res:
-		if !response.OK {
-			return ackResponse{}, fmt.Errorf("%s: %s", command, response.Msg)
-		}
-
 		return response, nil
 
 	case <-ctx.Done():
 		return ackResponse{}, fmt.Errorf("%s: %w", command, ctx.Err())
 	}
+}
+
+func (c *Client) syncEmit(ctx context.Context, command string, args ...any) (ackResponse, error) {
+	response, err := c.emitAck(ctx, command, args...)
+	if err != nil {
+		return ackResponse{}, err
+	}
+
+	if !response.OK {
+		return ackResponse{}, fmt.Errorf("%s: %s", command, response.Msg)
+	}
+
+	return response, nil
 }
 
 // syncEmitWithUpdateEvent emits command and returns once the server has

--- a/client.go
+++ b/client.go
@@ -219,9 +219,13 @@ type Client struct {
 	// Resync logs in with, see there.
 	sessionToken string
 
-	// sessionTokenPreset is the token WithSessionToken configured, which is
-	// what New authenticates with instead of a password.
+	// sessionTokenPreset is the token WithSessionToken configured, which New
+	// tries before the password login.
 	sessionTokenPreset string
+
+	// sessionTokenRejected records that the server refused sessionTokenPreset
+	// and the password login took over, see Client.SessionTokenRejected.
+	sessionTokenRejected bool
 
 	// autoLoggedIn records that the server has authentication disabled and
 	// logged the client in itself, which leaves it without a session token,
@@ -937,10 +941,12 @@ func (c *Client) Resync(ctx context.Context) error {
 	return nil
 }
 
-// SessionToken returns the session token the server handed out at login, or
-// the empty string for a client that never received one: a client that
-// connected to a server with authentication disabled, and one whose login ack
-// carried no token.
+// SessionToken returns the session token the client is authenticated with: the
+// one the server handed out for the login New performed, or the one
+// WithSessionToken supplied and the server accepted. It is the empty string for
+// a client that was never logged in with credentials - one that connected to a
+// server with authentication disabled or to one that wants to be set up first -
+// and for one whose login ack carried no token.
 //
 // It is the credential WithSessionToken takes, so a caller can persist it and
 // reconnect later without the password and without a one-time code. It is a
@@ -950,6 +956,22 @@ func (c *Client) SessionToken() string {
 	defer c.mu.Unlock()
 
 	return c.sessionToken
+}
+
+// SessionTokenRejected reports whether the server refused the token
+// WithSessionToken configured and New logged in with the username and password
+// instead.
+//
+// It is what tells a caller that its stored token is dead, because nothing else
+// does: the login succeeds either way, and SessionToken then returns the fresh
+// token of the password login, which the caller cannot tell from the one it
+// presented. A caller that persists tokens checks this and writes the new one
+// back, see WithSessionToken.
+func (c *Client) SessionTokenRejected() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.sessionTokenRejected
 }
 
 // MissingReadyEvents returns the best-effort ready events the server did not
@@ -1051,6 +1073,16 @@ func (c *Client) setSessionToken(token string) {
 	defer c.mu.Unlock()
 
 	c.sessionToken = token
+}
+
+// setSessionTokenRejected records that the token WithSessionToken configured
+// was refused and the password login recovered, see
+// Client.SessionTokenRejected.
+func (c *Client) setSessionTokenRejected() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.sessionTokenRejected = true
 }
 
 // splitReadyEvents returns the update events that carry the lists the local

--- a/client.go
+++ b/client.go
@@ -271,6 +271,10 @@ func WithLogLevel(level int) Option {
 // the connection to Uptime Kuma.
 // In the case of autosetup with an uninitialized Uptime Kuma this timeout
 // also includes the time required for the initial setup.
+// It covers the login as well, including the short wait for the server to
+// state how it wants to be authenticated. A server that states nothing is
+// waited for with no more than half of the remaining budget, so the login
+// still has time to run.
 func WithConnectTimeout(timeout time.Duration) Option {
 	return func(c *Client) {
 		c.socketioClientConnectTimeout = timeout

--- a/client.go
+++ b/client.go
@@ -485,12 +485,14 @@ func New(ctx context.Context, baseURL string, username string, password string, 
 		return nil, errors.New("credentials: username and password have to be set together")
 	}
 
-	if c.totpErr != nil {
-		return nil, c.totpErr
+	// The count comes first: a caller who configured two sources is told that
+	// before being sent to fix whichever of them also failed to decode.
+	if c.totpSources > 1 {
+		return nil, errors.New("totp: at most one of WithTOTPSecret and WithTOTPCode may be used")
 	}
 
-	if c.totpSources > 1 {
-		return nil, errors.New("totp: WithTOTPSecret and WithTOTPCode are mutually exclusive")
+	if c.totpErr != nil {
+		return nil, c.totpErr
 	}
 
 	ctxWithConnectTimeout := ctx

--- a/client.go
+++ b/client.go
@@ -203,6 +203,9 @@ type state struct {
 }
 
 // Client represents a connection to an Uptime Kuma server.
+//
+// A Client must be created by New. The zero value is not usable and its methods
+// panic.
 type Client struct {
 	socketioClient               *socketio.Client
 	socketioClientConnectTimeout time.Duration
@@ -227,18 +230,24 @@ type Client struct {
 	// and the password login took over, see Client.SessionTokenRejected.
 	sessionTokenRejected bool
 
+	// sessionTokenRejectedCallback is told about that fallback as it happens,
+	// see WithSessionTokenRejectedCallback.
+	sessionTokenRejectedCallback func(err error)
+
 	// autoLoggedIn records that the server has authentication disabled and
-	// logged the client in itself, which leaves it without a session token,
-	// see Resync.
+	// logged the client in itself. Credentials given anyway are still used, so
+	// this says nothing about whether there is a session token; what it is for
+	// is telling a client that has none why, see Resync.
 	autoLoggedIn bool
 
 	// totpCode produces the one-time code for an account with two-factor
-	// authentication enabled, see WithTOTPSecret and WithTOTPCode.
-	// totpCodeSet tells a configured callback from none, totpSources counts
-	// how many of the two options set one, and totpErr carries a secret New
-	// has to reject.
+	// authentication enabled, and is nil for a client configured with neither
+	// WithTOTPSecret nor WithTOTPCode. totpSources counts how many of the two
+	// options set one, so New can reject a caller that used both, and totpErr
+	// carries an option failure for New to report. Two failing options would
+	// leave only the later error, but New rejects the two-source case before it
+	// looks at totpErr, so at most one option's failure is ever reported.
 	totpCode    func(ctx context.Context) (string, error)
-	totpCodeSet bool
 	totpSources int
 	totpErr     error
 
@@ -473,6 +482,17 @@ func setupDatabase(ctx context.Context, baseURL string) error {
 
 // New creates a new Client connected to an Uptime Kuma server.
 //
+// username and password have to be set together or both be empty. Passing
+// neither is the way to connect to a server with authentication disabled, and
+// to one that WithSessionToken authenticates instead; a server that does want a
+// login answers a client with nothing to offer with ErrAuthRequired.
+//
+// The login it performs reports what the server refused through the package's
+// sentinel errors, so a caller can tell the cases apart with errors.Is:
+// ErrAuthRequired, ErrInvalidCredentials, ErrTwoFactorRequired,
+// ErrInvalidTOTPCode, ErrInvalidSessionToken, ErrUserInactive and
+// ErrRateLimited.
+//
 //nolint:revive // Complexity is necessary for complete client initialization and event setup
 func New(ctx context.Context, baseURL string, username string, password string, opts ...Option) (*Client, error) {
 	c := &Client{
@@ -493,8 +513,9 @@ func New(ctx context.Context, baseURL string, username string, password string, 
 		return nil, fmt.Errorf("ready events: unknown: %s", strings.Join(unknown, ", "))
 	}
 
-	if (username == "") != (password == "") {
-		return nil, errors.New("credentials: username and password have to be set together")
+	creds, err := newCredentials(username, password, c.sessionTokenPreset)
+	if err != nil {
+		return nil, err
 	}
 
 	// The count comes first: a caller who configured two sources is told that
@@ -667,11 +688,9 @@ func New(ctx context.Context, baseURL string, username string, password string, 
 	})
 	defer closeSetupRequired()
 
-	if c.autosetup {
-		client.On("setup", func() {
-			closeSetupRequired()
-		})
-	}
+	client.On("setup", func() {
+		closeSetupRequired()
+	})
 
 	// The server states how it wants the connection to be authenticated as the
 	// last thing it does for it, so these are registered before the connect and
@@ -771,16 +790,13 @@ connectLoop:
 		}
 	}()
 
-	err = c.authenticate(
-		ctxWithConnectTimeout,
-		credentials{username: username, password: password, token: c.sessionTokenPreset},
-		barrier,
-	)
+	err = c.authenticate(ctxWithConnectTimeout, creds, barrier)
 	if err != nil {
 		// A server that is not set up yet rejects the credentials it does not
 		// have a user for; running the setup is what makes them work, so that
 		// is not a failure when the server asked for one.
-		if !errors.Is(err, ErrInvalidCredentials) || !setupPending(setupRequired) {
+		if !errors.Is(err, ErrInvalidCredentials) ||
+			!setupPending(ctxWithConnectTimeout, setupRequired) {
 			return nil, err
 		}
 	}
@@ -876,8 +892,15 @@ func (c *Client) Disconnect() error {
 //
 // The resync is all or nothing, because the server has no command to re-request
 // a single list. What it does have is a login, which answers with all of them,
-// so Resync logs in again with the token from the login New performed. A client
-// created without credentials therefore cannot resync.
+// so Resync logs in again with the session token the client holds - the one the
+// login New performed handed out, or the one WithSessionToken supplied and the
+// server accepted. A client that never obtained one, because it connected
+// without credentials to a server with authentication disabled, cannot resync.
+//
+// A token the server has since stopped accepting is reported as
+// ErrInvalidSessionToken, wrapped by ErrUserInactive when the account it names
+// was deactivated or deleted. Neither is recoverable here: a new New is what
+// obtains a fresh token.
 //
 // Which lists Resync waits for follows New: the events configured with
 // WithReadyEvents are required and the remaining known events are best-effort,
@@ -951,9 +974,8 @@ func (c *Client) Resync(ctx context.Context) error {
 // SessionToken returns the session token the client is authenticated with: the
 // one the server handed out for the login New performed, or the one
 // WithSessionToken supplied and the server accepted. It is the empty string for
-// a client that was never logged in with credentials - one that connected
-// without them to a server with authentication disabled, or to one that wants
-// to be set up first - and for one whose login ack carried no token.
+// a client that connected without credentials to a server with authentication
+// disabled, which is the one case New returns a client that never logged in.
 //
 // It is the credential WithSessionToken takes, so a caller can persist it and
 // reconnect later without the password and without a one-time code. It is a

--- a/client.go
+++ b/client.go
@@ -893,7 +893,8 @@ func (c *Client) Resync(ctx context.Context) error {
 			// resend some of the lists but not all of them.
 			return errors.New(
 				"resync: the server logged the client in itself (authentication disabled) " +
-					"and offers no command to resend the lists",
+					"and offers no command to resend the lists, pass credentials to New " +
+					"for a session token",
 			)
 		}
 
@@ -946,9 +947,9 @@ func (c *Client) Resync(ctx context.Context) error {
 // SessionToken returns the session token the client is authenticated with: the
 // one the server handed out for the login New performed, or the one
 // WithSessionToken supplied and the server accepted. It is the empty string for
-// a client that was never logged in with credentials - one that connected to a
-// server with authentication disabled or to one that wants to be set up first -
-// and for one whose login ack carried no token.
+// a client that was never logged in with credentials - one that connected
+// without them to a server with authentication disabled, or to one that wants
+// to be set up first - and for one whose login ack carried no token.
 //
 // It is the credential WithSessionToken takes, so a caller can persist it and
 // reconnect later without the password and without a one-time code. It is a

--- a/client.go
+++ b/client.go
@@ -219,6 +219,10 @@ type Client struct {
 	// Resync logs in with, see there.
 	sessionToken string
 
+	// sessionTokenPreset is the token WithSessionToken configured, which is
+	// what New authenticates with instead of a password.
+	sessionTokenPreset string
+
 	// autoLoggedIn records that the server has authentication disabled and
 	// logged the client in itself, which leaves it without a session token,
 	// see Resync.
@@ -759,7 +763,7 @@ connectLoop:
 
 	err = c.authenticate(
 		ctxWithConnectTimeout,
-		credentials{username: username, password: password},
+		credentials{username: username, password: password, token: c.sessionTokenPreset},
 		barrier,
 	)
 	if err != nil {
@@ -887,7 +891,9 @@ func (c *Client) Resync(ctx context.Context) error {
 			)
 		}
 
-		return errors.New("resync: no session token, the client was created without credentials")
+		return errors.New(
+			"resync: no session token, the client was created without credentials",
+		)
 	}
 
 	gate := newReadyGate(c.resyncReadyEvents())
@@ -929,6 +935,21 @@ func (c *Client) Resync(ctx context.Context) error {
 	c.awaitOptionalReadyEvents(ctx, "Resync", gate, nil)
 
 	return nil
+}
+
+// SessionToken returns the session token the server handed out at login, or
+// the empty string for a client that never received one: a client that
+// connected to a server with authentication disabled, and one whose login ack
+// carried no token.
+//
+// It is the credential WithSessionToken takes, so a caller can persist it and
+// reconnect later without the password and without a one-time code. It is a
+// bearer credential that does not expire, see WithSessionToken.
+func (c *Client) SessionToken() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.sessionToken
 }
 
 // MissingReadyEvents returns the best-effort ready events the server did not

--- a/client_ack_test.go
+++ b/client_ack_test.go
@@ -82,8 +82,12 @@ type fakeAckServer struct {
 	// resyncPayload is the last loginByToken frame received.
 	resyncPayload string
 	// rejectCreds answers a login the way a server rejecting the username and
-	// password does.
-	rejectCreds bool
+	// password does. credsRejectionMsg is the message that rejection carries;
+	// the empty string sends the translation key a 2.x server sends, while a
+	// server from before the login messages were translated sends the message
+	// itself.
+	rejectCreds       bool
+	credsRejectionMsg string
 	// rejectTokenMsg answers a loginByToken the way a server rejecting the
 	// session token does, with this as the reason. The empty string accepts.
 	rejectTokenMsg string
@@ -247,6 +251,15 @@ func (s *fakeAckServer) setRejectCreds(reject bool) {
 	defer s.mu.Unlock()
 
 	s.rejectCreds = reject
+}
+
+// setCredsRejectionMsg rejects the credentials with a specific message, such
+// as the untranslated "Incorrect username or password." a 1.x server sends.
+func (s *fakeAckServer) setCredsRejectionMsg(msg string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.credsRejectionMsg = msg
 }
 
 func (s *fakeAckServer) setRejectToken() {
@@ -478,6 +491,10 @@ func (s *fakeAckServer) loginAck(code string) string {
 	defer s.mu.Unlock()
 
 	if s.rejectCreds || (s.setupRequired && !s.setupDone) {
+		if s.credsRejectionMsg != "" {
+			return fmt.Sprintf(`{"ok":false,"msg":%q}`, s.credsRejectionMsg)
+		}
+
 		return `{"ok":false,"msg":"authIncorrectCreds","msgi18n":true}`
 	}
 

--- a/client_ack_test.go
+++ b/client_ack_test.go
@@ -93,12 +93,17 @@ type fakeAckServer struct {
 	loginRequiredDelay time.Duration
 	// twoFactorRequired answers a login without a code the way a server does
 	// for an account with two-factor authentication enabled. twoFactorSecret
-	// is the secret the codes are verified against, and acceptedCodes records
-	// the codes already used, which a real server refuses to see again.
+	// is the secret the codes are verified against, replayGuard turns the
+	// server's refusal to see an accepted code twice on, and acceptedCodes is
+	// what that refusal reads.
 	twoFactorRequired bool
 	twoFactorSecret   string
 	replayGuard       bool
 	acceptedCodes     map[string]struct{}
+	// rejectCodedLogin rejects a login carrying a code for a reason that is
+	// not the code, which the client has to hand over as it is instead of
+	// spending its retry on it.
+	rejectCodedLogin bool
 	// loginCodes are the one-time codes the logins carried, in order.
 	loginCodes []string
 	// setupRequired answers the connect with a setup event and rejects the
@@ -238,8 +243,10 @@ func (s *fakeAckServer) setLoginRequiredDelay(d time.Duration) {
 }
 
 // setTwoFactorSecret turns two-factor authentication on and verifies the codes
-// against the shared test secret. With replayGuard set it also refuses a code
-// it has already accepted, the way a real server does.
+// against the shared test secret. With replayGuard set it also refuses every
+// code it has already accepted; the real server only remembers the last one it
+// let through, in twofa_last_token, which is stricter than these tests need to
+// tell apart.
 func (s *fakeAckServer) setTwoFactorSecret(replayGuard bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -265,6 +272,13 @@ func (s *fakeAckServer) receivedLoginCodes() []string {
 	defer s.mu.Unlock()
 
 	return append([]string(nil), s.loginCodes...)
+}
+
+func (s *fakeAckServer) setRejectCodedLogin(reject bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.rejectCodedLogin = reject
 }
 
 func (s *fakeAckServer) setSetupRequired(required bool) {
@@ -402,6 +416,10 @@ func (s *fakeAckServer) loginAck(code string) string {
 	// An ack asking for a one-time code carries neither an ok nor a message.
 	if s.twoFactorRequired && code == "" {
 		return `{"tokenRequired":true}`
+	}
+
+	if s.rejectCodedLogin && code != "" {
+		return `{"ok":false,"msg":"authIncorrectCreds","msgi18n":true}`
 	}
 
 	if s.twoFactorRequired && !s.acceptsCodeLocked(code) {

--- a/client_ack_test.go
+++ b/client_ack_test.go
@@ -88,6 +88,10 @@ type fakeAckServer struct {
 	// itself.
 	rejectCreds       bool
 	credsRejectionMsg string
+	// credsRejectionAck replaces the whole rejection ack, for the answers that
+	// are neither of the two shapes above: a translation key this client
+	// version has no sentinel for, and a rejection naming no reason at all.
+	credsRejectionAck string
 	// rejectTokenMsg answers a loginByToken the way a server rejecting the
 	// session token does, with this as the reason. The empty string accepts.
 	rejectTokenMsg string
@@ -126,6 +130,10 @@ type fakeAckServer struct {
 	// setupDone records that the setup command ran, which is what makes the
 	// credentials work.
 	setupDone bool
+	// setupDelay holds the setup event back so it lands after the client has
+	// already been told a login is wanted, which is the ordering the barrier
+	// cannot see and the setup fallback exists for.
+	setupDelay time.Duration
 	// loginRequiredAt and firstLoginAt are when the server said it wants a
 	// login and when the first login arrived, to assert their order.
 	loginRequiredAt time.Time
@@ -246,11 +254,11 @@ func (s *fakeAckServer) setOmitLoginToken(omit bool) {
 	s.omitLoginToken = omit
 }
 
-func (s *fakeAckServer) setRejectCreds(reject bool) {
+func (s *fakeAckServer) setRejectCreds() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.rejectCreds = reject
+	s.rejectCreds = true
 }
 
 // setCredsRejectionMsg rejects the credentials with a specific message, such
@@ -260,6 +268,15 @@ func (s *fakeAckServer) setCredsRejectionMsg(msg string) {
 	defer s.mu.Unlock()
 
 	s.credsRejectionMsg = msg
+}
+
+// setCredsRejectionAck rejects a login with this exact ack payload.
+func (s *fakeAckServer) setCredsRejectionAck(ack string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.rejectCreds = true
+	s.credsRejectionAck = ack
 }
 
 func (s *fakeAckServer) setRejectToken() {
@@ -335,6 +352,17 @@ func (s *fakeAckServer) setSetupRequired(required bool) {
 	s.setupRequired = required
 }
 
+// setLateSetup makes the server state that it wants a login first and send the
+// setup event only after d, the way the per-handler goroutines of a real client
+// can deliver two events of one payload in that order.
+func (s *fakeAckServer) setLateSetup(d time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.setupRequired = true
+	s.setupDelay = d
+}
+
 func (s *fakeAckServer) runSetup() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -360,11 +388,11 @@ func (s *fakeAckServer) firstLoginAfterLoginRequired() bool {
 		s.firstLoginAt.After(s.loginRequiredAt)
 }
 
-func (s *fakeAckServer) setOmitLoginRequired(omit bool) {
+func (s *fakeAckServer) setOmitLoginRequired() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.omitLoginRequired = omit
+	s.omitLoginRequired = true
 }
 
 func (s *fakeAckServer) recordLogin(code string) {
@@ -491,6 +519,10 @@ func (s *fakeAckServer) loginAck(code string) string {
 	defer s.mu.Unlock()
 
 	if s.rejectCreds || (s.setupRequired && !s.setupDone) {
+		if s.credsRejectionAck != "" {
+			return s.credsRejectionAck
+		}
+
 		if s.credsRejectionMsg != "" {
 			return fmt.Sprintf(`{"ok":false,"msg":%q}`, s.credsRejectionMsg)
 		}
@@ -526,7 +558,21 @@ func (s *fakeAckServer) sendAuthMode() {
 	omit := s.omitLoginRequired
 	delay := s.loginRequiredDelay
 	needsSetup := s.setupRequired
+	setupDelay := s.setupDelay
 	s.mu.Unlock()
+
+	if needsSetup && setupDelay > 0 {
+		// Sent out of band and after the event below, so the client sees a
+		// server that wants a login, has its credentials rejected, and only
+		// then learns that a setup is what it was rejected for.
+		go func() {
+			time.Sleep(setupDelay)
+
+			s.messages <- []byte(`42["setup"]`)
+		}()
+
+		needsSetup = false
+	}
 
 	if needsSetup {
 		// Both events go out in one engine.io payload, the way a real server

--- a/client_ack_test.go
+++ b/client_ack_test.go
@@ -51,6 +51,11 @@ const fakeAckCreatedID = 4242
 // expects to see again in a loginByToken.
 const fakeSessionToken = "fake-session-token"
 
+// fakePresetToken is a token a test hands to WithSessionToken. It is distinct
+// from the one the fake server issues at login, so that a test can tell the
+// token that was presented from the one that was handed out.
+const fakePresetToken = "preset-session-token"
+
 // fakeAckServer is a minimal socket.io server over HTTP long-polling that
 // completes the handshake, CONNECT, login and ready phases, so kuma.New()
 // returns a usable client. Unlike fakeSocketIOServer it then keeps serving:
@@ -79,9 +84,14 @@ type fakeAckServer struct {
 	// rejectCreds answers a login the way a server rejecting the username and
 	// password does.
 	rejectCreds bool
-	// rejectToken answers a loginByToken the way a server rejecting the
-	// session token does.
-	rejectToken bool
+	// rejectTokenMsg answers a loginByToken the way a server rejecting the
+	// session token does, with this as the reason. The empty string accepts.
+	rejectTokenMsg string
+	// tokenFrames are the tokens the loginByToken frames carried, in order,
+	// recorded whether the token is accepted or refused. firstTokenAt is when
+	// the first of them arrived, to assert it came before any password login.
+	tokenFrames  []string
+	firstTokenAt time.Time
 	// autoLogin answers the connect the way a server with authentication
 	// disabled does: it logs the client in itself and never asks for a login.
 	autoLogin bool
@@ -133,6 +143,24 @@ func loginCode(payload string) string {
 	}
 
 	return data.Token
+}
+
+// tokenFromFrame extracts the session token a loginByToken frame carries.
+func tokenFromFrame(payload string) string {
+	var frame []json.RawMessage
+
+	start := strings.Index(payload, "[")
+	if start < 0 || json.Unmarshal([]byte(payload[start:]), &frame) != nil || len(frame) < 2 {
+		return ""
+	}
+
+	var token string
+
+	if json.Unmarshal(frame[1], &token) != nil {
+		return ""
+	}
+
+	return token
 }
 
 func (s *fakeAckServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -216,11 +244,17 @@ func (s *fakeAckServer) setRejectCreds(reject bool) {
 	s.rejectCreds = reject
 }
 
-func (s *fakeAckServer) setRejectToken(reject bool) {
+func (s *fakeAckServer) setRejectToken() {
+	s.setRejectTokenWith("authInvalidToken")
+}
+
+// setRejectTokenWith refuses a loginByToken with a specific reason, such as the
+// authUserInactiveOrDeleted the server answers for a deactivated user.
+func (s *fakeAckServer) setRejectTokenWith(msg string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.rejectToken = reject
+	s.rejectTokenMsg = msg
 }
 
 func (s *fakeAckServer) setAutoLogin(auto bool) {
@@ -339,11 +373,45 @@ func (s *fakeAckServer) setSuppressOptionalLists(suppress bool) {
 	s.suppressOptionalLists = suppress
 }
 
-func (s *fakeAckServer) tokenRejected() bool {
+// tokenRejection returns the reason a loginByToken is to be refused with, or
+// the empty string for a token the server accepts.
+func (s *fakeAckServer) tokenRejection() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	return s.rejectToken
+	return s.rejectTokenMsg
+}
+
+// recordToken records the token a loginByToken frame carried. It runs before
+// the rejection is answered, so a refused frame is seen as well.
+func (s *fakeAckServer) recordToken(token string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.tokenFrames = append(s.tokenFrames, token)
+
+	if s.firstTokenAt.IsZero() {
+		s.firstTokenAt = time.Now()
+	}
+}
+
+// receivedTokens returns the tokens the loginByToken frames carried, in order.
+func (s *fakeAckServer) receivedTokens() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return append([]string(nil), s.tokenFrames...)
+}
+
+// loginAfterToken reports whether the password login the client fell back to
+// came after the token it presented first.
+func (s *fakeAckServer) loginAfterToken() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return !s.firstLoginAt.IsZero() &&
+		!s.firstTokenAt.IsZero() &&
+		s.firstLoginAt.After(s.firstTokenAt)
 }
 
 func (s *fakeAckServer) recordResync(payload string) bool {
@@ -490,11 +558,14 @@ func (s *fakeAckServer) handleClientMessage(body []byte) {
 		// A resync logs in again, which is what makes the server resend the
 		// lists. Checked before "login", which is a prefix of it.
 		if strings.Contains(payload, `"loginByToken"`) {
-			if s.tokenRejected() {
+			s.recordToken(tokenFromFrame(payload))
+
+			if msg := s.tokenRejection(); msg != "" {
 				s.messages <- fmt.Appendf(
 					nil,
-					`43%s[{"ok":false,"msg":"authInvalidToken","msgi18n":true}]`,
+					`43%s[{"ok":false,"msg":%q,"msgi18n":true}]`,
 					ackID,
+					msg,
 				)
 
 				return

--- a/client_ack_test.go
+++ b/client_ack_test.go
@@ -529,6 +529,16 @@ func (s *fakeAckServer) sendAuthMode() {
 	s.mu.Unlock()
 
 	if needsSetup {
+		// Both events go out in one engine.io payload, the way a real server
+		// delivers them to a client that polls: it emits setup at the top of
+		// its connection handler and the event below at the bottom, so a
+		// single long poll picks up both.
+		if !auto && !omit {
+			s.messages <- []byte("42[\"setup\"]\x1e42[\"loginRequired\"]")
+
+			return
+		}
+
 		s.messages <- []byte(`42["setup"]`)
 	}
 

--- a/client_ack_test.go
+++ b/client_ack_test.go
@@ -74,12 +74,47 @@ type fakeAckServer struct {
 	suppressOptionalLists bool
 	// resyncPayload is the last loginByToken frame received.
 	resyncPayload string
+	// rejectCreds answers a login the way a server rejecting the username and
+	// password does.
+	rejectCreds bool
+	// rejectToken answers a loginByToken the way a server rejecting the
+	// session token does.
+	rejectToken bool
+	// autoLogin answers the connect the way a server with authentication
+	// disabled does: it logs the client in itself and never asks for a login.
+	autoLogin bool
+	// omitLoginRequired answers the connect without stating how it wants to be
+	// authenticated, as a server too old to send the event does.
+	omitLoginRequired bool
+	// loginRequiredDelay holds the loginRequired event back, the way a server
+	// that registers its handlers after an await does.
+	loginRequiredDelay time.Duration
+	// twoFactorRequired answers a login without a code the way a server does
+	// for an account with two-factor authentication enabled.
+	twoFactorRequired bool
+	// setupRequired answers the connect with a setup event and rejects the
+	// credentials until the setup ran, as a server without users does.
+	setupRequired bool
+	// setupDone records that the setup command ran, which is what makes the
+	// credentials work.
+	setupDone bool
+	// loginRequiredAt and firstLoginAt are when the server said it wants a
+	// login and when the first login arrived, to assert their order.
+	loginRequiredAt time.Time
+	firstLoginAt    time.Time
+	// loginFrames counts the login frames received.
+	loginFrames int
 }
 
 func (s *fakeAckServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	sid := r.URL.Query().Get("sid")
 
 	switch {
+	case r.URL.Path == "/api/entry-page":
+		// The database is set up; what is missing is the first user, which the
+		// setup event asks for.
+		_, _ = w.Write([]byte(`{"type":"entryPage","entryPage":null}`))
+
 	case r.Method == http.MethodGet && sid == "":
 		type engineIOHandshake struct {
 			Sid          string   `json:"sid"`
@@ -145,6 +180,91 @@ func (s *fakeAckServer) setOmitLoginToken(omit bool) {
 	s.omitLoginToken = omit
 }
 
+func (s *fakeAckServer) setRejectCreds(reject bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.rejectCreds = reject
+}
+
+func (s *fakeAckServer) setRejectToken(reject bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.rejectToken = reject
+}
+
+func (s *fakeAckServer) setAutoLogin(auto bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.autoLogin = auto
+}
+
+func (s *fakeAckServer) setLoginRequiredDelay(d time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.loginRequiredDelay = d
+}
+
+func (s *fakeAckServer) setSetupRequired(required bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.setupRequired = required
+}
+
+func (s *fakeAckServer) runSetup() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.setupDone = true
+}
+
+func (s *fakeAckServer) setTwoFactorRequired(required bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.twoFactorRequired = required
+}
+
+// firstLoginAfterLoginRequired reports whether the client held its login back
+// until the server asked for one.
+func (s *fakeAckServer) firstLoginAfterLoginRequired() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return !s.firstLoginAt.IsZero() &&
+		!s.loginRequiredAt.IsZero() &&
+		s.firstLoginAt.After(s.loginRequiredAt)
+}
+
+func (s *fakeAckServer) setOmitLoginRequired(omit bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.omitLoginRequired = omit
+}
+
+func (s *fakeAckServer) recordLogin() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.loginFrames++
+
+	if s.firstLoginAt.IsZero() {
+		s.firstLoginAt = time.Now()
+	}
+}
+
+func (s *fakeAckServer) loginFrameCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.loginFrames
+}
+
 func (s *fakeAckServer) setSuppressLists(suppress bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -157,6 +277,13 @@ func (s *fakeAckServer) setSuppressOptionalLists(suppress bool) {
 	defer s.mu.Unlock()
 
 	s.suppressOptionalLists = suppress
+}
+
+func (s *fakeAckServer) tokenRejected() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.rejectToken
 }
 
 func (s *fakeAckServer) recordResync(payload string) bool {
@@ -179,11 +306,56 @@ func (s *fakeAckServer) loginAck() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	if s.rejectCreds || (s.setupRequired && !s.setupDone) {
+		return `{"ok":false,"msg":"authIncorrectCreds","msgi18n":true}`
+	}
+
+	// An ack asking for a one-time code carries neither an ok nor a message.
+	if s.twoFactorRequired {
+		return `{"tokenRequired":true}`
+	}
+
 	if s.omitLoginToken {
 		return `{"ok":true,"msg":"Logged in successfully."}`
 	}
 
 	return fmt.Sprintf(`{"ok":true,"msg":"Logged in successfully.","token":%q}`, fakeSessionToken)
+}
+
+// sendAuthMode states how the connection is to be authenticated, which a real
+// server does as the last thing it does for a new connection.
+func (s *fakeAckServer) sendAuthMode() {
+	s.mu.Lock()
+	auto := s.autoLogin
+	omit := s.omitLoginRequired
+	delay := s.loginRequiredDelay
+	needsSetup := s.setupRequired
+	s.mu.Unlock()
+
+	if needsSetup {
+		s.messages <- []byte(`42["setup"]`)
+	}
+
+	switch {
+	case auto:
+		s.messages <- []byte(`42["autoLogin"]`)
+		s.sendReadyEvents()
+
+	case omit:
+
+	default:
+		// Held back out of band so the delay does not stall the request that
+		// carried the connect.
+		go func() {
+			time.Sleep(delay)
+
+			s.mu.Lock()
+			s.loginRequiredAt = time.Now()
+			s.mu.Unlock()
+
+			s.messages <- []byte(`42["loginRequired"]`)
+		}()
+	}
 }
 
 func (s *fakeAckServer) sendReadyEvents() {
@@ -211,6 +383,7 @@ func (s *fakeAckServer) handleClientMessage(body []byte) {
 	switch socketIOData[0] {
 	case '0': // socket.io CONNECT
 		s.messages <- []byte("40")
+		s.sendAuthMode()
 
 	case '2': // socket.io EVENT
 		i := 1
@@ -224,6 +397,16 @@ func (s *fakeAckServer) handleClientMessage(body []byte) {
 		// A resync logs in again, which is what makes the server resend the
 		// lists. Checked before "login", which is a prefix of it.
 		if strings.Contains(payload, `"loginByToken"`) {
+			if s.tokenRejected() {
+				s.messages <- fmt.Appendf(
+					nil,
+					`43%s[{"ok":false,"msg":"authInvalidToken","msgi18n":true}]`,
+					ackID,
+				)
+
+				return
+			}
+
 			s.messages <- fmt.Appendf(nil, `43%s[{"ok":true}]`, ackID)
 
 			if s.recordResync(payload) {
@@ -233,9 +416,22 @@ func (s *fakeAckServer) handleClientMessage(body []byte) {
 			return
 		}
 
+		if strings.Contains(payload, `"setup"`) {
+			s.runSetup()
+			s.messages <- fmt.Appendf(nil, `43%s[{"ok":true,"msg":"ok"}]`, ackID)
+
+			return
+		}
+
 		if strings.Contains(payload, `"login"`) {
-			s.messages <- fmt.Appendf(nil, `43%s[%s]`, ackID, s.loginAck())
-			s.sendReadyEvents()
+			s.recordLogin()
+
+			ack := s.loginAck()
+			s.messages <- fmt.Appendf(nil, `43%s[%s]`, ackID, ack)
+
+			if strings.Contains(ack, `"ok":true`) {
+				s.sendReadyEvents()
+			}
 
 			return
 		}

--- a/client_ack_test.go
+++ b/client_ack_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pquerna/otp"
+	"github.com/pquerna/otp/totp"
 	"github.com/stretchr/testify/require"
 
 	kuma "github.com/breml/go-uptime-kuma-client"
@@ -90,8 +92,15 @@ type fakeAckServer struct {
 	// that registers its handlers after an await does.
 	loginRequiredDelay time.Duration
 	// twoFactorRequired answers a login without a code the way a server does
-	// for an account with two-factor authentication enabled.
+	// for an account with two-factor authentication enabled. twoFactorSecret
+	// is the secret the codes are verified against, and acceptedCodes records
+	// the codes already used, which a real server refuses to see again.
 	twoFactorRequired bool
+	twoFactorSecret   string
+	replayGuard       bool
+	acceptedCodes     map[string]struct{}
+	// loginCodes are the one-time codes the logins carried, in order.
+	loginCodes []string
 	// setupRequired answers the connect with a setup event and rejects the
 	// credentials until the setup ran, as a server without users does.
 	setupRequired bool
@@ -104,6 +113,26 @@ type fakeAckServer struct {
 	firstLoginAt    time.Time
 	// loginFrames counts the login frames received.
 	loginFrames int
+}
+
+// loginCode extracts the one-time code a login frame carries.
+func loginCode(payload string) string {
+	var frame []json.RawMessage
+
+	start := strings.Index(payload, "[")
+	if start < 0 || json.Unmarshal([]byte(payload[start:]), &frame) != nil || len(frame) < 2 {
+		return ""
+	}
+
+	var data struct {
+		Token string `json:"token"`
+	}
+
+	if json.Unmarshal(frame[1], &data) != nil {
+		return ""
+	}
+
+	return data.Token
 }
 
 func (s *fakeAckServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -208,6 +237,36 @@ func (s *fakeAckServer) setLoginRequiredDelay(d time.Duration) {
 	s.loginRequiredDelay = d
 }
 
+// setTwoFactorSecret turns two-factor authentication on and verifies the codes
+// against the shared test secret. With replayGuard set it also refuses a code
+// it has already accepted, the way a real server does.
+func (s *fakeAckServer) setTwoFactorSecret(replayGuard bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.twoFactorRequired = true
+	s.twoFactorSecret = rfc6238Secret
+	s.replayGuard = replayGuard
+	s.acceptedCodes = map[string]struct{}{}
+}
+
+// useCode marks a code as already accepted, the way another client logging in
+// with the same account inside the same time step would.
+func (s *fakeAckServer) useCode(code string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.acceptedCodes[code] = struct{}{}
+}
+
+// receivedLoginCodes returns the one-time codes the logins carried, in order.
+func (s *fakeAckServer) receivedLoginCodes() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return append([]string(nil), s.loginCodes...)
+}
+
 func (s *fakeAckServer) setSetupRequired(required bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -247,11 +306,12 @@ func (s *fakeAckServer) setOmitLoginRequired(omit bool) {
 	s.omitLoginRequired = omit
 }
 
-func (s *fakeAckServer) recordLogin() {
+func (s *fakeAckServer) recordLogin(code string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	s.loginFrames++
+	s.loginCodes = append(s.loginCodes, code)
 
 	if s.firstLoginAt.IsZero() {
 		s.firstLoginAt = time.Now()
@@ -302,7 +362,36 @@ func (s *fakeAckServer) lastResyncPayload() string {
 	return s.resyncPayload
 }
 
-func (s *fakeAckServer) loginAck() string {
+// acceptsCodeLocked verifies a one-time code the way the server does, with the
+// replay guard that refuses a code it has already let through. The caller holds
+// the lock.
+func (s *fakeAckServer) acceptsCodeLocked(code string) bool {
+	if s.twoFactorSecret == "" {
+		return false
+	}
+
+	if s.replayGuard {
+		if _, used := s.acceptedCodes[code]; used {
+			return false
+		}
+	}
+
+	valid, err := totp.ValidateCustom(code, s.twoFactorSecret, time.Now(), totp.ValidateOpts{
+		Period:    30,
+		Skew:      1,
+		Digits:    otp.DigitsSix,
+		Algorithm: otp.AlgorithmSHA1,
+	})
+	if err != nil || !valid {
+		return false
+	}
+
+	s.acceptedCodes[code] = struct{}{}
+
+	return true
+}
+
+func (s *fakeAckServer) loginAck(code string) string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -311,8 +400,12 @@ func (s *fakeAckServer) loginAck() string {
 	}
 
 	// An ack asking for a one-time code carries neither an ok nor a message.
-	if s.twoFactorRequired {
+	if s.twoFactorRequired && code == "" {
 		return `{"tokenRequired":true}`
+	}
+
+	if s.twoFactorRequired && !s.acceptsCodeLocked(code) {
+		return `{"ok":false,"msg":"authInvalidToken","msgi18n":true}`
 	}
 
 	if s.omitLoginToken {
@@ -424,9 +517,10 @@ func (s *fakeAckServer) handleClientMessage(body []byte) {
 		}
 
 		if strings.Contains(payload, `"login"`) {
-			s.recordLogin()
+			code := loginCode(payload)
+			s.recordLogin(code)
 
-			ack := s.loginAck()
+			ack := s.loginAck(code)
 			s.messages <- fmt.Appendf(nil, `43%s[%s]`, ackID, ack)
 
 			if strings.Contains(ack, `"ok":true`) {

--- a/client_resync_test.go
+++ b/client_resync_test.go
@@ -116,15 +116,36 @@ func TestResync(t *testing.T) {
 	})
 
 	t.Run("without_a_session_token_it_reports_that_instead_of_hanging", func(t *testing.T) {
+		// A server too old to state how it wants to be authenticated, given a
+		// client with nothing to offer: New logs in nowhere, so there is no
+		// token to resync with. An accepted login that carried no token cannot
+		// produce this state, see TestNewLoginWithoutSessionToken.
 		fake := &fakeAckServer{messages: make(chan []byte, 32)}
-		fake.setOmitLoginToken(true)
+		fake.setOmitLoginRequired()
 
-		kumaClient := newFakeAckClient(t, fake)
+		server := httptest.NewServer(fake)
+
+		newCtx, newCancel := context.WithTimeout(t.Context(), time.Minute)
+		t.Cleanup(func() {
+			newCancel()
+			server.CloseClientConnections()
+			server.Close()
+		})
+
+		kumaClient, err := kuma.New(
+			newCtx, server.URL, "", "",
+			kuma.WithConnectTimeout(10*time.Second),
+			// Such a server sends no lists to a client it never logged in, so
+			// the ready gate is what would be waited out, not the resync.
+			kuma.WithReadyEvents(),
+			kuma.WithReadyGracePeriod(0),
+		)
+		require.NoError(t, err)
 
 		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 		defer cancel()
 
-		err := kumaClient.Resync(ctx)
+		err = kumaClient.Resync(ctx)
 
 		require.ErrorContains(t, err, "no session token")
 		require.Empty(t, fake.lastResyncPayload(),

--- a/client_timeout_test.go
+++ b/client_timeout_test.go
@@ -136,7 +136,7 @@ func (s *fakeSocketIOServer) handleClientMessage(body []byte) {
 
 		ackID := string(socketIOData[1:i])
 		// Enqueue login ACK: engine.io "4" + socket.io "3" (Ack) + ack ID + JSON payload.
-		ack := fmt.Sprintf(`43%s[{"ok":true,"msg":"Logged in successfully."}]`, ackID)
+		ack := fmt.Sprintf(`43%s[{"ok":true,"msg":"Logged in successfully.","token":"fake-session-token"}]`, ackID)
 		s.messages <- []byte(ack)
 
 		// Enqueue any configured post-login list events.
@@ -262,7 +262,7 @@ func handleWebSocketUpgrade(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ackID := msg[2:i]
-	ack := fmt.Sprintf(`43%s[{"ok":true,"msg":"Logged in successfully."}]`, ackID)
+	ack := fmt.Sprintf(`43%s[{"ok":true,"msg":"Logged in successfully.","token":"fake-session-token"}]`, ackID)
 	err = wsSendText(conn, ack)
 	if err != nil {
 		return

--- a/client_timeout_test.go
+++ b/client_timeout_test.go
@@ -123,6 +123,10 @@ func (s *fakeSocketIOServer) handleClientMessage(body []byte) {
 		// Enqueue CONNECT ACK: engine.io "4" (Message) + socket.io "0" (Connect).
 		s.messages <- []byte("40")
 
+		// A real server states how it wants to be authenticated right after
+		// the connect, which is what the client waits for before it logs in.
+		s.messages <- []byte(`42["loginRequired"]`)
+
 	case '2': // socket.io EVENT — the login request
 		// Extract the ack ID: digits immediately after the "2" type byte.
 		i := 1
@@ -237,6 +241,11 @@ func handleWebSocketUpgrade(w http.ResponseWriter, r *http.Request) {
 	}
 
 	err = wsSendText(conn, `40{"sid":"ws-test-sid"}`)
+	if err != nil {
+		return
+	}
+
+	err = wsSendText(conn, `42["loginRequired"]`)
 	if err != nil {
 		return
 	}
@@ -656,8 +665,10 @@ func TestNewReadyGraceWithinCallerDeadline(t *testing.T) {
 	})
 
 	// Shorter than the default ready grace period, and no WithConnectTimeout,
-	// so nothing but this deadline ends the grace window.
-	ctx, cancel := context.WithTimeout(t.Context(), 300*time.Millisecond)
+	// so nothing but this deadline ends the grace window. The long-polling
+	// transport delivers one frame per poll, so the budget has to cover the
+	// loginRequired frame the client waits for before it logs in as well.
+	ctx, cancel := context.WithTimeout(t.Context(), 400*time.Millisecond)
 	defer cancel()
 
 	client, err := kuma.New(ctx, server.URL, "admin", "admin1")

--- a/doc.go
+++ b/doc.go
@@ -35,6 +35,34 @@
 //	}
 //	id, err := client.CreateMonitor(ctx, monitor)
 //
+// # Authentication
+//
+// A username and password is the usual way in. An account with two-factor
+// authentication enabled additionally needs the shared secret, which the
+// client turns into the one-time code the server asks for:
+//
+//	client, err := kuma.New(ctx, url, "username", "password",
+//	    kuma.WithTOTPSecret(secret))
+//
+// A successful login answers with a session token. Persisting it lets a later
+// client connect with neither the password nor a one-time code, which is also
+// how several clients start at once against an account with two-factor
+// authentication: the server refuses a one-time code it has already accepted,
+// but takes the same token any number of times.
+//
+//	token := client.SessionToken()
+//	// ... later, in another process
+//	client, err := kuma.New(ctx, url, "", "", kuma.WithSessionToken(token))
+//
+// The token does not expire; the server invalidates it only when the password
+// changes or the user is deactivated. Store it the way the password would be
+// stored.
+//
+// A server with authentication disabled logs the client in by itself, so it
+// takes no credentials at all:
+//
+//	client, err := kuma.New(ctx, url, "", "")
+//
 // # Supported Monitor Types
 //
 // HTTP, TCP, Ping, DNS, gRPC, Redis, PostgreSQL, Real Browser, and more.

--- a/doc.go
+++ b/doc.go
@@ -54,9 +54,9 @@
 //	// ... later, in another process
 //	client, err := kuma.New(ctx, url, "", "", kuma.WithSessionToken(token))
 //
-// The token does not expire; the server invalidates it only when the password
-// changes or the user is deactivated. Store it the way the password would be
-// stored.
+// The token is a bearer credential that does not expire. Store it the way the
+// password would be stored, see [WithSessionToken] for what invalidates it and
+// for the fallback a client with a password gets when it is refused.
 //
 // A server with authentication disabled logs the client in by itself, so it
 // takes no credentials at all:

--- a/export_test.go
+++ b/export_test.go
@@ -1,0 +1,18 @@
+package kuma
+
+// The two-factor management commands and the code generation are internal:
+// they administer an account rather than authenticate a client, and there is
+// no request for them as public API yet. The end-to-end tests need them to put
+// a real server into the state they exercise, and those live in the external
+// test package, so they are exported for the tests alone.
+//
+//nolint:gochecknoglobals // the standard way to reach internals from an external test package.
+var (
+	Prepare2FA  = (*Client).prepare2FA
+	Save2FA     = (*Client).save2FA
+	Disable2FA  = (*Client).disable2FA
+	TwoFAStatus = (*Client).twoFAStatus
+
+	NormalizeTOTPSecret = normalizeTOTPSecret
+	TOTPCodeAt          = totpCodeAt
+)

--- a/export_test.go
+++ b/export_test.go
@@ -1,5 +1,7 @@
 package kuma
 
+import "time"
+
 // The two-factor management commands and the code generation are internal:
 // they administer an account rather than authenticate a client, and there is
 // no request for them as public API yet. The end-to-end tests need them to put
@@ -16,3 +18,16 @@ var (
 	NormalizeTOTPSecret = normalizeTOTPSecret
 	TOTPCodeAt          = totpCodeAt
 )
+
+// SetSetupEventGrace widens the window setupPending gives a setup event that
+// has not arrived yet, and returns the function that puts it back.
+//
+// The window settles a race whose timing a fake server cannot hit reliably, so
+// a test that wants the late-setup path takes the timing out of the assertion
+// rather than tuning a delay against it.
+func SetSetupEventGrace(d time.Duration) func() {
+	previous := setupEventGrace
+	setupEventGrace = d
+
+	return func() { setupEventGrace = previous }
+}

--- a/go.mod
+++ b/go.mod
@@ -81,6 +81,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.9.1 // indirect
 	github.com/bombsimon/wsl/v4 v4.7.0 // indirect
 	github.com/bombsimon/wsl/v5 v5.8.0 // indirect
+	github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc // indirect
 	github.com/breml/bidichk v0.3.3 // indirect
 	github.com/breml/errchkjson v0.4.1 // indirect
 	github.com/breml/githooks v0.0.0-20260421174736-44943ba7a400 // indirect
@@ -261,6 +262,7 @@ require (
 	github.com/pjbgf/sha1cd v0.3.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
+	github.com/pquerna/otp v1.5.0 // indirect
 	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.2
 require (
 	github.com/maldikhan/go.socket.io v0.1.1
 	github.com/ory/dockertest/v3 v3.12.0
+	github.com/pquerna/otp v1.5.0
 )
 
 require (
@@ -262,7 +263,6 @@ require (
 	github.com/pjbgf/sha1cd v0.3.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
-	github.com/pquerna/otp v1.5.0 // indirect
 	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -163,6 +163,8 @@ github.com/bombsimon/wsl/v4 v4.7.0 h1:1Ilm9JBPRczjyUs6hvOPKvd7VL1Q++PL8M0SXBDf+j
 github.com/bombsimon/wsl/v4 v4.7.0/go.mod h1:uV/+6BkffuzSAVYD+yGyld1AChO7/EuLrCF/8xTiapg=
 github.com/bombsimon/wsl/v5 v5.8.0 h1:JTkyfs4yl8SPejrCF2GdABXE+mO1WvM7iUYzRWlsxDs=
 github.com/bombsimon/wsl/v5 v5.8.0/go.mod h1:AbOLsulgkqP4ZnitHf9gwPtCOGlrzkk0jb0uNxRSY0o=
+github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc h1:biVzkmvwrH8WK8raXaxBx6fRVTlJILwEwQGL1I/ByEI=
+github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/breml/bidichk v0.3.3 h1:WSM67ztRusf1sMoqH6/c4OBCUlRVTKq+CbSeo0R17sE=
 github.com/breml/bidichk v0.3.3/go.mod h1:ISbsut8OnjB367j5NseXEGGgO/th206dVa427kR8YTE=
 github.com/breml/errchkjson v0.4.1 h1:keFSS8D7A2T0haP9kzZTi7o26r7kE3vymjZNeNDRDwg=
@@ -609,6 +611,8 @@ github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pquerna/otp v1.5.0 h1:NMMR+WrmaqXU4EzdGJEE1aUUI0AMRzsp96fFFWNPwxs=
+github.com/pquerna/otp v1.5.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
 github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h0RJWRi/o0o=
 github.com/prometheus/client_golang v1.23.2/go.mod h1:Tb1a6LWHB3/SPIzCoaDXI4I8UHKeFTEQ1YCr+0Gyqmg=
 github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=

--- a/main_test.go
+++ b/main_test.go
@@ -31,7 +31,11 @@ func TestMain(m *testing.M) {
 }
 
 func testMainSetup(m *testing.M) (int, error) {
-	dockerTimeout := uint(60)
+	// Long enough for the whole package to run against the container: the
+	// integration tests alone take about a minute, and an expiry that lands in
+	// the middle of them fails the run with a closed connection rather than a
+	// real defect.
+	dockerTimeout := uint(300)
 
 	e2eTest, _ := strconv.ParseBool(os.Getenv("E2E_TEST"))
 	if e2eTest {

--- a/totp.go
+++ b/totp.go
@@ -16,13 +16,14 @@ import (
 const totpStep = 30 * time.Second
 
 // normalizeTOTPSecret returns the secret in the padded upper-case base32 form
-// the code generation expects, and reports a secret it cannot decode.
+// base32.StdEncoding decodes, and reports a secret it cannot decode.
 //
-// The server hands the secret out in the otpauth:// URI it shows when
-// two-factor authentication is set up, with the base32 padding stripped, so
-// restoring the padding is what makes such a secret usable at all. A secret
-// copied out of a user interface may also carry spaces, hyphens and lower
-// case, all of which are accepted.
+// The code generation tolerates a secret that is unpadded or lower case on its
+// own, so neither of those is why this exists. What it is for is the separators
+// a secret carries when it is copied out of a user interface - the server shows
+// it in groups - which are stripped from the middle rather than only from the
+// ends, and the decode below, which turns a mistyped secret into an error from
+// New instead of a login the server rejects for reasons the caller cannot see.
 func normalizeTOTPSecret(secret string) (string, error) {
 	normalized := strings.ToUpper(strings.NewReplacer(" ", "", "-", "", "=", "").Replace(secret))
 	if normalized == "" {

--- a/totp.go
+++ b/totp.go
@@ -1,0 +1,67 @@
+package kuma
+
+import (
+	"encoding/base32"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/pquerna/otp"
+	"github.com/pquerna/otp/totp"
+)
+
+// totpStep is the time step RFC 6238 uses and the one the server verifies
+// with, see twoFAVerifyOptions in the server's server.js.
+const totpStep = 30 * time.Second
+
+// normalizeTOTPSecret returns the secret in the padded upper-case base32 form
+// the code generation expects, and reports a secret it cannot decode.
+//
+// The server hands the secret out in the otpauth:// URI it shows when
+// two-factor authentication is set up, with the base32 padding stripped, so
+// restoring the padding is what makes such a secret usable at all. A secret
+// copied out of a user interface may also carry spaces, hyphens and lower
+// case, all of which are accepted.
+func normalizeTOTPSecret(secret string) (string, error) {
+	normalized := strings.ToUpper(strings.NewReplacer(" ", "", "-", "", "=", "").Replace(secret))
+	if normalized == "" {
+		return "", errors.New("totp secret: empty")
+	}
+
+	if padding := len(normalized) % 8; padding != 0 {
+		normalized += strings.Repeat("=", 8-padding)
+	}
+
+	_, err := base32.StdEncoding.DecodeString(normalized)
+	if err != nil {
+		return "", fmt.Errorf("totp secret: not base32: %w", err)
+	}
+
+	return normalized, nil
+}
+
+// totpCodeAt returns the one-time code for secret at t, with the parameters
+// the server verifies with: HMAC-SHA1, a 30 second step and six digits.
+func totpCodeAt(secret string, t time.Time) (string, error) {
+	code, err := totp.GenerateCodeCustom(secret, t, totp.ValidateOpts{
+		Period:    uint(totpStep / time.Second),
+		Skew:      0,
+		Digits:    otp.DigitsSix,
+		Algorithm: otp.AlgorithmSHA1,
+	})
+	if err != nil {
+		return "", fmt.Errorf("totp code: %w", err)
+	}
+
+	return code, nil
+}
+
+// totpStepStart returns the beginning of the time step t falls into.
+//
+// The server records the last code it accepted and refuses to see it again, so
+// a code that was rejected for that reason is only worth replacing once the
+// step it belongs to is over.
+func totpStepStart(t time.Time) time.Time {
+	return t.Truncate(totpStep)
+}

--- a/totp_test.go
+++ b/totp_test.go
@@ -86,10 +86,15 @@ func TestNormalizeTOTPSecret(t *testing.T) {
 }
 
 // TestNormalizeTOTPSecretServerShape covers the secret Uptime Kuma actually
-// hands out: 64 random bytes, base32 encoded with the padding stripped.
+// hands out: the 64 random alphanumeric characters of genSecret, base32
+// encoded and stripped of the one padding character that leaves. 103 is what
+// makes this the interesting case - a length that is not a multiple of 8, so
+// the padding has to be restored before the secret decodes at all.
 func TestNormalizeTOTPSecretServerShape(t *testing.T) {
-	const serverSecret = "KRUGS4ZANFZSAYJANRQXE6JAOZQWY5LFMRPWG33EMVSA" +
-		"KRUGS4ZANFZSAYJANRQXE6JAOZQWY5LFMRPWG33EMVSAKRUGS4ZANFZSAYJA"
+	const serverSecret = "MRXUIZ2RKI4TMY2JGFGDMWJZONETK5KZGE2WE3SGHBHEUUKIOVMU" +
+		"OSCSHEZUY3BSJF2GUUKXNNVFCWRXJ44DKN3TOBIHK2JSN52DG5Y"
+
+	require.NotZero(t, len(serverSecret)%8, "the fixture has to need the padding restored")
 
 	normalized, err := kuma.NormalizeTOTPSecret(serverSecret)
 

--- a/totp_test.go
+++ b/totp_test.go
@@ -1,0 +1,103 @@
+package kuma_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	kuma "github.com/breml/go-uptime-kuma-client"
+)
+
+// rfc6238Secret is the base32 form of the RFC 6238 test key
+// "12345678901234567890".
+const rfc6238Secret = "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ"
+
+// TestTOTPCodeAtRFC6238 checks the generated codes against the SHA1 test
+// vectors of RFC 6238, appendix B. Uptime Kuma verifies with the same
+// parameters, so a code this agrees with is a code the server accepts.
+func TestTOTPCodeAtRFC6238(t *testing.T) {
+	tests := []struct {
+		name string
+		unix int64
+		want string
+	}{
+		{name: "1970", unix: 59, want: "287082"},
+		{name: "2005", unix: 1111111109, want: "081804"},
+		{name: "2005 next step", unix: 1111111111, want: "050471"},
+		{name: "2009", unix: 1234567890, want: "005924"},
+		{name: "2033", unix: 2000000000, want: "279037"},
+		{name: "2603", unix: 20000000000, want: "353130"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			code, err := kuma.TOTPCodeAt(rfc6238Secret, time.Unix(test.unix, 0).UTC())
+
+			require.NoError(t, err)
+			require.Equal(t, test.want, code)
+		})
+	}
+}
+
+// TestNormalizeTOTPSecret covers the shapes a secret reaches the client in.
+// Uptime Kuma strips the base32 padding from the secret it puts in the
+// otpauth:// URI, so restoring it is what makes such a secret usable at all.
+func TestNormalizeTOTPSecret(t *testing.T) {
+	tests := []struct {
+		name    string
+		secret  string
+		want    string
+		wantErr bool
+	}{
+		{name: "already normalized", secret: rfc6238Secret, want: rfc6238Secret},
+		{name: "lower case", secret: "gezdgnbvgy3tqojqgezdgnbvgy3tqojq", want: rfc6238Secret},
+		{name: "spaced", secret: "GEZD GNBV GY3T QOJQ GEZD GNBV GY3T QOJQ", want: rfc6238Secret},
+		{name: "hyphenated", secret: "GEZD-GNBV-GY3T-QOJQ-GEZD-GNBV-GY3T-QOJQ", want: rfc6238Secret},
+		{
+			name:   "unpadded",
+			secret: "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZA",
+			want:   "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZA====",
+		},
+		{
+			name:   "padded",
+			secret: "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZA====",
+			want:   "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZA====",
+		},
+		{name: "empty", secret: "", wantErr: true},
+		{name: "blank", secret: "   ", wantErr: true},
+		{name: "not base32", secret: "not-a-secret!", wantErr: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := kuma.NormalizeTOTPSecret(test.secret)
+
+			if test.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, test.want, got)
+		})
+	}
+}
+
+// TestNormalizeTOTPSecretServerShape covers the secret Uptime Kuma actually
+// hands out: 64 random bytes, base32 encoded with the padding stripped.
+func TestNormalizeTOTPSecretServerShape(t *testing.T) {
+	const serverSecret = "KRUGS4ZANFZSAYJANRQXE6JAOZQWY5LFMRPWG33EMVSA" +
+		"KRUGS4ZANFZSAYJANRQXE6JAOZQWY5LFMRPWG33EMVSAKRUGS4ZANFZSAYJA"
+
+	normalized, err := kuma.NormalizeTOTPSecret(serverSecret)
+
+	require.NoError(t, err)
+	require.Zero(t, len(normalized)%8, "the decoder needs the padding back")
+
+	code, err := kuma.TOTPCodeAt(normalized, time.Unix(1234567890, 0).UTC())
+
+	require.NoError(t, err)
+	require.Len(t, code, 6)
+}


### PR DESCRIPTION
Classify the server's login rejections into sentinel errors, and wait for the
server to state how it wants to be authenticated before logging in.

## Why

Two answers the server gives carry no `ok` field, and the client had nothing to
say about either. An account with two-factor authentication enabled is answered
with `{"tokenRequired": true}`, which `syncEmit` rendered as the error
`login: ` with an empty message. A caller with no credentials against a server
that wants a login waited out its whole connect timeout.

The server also registers its `login` and `loginByToken` handlers after an
`await` in the connection handler, so a login emitted immediately from the
`connect` callback can land in the gap and be dropped silently — the connection
stays healthy and the client hangs until its timeout. That is upstream
louislam/uptime-kuma#7710. It emits `loginRequired`, or `autoLogin` for a server
with authentication disabled, only once every handler is in place, so waiting
for that event closes the window with no new option and no polling.

## What

- Split `syncEmit` into `emitAck`, which returns the ack as sent, and the `ok`
  check on top. Every existing caller is unchanged.
- Add `ErrAuthRequired`, `ErrInvalidCredentials`, `ErrTwoFactorRequired`,
  `ErrInvalidTOTPCode` and `ErrInvalidSessionToken`, classified by the message
  the server sent instead of a `strings.Contains` on a formatted Go error. The
  pre-2.x English message is kept, now as an equality test.
- Wait for `loginRequired` / `autoLogin` before logging in, bounded by a 500 ms
  fallback so a server too old to send either event still gets a login.
- Recognize the server with authentication disabled: send no login, and have
  `Resync` report why it cannot work there.
- Reject a username without a password, and vice versa.

## Behaviour changes

Both replace a hang with an error: `New` with only one of the two credentials
fails immediately, and `New` with none against a server that wants a login
returns `ErrAuthRequired` instead of timing out.

## Tests

Eight new tests against the fakes, which learn to emit `loginRequired` and
`autoLogin`, answer `tokenRequired`, and reject credentials and tokens. The
important one is the setup fallback: rejected credentials plus a `setup` event
plus `WithAutosetup` must still run the setup, which is the regression guard for
removing the string matching. `task lint`, `task test` and `task test-e2e` all
pass, the latter against a real `louislam/uptime-kuma:2.5.0`.

Closes #364
