### PR TITLE
feat(client): support two-factor authenticated accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ go get github.com/breml/go-uptime-kuma-client
 - **Maintenance Windows**: Schedule maintenance periods
 - **Status Pages**: Create and manage public status pages
 - **Real-time Updates**: Socket.IO-based event system for state synchronization
+- **Authentication**: Username and password, two-factor authentication without a
+  human at the keyboard, session token reuse, and servers with authentication
+  disabled
 
 ## Usage
 
@@ -92,6 +95,51 @@ func main() {
  log.Printf("Created monitor with ID: %d", monitorID)
 }
 ```
+
+## Authentication
+
+A username and password is the usual way in. An account with two-factor
+authentication enabled additionally needs the shared secret, which the client
+turns into the one-time code the server asks for:
+
+```go
+client, err := kuma.New(ctx, url, "username", "password",
+ kuma.WithTOTPSecret(secret))
+```
+
+`WithTOTPCode` takes a callback instead, for a secret the client cannot read
+itself.
+
+A successful login answers with a session token. Persisting it lets a later
+client connect with neither the password nor a one-time code:
+
+```go
+token := client.SessionToken()
+
+// ... later, in another process
+client, err := kuma.New(ctx, url, "", "", kuma.WithSessionToken(token))
+```
+
+This is also how several clients start at once against an account with
+two-factor authentication: the server refuses a one-time code it has already
+accepted, but takes the same token any number of times.
+
+The token does not expire. The server invalidates it only when the password
+changes or the user is deactivated, and for an account with two-factor
+authentication it is a stronger credential than the password, because it needs
+no second factor. Store it the way the password would be stored.
+
+A server with authentication disabled logs the client in by itself, so it takes
+no credentials at all:
+
+```go
+client, err := kuma.New(ctx, url, "", "")
+```
+
+Uptime Kuma API keys are not an option here: the server accepts them for HTTP
+basic auth on `/metrics` only, never for the Socket.IO API this client speaks.
+There is likewise no OIDC, SSO, LDAP or client-certificate login in any
+released Uptime Kuma version.
 
 ## Documentation
 

--- a/auth.go
+++ b/auth.go
@@ -43,6 +43,30 @@ var ErrInvalidTOTPCode = errors.New("invalid two-factor authentication code")
 // changed password or a user that was deactivated or deleted.
 var ErrInvalidSessionToken = errors.New("session token rejected")
 
+// WithSessionToken authenticates with a session token from an earlier login
+// instead of a password, see Client.SessionToken.
+//
+// The token is what the server hands out on a successful login and what it
+// accepts in place of one. It bypasses two-factor authentication entirely, so
+// a client holding one needs neither the password nor the one-time code, which
+// also makes it the way to start many clients at once against an account with
+// two-factor authentication enabled, see WithTOTPSecret.
+//
+// If a username and password are given as well, the token is tried first and
+// the password login is the fallback for a token the server rejects. Without
+// them a rejected token fails New with ErrInvalidSessionToken.
+//
+// Security: the token is a bearer credential that does not expire. The server
+// invalidates it only when the password changes or the user is deactivated,
+// and it is a stronger credential than the password for an account with
+// two-factor authentication, because it needs no second factor. Store it the
+// way the password would be stored.
+func WithSessionToken(token string) Option {
+	return func(c *Client) {
+		c.sessionTokenPreset = token
+	}
+}
+
 // WithTOTPSecret configures the shared secret of an account with two-factor
 // authentication enabled, so the client can answer the server's request for a
 // one-time code itself and log in without a human at the keyboard.
@@ -152,6 +176,7 @@ type authBarrier struct {
 type credentials struct {
 	username string
 	password string
+	token    string
 }
 
 // loginError translates a rejected login ack into one of the package's sentinel
@@ -209,6 +234,11 @@ func (c credentials) isSet() bool {
 	return c.username != "" && c.password != ""
 }
 
+// hasAny reports whether there is anything at all to authenticate with.
+func (c credentials) hasAny() bool {
+	return c.isSet() || c.token != ""
+}
+
 // authenticate logs the client in the way the server asked for, and records the
 // session token a successful login answers with.
 //
@@ -227,12 +257,12 @@ func (c *Client) authenticate(ctx context.Context, creds credentials, barrier au
 		return nil
 
 	case authModeLoginRequired:
-		if !creds.isSet() {
+		if !creds.hasAny() {
 			return ErrAuthRequired
 		}
 
 	case authModeUnknown:
-		if !creds.isSet() {
+		if !creds.hasAny() {
 			// A server that never said it wants a login is not asked for one.
 			return nil
 		}
@@ -241,7 +271,41 @@ func (c *Client) authenticate(ctx context.Context, creds credentials, barrier au
 		// authMode has no other values.
 	}
 
+	if creds.token != "" {
+		err := c.loginWithToken(ctx, creds.token)
+		if err == nil {
+			return nil
+		}
+
+		if !errors.Is(err, ErrInvalidSessionToken) || !creds.isSet() {
+			return err
+		}
+
+		// A token the server no longer accepts is what a password change
+		// leaves behind, and the password is what recovers from it.
+		c.socketioLogger.Warnf("session token rejected, falling back to the password login")
+	}
+
 	return c.loginWithPassword(ctx, creds.username, creds.password)
+}
+
+// loginWithToken presents a session token from an earlier login, see
+// WithSessionToken.
+func (c *Client) loginWithToken(ctx context.Context, token string) error {
+	response, err := c.emitAck(ctx, "loginByToken", token)
+	if err != nil {
+		return err
+	}
+
+	if !response.OK {
+		return loginError("loginByToken", response)
+	}
+
+	// The server answers a loginByToken without a token of its own, so the one
+	// that worked is the one to keep, see Client.SessionToken.
+	c.setSessionToken(token)
+
+	return nil
 }
 
 // loginWithPassword logs in with a username and password, and answers the

--- a/auth.go
+++ b/auth.go
@@ -23,8 +23,9 @@ var ErrAuthRequired = errors.New("server requires authentication")
 var ErrInvalidCredentials = errors.New("incorrect username or password")
 
 // ErrTwoFactorRequired is returned when the account has two-factor
-// authentication enabled, which the client cannot answer yet: the server asks
-// for a one-time code and the client has none to give.
+// authentication enabled and the client has no code to answer with, because
+// neither WithTOTPSecret nor WithTOTPCode was configured or because the
+// configured callback produced nothing usable.
 //
 // It is the typed form of the server's tokenRequired answer to a login. That
 // answer carries neither an ok nor a message, so without this it surfaces as an
@@ -59,11 +60,15 @@ var ErrInvalidSessionToken = errors.New("session token rejected")
 // authentication disabled is verified against a secret that does not exist,
 // after the login has already been answered.
 //
-// The server records the last code it accepted and refuses to see it again, so
-// two clients logging in with the same account inside one 30 second step
-// cannot both succeed. The client retries once in the next step when the
-// caller's deadline allows it, but a caller starting many clients at once is
-// better served by WithSessionToken.
+// The server records the last code it accepted and refuses to see it again,
+// see ErrInvalidTOTPCode, so two clients logging in with the same account
+// inside one 30 second step cannot both succeed. The client retries once in
+// the next step when the caller's deadline allows it, which is why starting
+// many clients for one account at once wants a deadline that can cover a step.
+//
+// The server answers a wrong secret and a clock too far off with the same
+// rejection, so those cost the same retry: a login that can never succeed
+// takes up to one step to fail. WithConnectTimeout bounds it.
 //
 // WithTOTPSecret and WithTOTPCode are mutually exclusive.
 func WithTOTPSecret(secret string) Option {
@@ -88,18 +93,27 @@ func WithTOTPSecret(secret string) Option {
 // caller whose secret lives somewhere the client cannot read it, such as a
 // hardware token or an external authenticator.
 //
-// It is called only when the server asks for a code, and once more for the
-// single retry the client makes in the next time step, see ErrInvalidTOTPCode.
-// WithTOTPSecret is this option with the code computed from a secret, and the
-// two are mutually exclusive.
+// It is called at most twice per login: once when the server asks for a code,
+// and once more for the single retry the client makes in the next time step,
+// which happens only if the server rejected the first code and the caller's
+// deadline can cover the wait, see ErrInvalidTOTPCode. A callback that returns
+// an empty code fails the login with ErrTwoFactorRequired rather than sending
+// it, because the server reads an empty code as no code at all.
+//
+// A nil callback fails New, the way a secret WithTOTPSecret cannot decode
+// does. WithTOTPSecret is this option with the code computed from a secret,
+// and the two are mutually exclusive.
 func WithTOTPCode(code func(ctx context.Context) (string, error)) Option {
 	return func(c *Client) {
+		c.totpSources++
+
 		if code == nil {
+			c.totpErr = errors.New("totp: WithTOTPCode was given a nil callback")
+
 			return
 		}
 
 		c.totpCodeSet = true
-		c.totpSources++
 		c.totpCode = code
 	}
 }
@@ -275,41 +289,91 @@ func (c *Client) loginWithPassword(ctx context.Context, username string, passwor
 // secret, a clock too far off - produces the same answer again, so a single
 // retry is enough, and it is skipped altogether when the caller's deadline
 // cannot cover the wait.
+//
+// The ways this fails are kept apart in the error, because they call for
+// different fixes: no code source, a source that produced nothing usable, a
+// deadline too short to outlast the replay guard, and a code rejected in two
+// consecutive steps, which is what rules the replay guard out.
 func (c *Client) loginWithTOTP(ctx context.Context, username string, password string) error {
 	if !c.totpCodeSet {
 		return ErrTwoFactorRequired
 	}
 
 	for retry := range 2 {
-		if retry > 0 && !waitForNextTOTPStep(ctx) {
-			break
+		if retry > 0 {
+			waitErr := awaitTOTPRetry(ctx)
+			if waitErr != nil {
+				return waitErr
+			}
 		}
 
-		code, err := c.totpCode(ctx)
-		if err != nil {
-			return fmt.Errorf("login: totp code: %w", err)
-		}
-
-		response, err := c.login(ctx, username, password, code)
-		if err != nil {
+		err := c.loginOnceWithTOTP(ctx, username, password)
+		if !errors.Is(err, ErrInvalidTOTPCode) {
 			return err
-		}
-
-		if response.OK {
-			c.setSessionToken(response.Token)
-
-			return nil
-		}
-
-		if !errors.Is(loginError("login", response), ErrInvalidTOTPCode) {
-			return loginError("login", response)
 		}
 	}
 
 	return fmt.Errorf(
-		"%w: the server also rejects a code it has accepted before, "+
-			"so another login with this account may have just used this one",
+		"%w: rejected in two consecutive time steps, which rules out the server's replay "+
+			"guard, so what is left to check is the secret and this host's clock",
 		ErrInvalidTOTPCode,
+	)
+}
+
+// loginOnceWithTOTP makes one attempt at a login with a one-time code. A code
+// the server rejects comes back wrapping ErrInvalidTOTPCode, which is the only
+// outcome another attempt could change.
+func (c *Client) loginOnceWithTOTP(ctx context.Context, username string, password string) error {
+	code, err := c.totpCode(ctx)
+	if err != nil {
+		return fmt.Errorf("login: %w", err)
+	}
+
+	// The server reads an empty code as no code at all and asks again instead
+	// of rejecting it, in an ack carrying neither an ok nor a message, so
+	// sending one buys an error with nothing in it.
+	if code == "" {
+		return fmt.Errorf("%w: the configured code source produced an empty code", ErrTwoFactorRequired)
+	}
+
+	response, err := c.login(ctx, username, password, code)
+	if err != nil {
+		return err
+	}
+
+	if response.OK {
+		c.setSessionToken(response.Token)
+
+		return nil
+	}
+
+	if response.TokenRequired {
+		return fmt.Errorf(
+			"%w: the server asked for a code again instead of answering the one it was given",
+			ErrTwoFactorRequired,
+		)
+	}
+
+	return loginError("login", response)
+}
+
+// awaitTOTPRetry waits out the current time step, so the attempt after it has
+// a code the server has not seen before, and says why it could not.
+func awaitTOTPRetry(ctx context.Context) error {
+	waited, err := waitForNextTOTPStep(ctx)
+	if err != nil {
+		return fmt.Errorf("login: %w", err)
+	}
+
+	if waited {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"%w: recovering from a code the server has seen before needs a wait of up to %s "+
+			"for the next time step, which does not fit in the deadline",
+		ErrInvalidTOTPCode,
+		totpStep,
 	)
 }
 
@@ -337,15 +401,17 @@ func (c *Client) setAutoLoggedIn() {
 	c.autoLoggedIn = true
 }
 
-// waitForNextTOTPStep waits until the current time step is over, and reports
-// whether the wait completed inside the caller's budget. A deadline that
-// cannot cover the wait is left alone rather than run into.
-func waitForNextTOTPStep(ctx context.Context) bool {
+// waitForNextTOTPStep waits until the current time step is over and reports
+// whether it got there. A deadline that cannot cover the wait is left alone
+// rather than run into, which is the (false, nil) answer; a wait the context
+// cuts short returns that context's error, so a cancellation on the way is not
+// reported as a code the server disliked.
+func waitForNextTOTPStep(ctx context.Context) (bool, error) {
 	wait := time.Until(totpStepStart(time.Now()).Add(totpStep))
 
 	deadline, hasDeadline := ctx.Deadline()
 	if hasDeadline && time.Until(deadline) <= wait {
-		return false
+		return false, nil
 	}
 
 	timer := time.NewTimer(wait)
@@ -353,10 +419,10 @@ func waitForNextTOTPStep(ctx context.Context) bool {
 
 	select {
 	case <-timer.C:
-		return true
+		return true, nil
 
 	case <-ctx.Done():
-		return false
+		return false, fmt.Errorf("waiting for the next totp time step: %w", ctx.Err())
 	}
 }
 

--- a/auth.go
+++ b/auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"time"
 )
 
@@ -41,6 +42,67 @@ var ErrInvalidTOTPCode = errors.New("invalid two-factor authentication code")
 // see Client.Resync. The token carries no expiry, so what invalidates it is a
 // changed password or a user that was deactivated or deleted.
 var ErrInvalidSessionToken = errors.New("session token rejected")
+
+// WithTOTPSecret configures the shared secret of an account with two-factor
+// authentication enabled, so the client can answer the server's request for a
+// one-time code itself and log in without a human at the keyboard.
+//
+// The secret is the base32 string from the otpauth:// URI Uptime Kuma shows
+// when two-factor authentication is set up. Spaces, hyphens, lower case and
+// the missing base32 padding the server strips are all accepted; a secret that
+// cannot be decoded fails New rather than the login it would be needed for.
+//
+// The code is generated only once the server asks for one, so configuring a
+// secret for an account without two-factor authentication changes nothing. It
+// is generated then and not before because the server evaluates the fields of
+// a login independently: a code sent to an account that has two-factor
+// authentication disabled is verified against a secret that does not exist,
+// after the login has already been answered.
+//
+// The server records the last code it accepted and refuses to see it again, so
+// two clients logging in with the same account inside one 30 second step
+// cannot both succeed. The client retries once in the next step when the
+// caller's deadline allows it, but a caller starting many clients at once is
+// better served by WithSessionToken.
+//
+// WithTOTPSecret and WithTOTPCode are mutually exclusive.
+func WithTOTPSecret(secret string) Option {
+	return func(c *Client) {
+		c.totpSources++
+
+		normalized, err := normalizeTOTPSecret(secret)
+		if err != nil {
+			c.totpErr = err
+
+			return
+		}
+
+		c.totpCodeSet = true
+		c.totpCode = func(_ context.Context) (string, error) {
+			return totpCodeAt(normalized, time.Now())
+		}
+	}
+}
+
+// WithTOTPCode configures a callback that produces the one-time code, for a
+// caller whose secret lives somewhere the client cannot read it, such as a
+// hardware token or an external authenticator.
+//
+// It is called only when the server asks for a code, and once more for the
+// single retry the client makes in the next time step, see ErrInvalidTOTPCode.
+// WithTOTPSecret is this option with the code computed from a secret, and the
+// two are mutually exclusive.
+func WithTOTPCode(code func(ctx context.Context) (string, error)) Option {
+	return func(c *Client) {
+		if code == nil {
+			return
+		}
+
+		c.totpCodeSet = true
+		c.totpSources++
+		c.totpCode = code
+	}
+}
 
 // authBarrierWait bounds how long the client waits for the server to state how
 // it wants to be authenticated, see authBarrier.
@@ -182,13 +244,10 @@ func (c *Client) authenticate(ctx context.Context, creds credentials, barrier au
 	return c.loginWithPassword(ctx, creds.username, creds.password)
 }
 
-// loginWithPassword logs in with a username and password.
+// loginWithPassword logs in with a username and password, and answers the
+// server's request for a one-time code if it makes one.
 func (c *Client) loginWithPassword(ctx context.Context, username string, password string) error {
-	response, err := c.emitAck(
-		ctx,
-		"login",
-		map[string]any{"username": username, "password": password, "token": ""},
-	)
+	response, err := c.login(ctx, username, password, "")
 	if err != nil {
 		return err
 	}
@@ -202,10 +261,71 @@ func (c *Client) loginWithPassword(ctx context.Context, username string, passwor
 	// An ack asking for a one-time code carries neither an ok nor a message,
 	// so it has to be recognized before the message is looked at.
 	if response.TokenRequired {
-		return ErrTwoFactorRequired
+		return c.loginWithTOTP(ctx, username, password)
 	}
 
 	return loginError("login", response)
+}
+
+// loginWithTOTP answers the server's request for a one-time code.
+//
+// A code the server rejects is retried once in the next time step, because the
+// server refuses a code it has accepted before and the next step is what
+// produces a different one. Every other reason for the rejection - a wrong
+// secret, a clock too far off - produces the same answer again, so a single
+// retry is enough, and it is skipped altogether when the caller's deadline
+// cannot cover the wait.
+func (c *Client) loginWithTOTP(ctx context.Context, username string, password string) error {
+	if !c.totpCodeSet {
+		return ErrTwoFactorRequired
+	}
+
+	for retry := range 2 {
+		if retry > 0 && !waitForNextTOTPStep(ctx) {
+			break
+		}
+
+		code, err := c.totpCode(ctx)
+		if err != nil {
+			return fmt.Errorf("login: totp code: %w", err)
+		}
+
+		response, err := c.login(ctx, username, password, code)
+		if err != nil {
+			return err
+		}
+
+		if response.OK {
+			c.setSessionToken(response.Token)
+
+			return nil
+		}
+
+		if !errors.Is(loginError("login", response), ErrInvalidTOTPCode) {
+			return loginError("login", response)
+		}
+	}
+
+	return fmt.Errorf(
+		"%w: the server also rejects a code it has accepted before, "+
+			"so another login with this account may have just used this one",
+		ErrInvalidTOTPCode,
+	)
+}
+
+// login emits the login command with an optional one-time code and returns the
+// ack, whether it reports success or not.
+func (c *Client) login(
+	ctx context.Context,
+	username string,
+	password string,
+	code string,
+) (ackResponse, error) {
+	return c.emitAck(
+		ctx,
+		"login",
+		map[string]any{"username": username, "password": password, "token": code},
+	)
 }
 
 // setAutoLoggedIn records that the server logged the client in itself, see
@@ -215,6 +335,29 @@ func (c *Client) setAutoLoggedIn() {
 	defer c.mu.Unlock()
 
 	c.autoLoggedIn = true
+}
+
+// waitForNextTOTPStep waits until the current time step is over, and reports
+// whether the wait completed inside the caller's budget. A deadline that
+// cannot cover the wait is left alone rather than run into.
+func waitForNextTOTPStep(ctx context.Context) bool {
+	wait := time.Until(totpStepStart(time.Now()).Add(totpStep))
+
+	deadline, hasDeadline := ctx.Deadline()
+	if hasDeadline && time.Until(deadline) <= wait {
+		return false
+	}
+
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+		return true
+
+	case <-ctx.Done():
+		return false
+	}
 }
 
 // setupPending reports whether the server asked to be set up.
@@ -232,4 +375,55 @@ func setupPending(setupRequired <-chan struct{}) bool {
 	default:
 		return false
 	}
+}
+
+// prepare2FA asks the server for a new two-factor secret and returns it.
+//
+// The server stores the secret right away, before it has been confirmed, and
+// only starts requiring a code once save2FA ran. currentPassword is the
+// password of the logged in account, which the server checks again for this
+// command even though the connection is already authenticated.
+func (c *Client) prepare2FA(ctx context.Context, currentPassword string) (string, error) {
+	response, err := c.syncEmit(ctx, "prepare2FA", currentPassword)
+	if err != nil {
+		return "", err
+	}
+
+	uri, err := url.Parse(response.URI)
+	if err != nil {
+		return "", fmt.Errorf("prepare2FA: parse otpauth uri: %w", err)
+	}
+
+	secret := uri.Query().Get("secret")
+	if secret == "" {
+		return "", errors.New("prepare2FA: otpauth uri carries no secret")
+	}
+
+	return secret, nil
+}
+
+// save2FA turns two-factor authentication on for the logged in account, using
+// the secret prepare2FA handed out.
+func (c *Client) save2FA(ctx context.Context, currentPassword string) error {
+	_, err := c.syncEmit(ctx, "save2FA", currentPassword)
+
+	return err
+}
+
+// disable2FA turns two-factor authentication off for the logged in account.
+func (c *Client) disable2FA(ctx context.Context, currentPassword string) error {
+	_, err := c.syncEmit(ctx, "disable2FA", currentPassword)
+
+	return err
+}
+
+// twoFAStatus reports whether two-factor authentication is on for the logged
+// in account.
+func (c *Client) twoFAStatus(ctx context.Context) (bool, error) {
+	response, err := c.syncEmit(ctx, "twoFAStatus")
+	if err != nil {
+		return false, err
+	}
+
+	return response.Status, nil
 }

--- a/auth.go
+++ b/auth.go
@@ -43,6 +43,16 @@ var ErrInvalidTOTPCode = errors.New("invalid two-factor authentication code")
 // changed password or a user that was deactivated or deleted.
 var ErrInvalidSessionToken = errors.New("session token rejected")
 
+// ErrUserInactive is returned when the server rejects a session token because
+// the account it names is deactivated or deleted. It wraps
+// ErrInvalidSessionToken as well, so a caller that only cares that the token is
+// gone keeps matching on that one.
+//
+// It is the token rejection a password cannot recover from: the server requires
+// an active user for a password login too, so New reports it instead of falling
+// back, see WithSessionToken.
+var ErrUserInactive = errors.New("user inactive or deleted")
+
 // WithSessionToken authenticates with a session token from an earlier login
 // instead of a password, see Client.SessionToken.
 //
@@ -53,8 +63,13 @@ var ErrInvalidSessionToken = errors.New("session token rejected")
 // two-factor authentication enabled, see WithTOTPSecret.
 //
 // If a username and password are given as well, the token is tried first and
-// the password login is the fallback for a token the server rejects. Without
-// them a rejected token fails New with ErrInvalidSessionToken.
+// the password login is the fallback for a token the server refuses.
+// Client.SessionTokenRejected reports that this happened, because the login
+// succeeds either way and the stored token is dead. The fallback is skipped
+// where the password cannot help: for a deactivated or deleted user, see
+// ErrUserInactive, and for a failure that is not a rejection at all, such as a
+// transport error. Without a username and password a rejected token fails New
+// with ErrInvalidSessionToken.
 //
 // Security: the token is a bearer credential that does not expire. The server
 // invalidates it only when the password changes or the user is deactivated,
@@ -188,7 +203,7 @@ func loginError(command string, response ackResponse) error {
 		return ErrInvalidCredentials
 
 	case "authUserInactiveOrDeleted":
-		return fmt.Errorf("%w: user inactive or deleted", ErrInvalidSessionToken)
+		return fmt.Errorf("%w: %w", ErrInvalidSessionToken, ErrUserInactive)
 
 	case "authInvalidToken":
 		// The server answers two different rejections with this one message: a
@@ -240,7 +255,8 @@ func (c credentials) hasAny() bool {
 }
 
 // authenticate logs the client in the way the server asked for, and records the
-// session token a successful login answers with.
+// session token the connection ends up authenticated with, whether the server
+// handed it out or accepted the one the client presented.
 //
 // It returns nil without logging in for a server that authenticated the client
 // itself, for one that wants to be set up first, and for one that never stated
@@ -272,21 +288,48 @@ func (c *Client) authenticate(ctx context.Context, creds credentials, barrier au
 	}
 
 	if creds.token != "" {
-		err := c.loginWithToken(ctx, creds.token)
-		if err == nil {
+		tokenErr := c.loginWithToken(ctx, creds.token)
+		if tokenErr == nil {
 			return nil
 		}
 
-		if !errors.Is(err, ErrInvalidSessionToken) || !creds.isSet() {
-			return err
+		if !recoverableWithPassword(tokenErr, creds) {
+			return tokenErr
 		}
 
 		// A token the server no longer accepts is what a password change
 		// leaves behind, and the password is what recovers from it.
-		c.socketioLogger.Warnf("session token rejected, falling back to the password login")
+		c.socketioLogger.Warnf(
+			"session token rejected (%v), falling back to the password login for %q",
+			tokenErr,
+			creds.username,
+		)
+
+		err := c.loginWithPassword(ctx, creds.username, creds.password)
+		if err != nil {
+			// The rejected token is what sent the login down this path, which
+			// the password failure on its own does not say.
+			return fmt.Errorf("%w, and the password login that followed: %w", tokenErr, err)
+		}
+
+		c.setSessionTokenRejected()
+
+		return nil
 	}
 
 	return c.loginWithPassword(ctx, creds.username, creds.password)
+}
+
+// recoverableWithPassword reports whether a rejected session token is worth
+// following with a password login: only a token the server refuses, and only
+// when there is a password to offer. A deactivated or deleted user is the
+// rejection the server answers the same way for both credentials, and anything
+// that is not a rejection - a transport failure, a message the client does not
+// know - says nothing about the password either way.
+func recoverableWithPassword(err error, creds credentials) bool {
+	return errors.Is(err, ErrInvalidSessionToken) &&
+		!errors.Is(err, ErrUserInactive) &&
+		creds.isSet()
 }
 
 // loginWithToken presents a session token from an earlier login, see

--- a/auth_e2e_test.go
+++ b/auth_e2e_test.go
@@ -1,0 +1,192 @@
+package kuma_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/ory/dockertest/v3"
+	"github.com/ory/dockertest/v3/docker"
+	"github.com/stretchr/testify/require"
+
+	kuma "github.com/breml/go-uptime-kuma-client"
+)
+
+// newKumaContainer starts an Uptime Kuma of its own and returns its base URL.
+//
+// The tests below turn two-factor authentication on for the admin account,
+// which every other test in this package logs in as, so they cannot share the
+// server TestMain brings up.
+func newKumaContainer(t *testing.T) string {
+	t.Helper()
+
+	pool, err := dockertest.NewPool("")
+	require.NoError(t, err)
+	require.NoError(t, pool.Client.Ping())
+
+	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
+		Name:       fmt.Sprintf("uptime-kuma-auth-%s", randomString(8)),
+		Repository: "louislam/uptime-kuma",
+		Tag:        "2.5.0",
+		ExtraHosts: []string{"host.docker.internal:host-gateway"},
+	}, func(config *docker.HostConfig) {
+		config.AutoRemove = true
+		config.RestartPolicy = docker.RestartPolicy{Name: "no"}
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, resource.Expire(600))
+
+	t.Cleanup(func() {
+		purgeErr := pool.Purge(resource)
+		if purgeErr != nil {
+			log.Printf("Could not purge resource: %v", purgeErr)
+		}
+	})
+
+	baseURL := "http://localhost:" + resource.GetPort("3001/tcp")
+
+	// The server needs a moment before it accepts connections, and the first
+	// client is the one that runs the setup.
+	err = pool.Retry(func() error {
+		setupClient, setupErr := kuma.New(
+			t.Context(),
+			baseURL,
+			"admin", "admin1",
+			kuma.WithAutosetup(),
+			kuma.WithLogLevel(kuma.LogLevel(os.Getenv("SOCKETIO_LOG_LEVEL"))),
+			kuma.WithConnectTimeout(10*time.Second),
+		)
+		if setupErr != nil {
+			return setupErr
+		}
+
+		return setupClient.Disconnect()
+	})
+	require.NoError(t, err)
+
+	return baseURL
+}
+
+// TestAuthenticationAgainstServer covers the authentication paths that only a
+// real server can show: it turns two-factor authentication on for the admin
+// account and then logs in the ways a client without a human at the keyboard
+// has.
+//
+// Note the server's login rate limit of 20 per minute and the 30 per minute for
+// the two-factor commands. The sequence below stays inside both, a repeated run
+// against the same server would not.
+func TestAuthenticationAgainstServer(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	baseURL := newKumaContainer(t)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Minute)
+	defer cancel()
+
+	admin, err := kuma.New(ctx, baseURL, "admin", "admin1", kuma.WithConnectTimeout(10*time.Second))
+	require.NoError(t, err)
+
+	defer func() { _ = admin.Disconnect() }()
+
+	// The server checks the current password again for these commands, even
+	// though the connection is already authenticated.
+	secret, err := kuma.Prepare2FA(admin, ctx, "admin1")
+	require.NoError(t, err)
+	require.NotEmpty(t, secret)
+
+	normalized, err := kuma.NormalizeTOTPSecret(secret)
+	require.NoError(t, err)
+
+	require.NoError(t, kuma.Save2FA(admin, ctx, "admin1"))
+
+	// Deferred rather than registered as cleanup: the test context is already
+	// cancelled by the time cleanups run.
+	defer func() { _ = kuma.Disable2FA(admin, ctx, "admin1") }()
+
+	enabled, err := kuma.TwoFAStatus(admin, ctx)
+	require.NoError(t, err)
+	require.True(t, enabled)
+
+	t.Run("a login without a code is told what is missing", func(t *testing.T) {
+		client, newErr := kuma.New(
+			ctx,
+			baseURL,
+			"admin",
+			"admin1",
+			kuma.WithConnectTimeout(10*time.Second),
+		)
+
+		require.ErrorIs(t, newErr, kuma.ErrTwoFactorRequired)
+		require.Nil(t, client)
+	})
+
+	t.Run("the secret answers the request for a code", func(t *testing.T) {
+		client, newErr := kuma.New(
+			ctx,
+			baseURL,
+			"admin",
+			"admin1",
+			kuma.WithTOTPSecret(normalized),
+			kuma.WithConnectTimeout(10*time.Second),
+		)
+
+		require.NoError(t, newErr)
+		require.NotNil(t, client)
+
+		t.Cleanup(func() { _ = client.Disconnect() })
+	})
+
+	t.Run("a code the server has seen is refused", func(t *testing.T) {
+		// Line the two logins up inside one time step, which is what the
+		// server's replay guard reacts to. Without the alignment the second
+		// login could fall into the next step and succeed.
+		waitForFreshTOTPStep(t)
+
+		first, newErr := kuma.New(
+			ctx,
+			baseURL,
+			"admin",
+			"admin1",
+			kuma.WithTOTPSecret(normalized),
+			kuma.WithConnectTimeout(10*time.Second),
+		)
+		require.NoError(t, newErr)
+
+		t.Cleanup(func() { _ = first.Disconnect() })
+
+		// A connect timeout shorter than what is left of the step keeps the
+		// client from waiting the step out and retrying.
+		second, newErr := kuma.New(
+			ctx,
+			baseURL,
+			"admin",
+			"admin1",
+			kuma.WithTOTPSecret(normalized),
+			kuma.WithConnectTimeout(5*time.Second),
+		)
+
+		require.ErrorIs(t, newErr, kuma.ErrInvalidTOTPCode)
+		require.Nil(t, second)
+	})
+}
+
+// waitForFreshTOTPStep blocks until the current time step has ended, so that a
+// pair of logins made right afterwards falls into one step the server has not
+// seen a code from yet.
+//
+// Waiting for the boundary rather than for some headroom is what makes this
+// reliable: an earlier login in this test has already used the current step's
+// code, and the server refuses to see it again.
+func waitForFreshTOTPStep(t *testing.T) {
+	t.Helper()
+
+	const step = 30 * time.Second
+
+	time.Sleep(time.Until(time.Now().Truncate(step).Add(step)) + 100*time.Millisecond)
+}

--- a/auth_e2e_test.go
+++ b/auth_e2e_test.go
@@ -113,6 +113,8 @@ func TestAuthenticationAgainstServer(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, enabled)
 
+	var sessionToken string
+
 	t.Run("a login without a code is told what is missing", func(t *testing.T) {
 		client, newErr := kuma.New(
 			ctx,
@@ -140,6 +142,30 @@ func TestAuthenticationAgainstServer(t *testing.T) {
 		require.NotNil(t, client)
 
 		t.Cleanup(func() { _ = client.Disconnect() })
+
+		sessionToken = client.SessionToken()
+		require.NotEmpty(t, sessionToken, "a login answers with the token it can be repeated with")
+	})
+
+	t.Run("the session token needs neither password nor code", func(t *testing.T) {
+		client, newErr := kuma.New(
+			ctx,
+			baseURL,
+			"",
+			"",
+			kuma.WithSessionToken(sessionToken),
+			kuma.WithConnectTimeout(10*time.Second),
+		)
+
+		require.NoError(t, newErr)
+		require.NotNil(t, client)
+
+		t.Cleanup(func() { _ = client.Disconnect() })
+
+		require.Equal(t, sessionToken, client.SessionToken())
+
+		// The lists come from a login, and the token is what repeats one.
+		require.NoError(t, client.Resync(ctx))
 	})
 
 	t.Run("a code the server has seen is refused", func(t *testing.T) {

--- a/auth_test.go
+++ b/auth_test.go
@@ -2,6 +2,7 @@ package kuma_test
 
 import (
 	"context"
+	"errors"
 	"net/http/httptest"
 	"os"
 	"strconv"
@@ -221,6 +222,10 @@ func TestResyncRejectedToken(t *testing.T) {
 // enabled against a client that holds the shared secret: the server asks for a
 // one-time code and the client answers it without a human at the keyboard.
 func TestNewWithTOTPSecret(t *testing.T) {
+	// The code is compared against one generated after New returned, so both
+	// have to fall into the same step for the comparison to mean anything.
+	requireTOTPStepHeadroom(t, 5*time.Second)
+
 	fake, url := newAuthFake(t)
 	fake.setTwoFactorSecret(false)
 
@@ -290,6 +295,13 @@ func TestNewWithTOTPCode(t *testing.T) {
 // current time step, so a caller whose deadline cannot cover that wait has to
 // be told promptly instead of being run into it.
 func TestNewTOTPReplayGuardTightDeadline(t *testing.T) {
+	// The deadline has to be shorter than the wait for the next step for this
+	// to cover anything, and how long that wait is depends on the time of day,
+	// so the step is given room for both before either is measured.
+	const tightDeadline = 3 * time.Second
+
+	requireTOTPStepHeadroom(t, 2*tightDeadline)
+
 	fake, url := newAuthFake(t)
 	fake.setTwoFactorSecret(true)
 
@@ -299,7 +311,7 @@ func TestNewTOTPReplayGuardTightDeadline(t *testing.T) {
 	require.NoError(t, err)
 	fake.useCode(code)
 
-	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), tightDeadline)
 	defer cancel()
 
 	start := time.Now()
@@ -315,7 +327,27 @@ func TestNewTOTPReplayGuardTightDeadline(t *testing.T) {
 
 	require.ErrorIs(t, err, kuma.ErrInvalidTOTPCode)
 	require.Nil(t, client)
-	require.Less(t, elapsed, 3*time.Second, "must not run into the deadline waiting for the next step")
+	require.Less(t, elapsed, tightDeadline, "must not run into the deadline waiting for the next step")
+}
+
+// requireTOTPStepHeadroom leaves at least want of the current time step, by
+// sleeping out a step that is nearly over.
+//
+// A test that says something about the wait for the next step otherwise says
+// it only for the time of day it happens to run at: near the end of a step
+// that wait is short, and a deadline meant to be too small to cover it covers
+// it after all.
+func requireTOTPStepHeadroom(t *testing.T, want time.Duration) {
+	t.Helper()
+
+	const step = 30 * time.Second
+
+	remaining := time.Until(time.Now().Truncate(step).Add(step))
+	if remaining > want {
+		return
+	}
+
+	time.Sleep(remaining + 100*time.Millisecond)
 }
 
 // TestNewTOTPSecretRejected covers the secret the client cannot decode, which
@@ -346,7 +378,157 @@ func TestNewTOTPOptionsConflict(t *testing.T) {
 	)
 
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "mutually exclusive")
+	require.Contains(t, err.Error(), "at most one")
+	require.Nil(t, client)
+}
+
+// TestNewTOTPCodeNil covers the nil callback, which is a caller who meant to
+// configure a code source and did not. It fails the connect rather than
+// leaving the client to report at login time that nothing was configured.
+func TestNewTOTPCodeNil(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	client, err := kuma.New(ctx, "http://127.0.0.1:1", "admin", "admin1", kuma.WithTOTPCode(nil))
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "nil callback")
+	require.Nil(t, client)
+}
+
+// TestNewTOTPOptionsConflictReportsTheConflictFirst covers both options given
+// with a secret that also fails to decode: the conflict is the caller's first
+// mistake, so fixing the secret must not be what uncovers it.
+func TestNewTOTPOptionsConflictReportsTheConflictFirst(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	client, err := kuma.New(
+		ctx,
+		"http://127.0.0.1:1",
+		"admin",
+		"admin1",
+		kuma.WithTOTPSecret("!!!"),
+		kuma.WithTOTPCode(func(context.Context) (string, error) { return "000000", nil }),
+	)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "at most one")
+	require.Nil(t, client)
+}
+
+// TestNewTOTPEmptyCode covers the callback that produces nothing, such as a
+// hardware token prompt the user dismissed. The server reads an empty code as
+// no code and asks again, in an ack carrying neither an ok nor a message, so
+// sending it would buy an error with nothing in it.
+func TestNewTOTPEmptyCode(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setTwoFactorSecret(false)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(
+		ctx,
+		url,
+		"admin",
+		"admin1",
+		kuma.WithTOTPCode(func(context.Context) (string, error) { return "", nil }),
+		kuma.WithConnectTimeout(5*time.Second),
+	)
+
+	require.ErrorIs(t, err, kuma.ErrTwoFactorRequired)
+	require.Nil(t, client)
+	require.Empty(t, fake.receivedLoginCodes()[1:], "an empty code is not worth sending")
+}
+
+// TestNewTOTPCodeFails covers the callback that reports an error, which is the
+// caller's own failure and has to reach them as one rather than as a rejected
+// code.
+func TestNewTOTPCodeFails(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setTwoFactorSecret(false)
+
+	wantErr := errors.New("hardware token unplugged")
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(
+		ctx,
+		url,
+		"admin",
+		"admin1",
+		kuma.WithTOTPCode(func(context.Context) (string, error) { return "", wantErr }),
+		kuma.WithConnectTimeout(5*time.Second),
+	)
+
+	require.ErrorIs(t, err, wantErr)
+	require.NotErrorIs(t, err, kuma.ErrInvalidTOTPCode)
+	require.Nil(t, client)
+}
+
+// TestNewTOTPRejectedForAnotherReason covers the coded login the server
+// rejects for something other than the code. Only a rejected code is worth the
+// retry, so anything else has to reach the caller as itself rather than as the
+// replay guard the retry would end in.
+func TestNewTOTPRejectedForAnotherReason(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setTwoFactorSecret(false)
+	fake.setRejectCodedLogin(true)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(
+		ctx,
+		url,
+		"admin",
+		"admin1",
+		kuma.WithTOTPSecret(rfc6238Secret),
+		kuma.WithConnectTimeout(5*time.Second),
+	)
+
+	require.ErrorIs(t, err, kuma.ErrInvalidCredentials)
+	require.NotErrorIs(t, err, kuma.ErrInvalidTOTPCode)
+	require.Nil(t, client)
+	require.Len(t, fake.receivedLoginCodes(), 2, "a rejection the retry cannot change is not retried")
+}
+
+// TestNewTOTPWaitCancelled covers the caller who gives up while the client is
+// waiting out the time step: the cancellation is what happened, and reporting
+// it as a rejected code would send them looking for a second client that used
+// the same one.
+func TestNewTOTPWaitCancelled(t *testing.T) {
+	requireTOTPStepHeadroom(t, 5*time.Second)
+
+	fake, url := newAuthFake(t)
+	fake.setTwoFactorSecret(true)
+
+	code, err := kuma.TOTPCodeAt(rfc6238Secret, time.Now())
+	require.NoError(t, err)
+	fake.useCode(code)
+
+	// No deadline, so the client commits to the wait instead of skipping it.
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	go func() {
+		for range 100 {
+			if len(fake.receivedLoginCodes()) > 1 {
+				break
+			}
+
+			time.Sleep(20 * time.Millisecond)
+		}
+
+		cancel()
+	}()
+
+	client, err := kuma.New(ctx, url, "admin", "admin1", kuma.WithTOTPSecret(rfc6238Secret))
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.NotErrorIs(t, err, kuma.ErrInvalidTOTPCode)
 	require.Nil(t, client)
 }
 
@@ -355,8 +537,8 @@ func TestNewTOTPOptionsConflict(t *testing.T) {
 // server has not seen, so the login goes through without the caller doing
 // anything.
 //
-// Waiting for the step boundary takes up to 30 seconds, so this runs only in
-// the end-to-end suite.
+// Waiting for the step boundary takes up to 30 seconds, so this runs only when
+// E2E_TEST is set, even though it drives the fake rather than a real server.
 func TestNewTOTPReplayGuardRecovers(t *testing.T) {
 	e2eTest, _ := strconv.ParseBool(os.Getenv("E2E_TEST"))
 	if !e2eTest {

--- a/auth_test.go
+++ b/auth_test.go
@@ -391,3 +391,124 @@ func TestNewTOTPReplayGuardRecovers(t *testing.T) {
 	require.Len(t, codes, 3, "the login without a code, the rejected one and the retry")
 	require.NotEqual(t, codes[1], codes[2], "the retry has to fall into a later time step")
 }
+
+// TestNewWithSessionToken covers the client that holds a token from an earlier
+// login: it authenticates with no password and no one-time code at all.
+func TestNewWithSessionToken(t *testing.T) {
+	fake, url := newAuthFake(t)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(
+		ctx,
+		url,
+		"",
+		"",
+		kuma.WithSessionToken(fakeSessionToken),
+		kuma.WithConnectTimeout(5*time.Second),
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	t.Cleanup(func() { _ = client.Disconnect() })
+
+	require.Equal(t, 0, fake.loginFrameCount(), "a token login sends no password login")
+	require.Equal(t, fakeSessionToken, client.SessionToken())
+}
+
+// TestNewSessionTokenBypassesTwoFactor covers the reason a token is worth
+// keeping for an account with two-factor authentication: the server accepts it
+// without ever asking for a one-time code.
+func TestNewSessionTokenBypassesTwoFactor(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setTwoFactorSecret(false)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(
+		ctx,
+		url,
+		"",
+		"",
+		kuma.WithSessionToken(fakeSessionToken),
+		kuma.WithConnectTimeout(5*time.Second),
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	t.Cleanup(func() { _ = client.Disconnect() })
+
+	require.Empty(t, fake.receivedLoginCodes())
+}
+
+// TestNewRejectedSessionTokenFallsBack covers the token the server no longer
+// accepts, which is what a password change leaves behind. A caller that also
+// gave a username and password recovers with it.
+func TestNewRejectedSessionTokenFallsBack(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setRejectToken(true)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(
+		ctx,
+		url,
+		"admin",
+		"admin1",
+		kuma.WithSessionToken("stale-token"),
+		kuma.WithConnectTimeout(5*time.Second),
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	t.Cleanup(func() { _ = client.Disconnect() })
+
+	require.Equal(t, 1, fake.loginFrameCount(), "the password login is the fallback")
+	require.Equal(t, fakeSessionToken, client.SessionToken(), "the fresh token replaces the stale one")
+}
+
+// TestNewRejectedSessionTokenWithoutPassword covers the same rejection for a
+// caller that has nothing to fall back to.
+func TestNewRejectedSessionTokenWithoutPassword(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setRejectToken(true)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(
+		ctx,
+		url,
+		"",
+		"",
+		kuma.WithSessionToken("stale-token"),
+		kuma.WithConnectTimeout(5*time.Second),
+	)
+
+	require.ErrorIs(t, err, kuma.ErrInvalidSessionToken)
+	require.Nil(t, client)
+	require.Equal(t, 0, fake.loginFrameCount())
+}
+
+// TestSessionTokenAfterAutoLogin covers the server with authentication
+// disabled, which logs the client in without handing out a token.
+func TestSessionTokenAfterAutoLogin(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setAutoLogin(true)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(ctx, url, "", "", kuma.WithConnectTimeout(5*time.Second))
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = client.Disconnect() })
+
+	require.Empty(t, client.SessionToken())
+}

--- a/auth_test.go
+++ b/auth_test.go
@@ -207,7 +207,7 @@ func TestResyncRejectedToken(t *testing.T) {
 
 	t.Cleanup(func() { _ = client.Disconnect() })
 
-	fake.setRejectToken(true)
+	fake.setRejectToken()
 
 	resyncCtx, resyncCancel := context.WithTimeout(ctx, 2*time.Second)
 	defer resyncCancel()
@@ -405,7 +405,7 @@ func TestNewWithSessionToken(t *testing.T) {
 		url,
 		"",
 		"",
-		kuma.WithSessionToken(fakeSessionToken),
+		kuma.WithSessionToken(fakePresetToken),
 		kuma.WithConnectTimeout(5*time.Second),
 	)
 
@@ -415,7 +415,11 @@ func TestNewWithSessionToken(t *testing.T) {
 	t.Cleanup(func() { _ = client.Disconnect() })
 
 	require.Equal(t, 0, fake.loginFrameCount(), "a token login sends no password login")
-	require.Equal(t, fakeSessionToken, client.SessionToken())
+	require.Equal(t, []string{fakePresetToken}, fake.receivedTokens(),
+		"the configured token is what goes on the wire")
+	require.Equal(t, fakePresetToken, client.SessionToken(),
+		"a loginByToken is answered without a token, so the one that worked is kept")
+	require.False(t, client.SessionTokenRejected())
 }
 
 // TestNewSessionTokenBypassesTwoFactor covers the reason a token is worth
@@ -433,7 +437,7 @@ func TestNewSessionTokenBypassesTwoFactor(t *testing.T) {
 		url,
 		"",
 		"",
-		kuma.WithSessionToken(fakeSessionToken),
+		kuma.WithSessionToken(fakePresetToken),
 		kuma.WithConnectTimeout(5*time.Second),
 	)
 
@@ -442,6 +446,7 @@ func TestNewSessionTokenBypassesTwoFactor(t *testing.T) {
 
 	t.Cleanup(func() { _ = client.Disconnect() })
 
+	require.Equal(t, 0, fake.loginFrameCount(), "the token login never asks for a code")
 	require.Empty(t, fake.receivedLoginCodes())
 }
 
@@ -450,7 +455,7 @@ func TestNewSessionTokenBypassesTwoFactor(t *testing.T) {
 // gave a username and password recovers with it.
 func TestNewRejectedSessionTokenFallsBack(t *testing.T) {
 	fake, url := newAuthFake(t)
-	fake.setRejectToken(true)
+	fake.setRejectToken()
 
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
@@ -469,15 +474,19 @@ func TestNewRejectedSessionTokenFallsBack(t *testing.T) {
 
 	t.Cleanup(func() { _ = client.Disconnect() })
 
+	require.Equal(t, []string{"stale-token"}, fake.receivedTokens(), "the token is tried first")
 	require.Equal(t, 1, fake.loginFrameCount(), "the password login is the fallback")
+	require.True(t, fake.loginAfterToken(), "the password login follows the rejected token")
 	require.Equal(t, fakeSessionToken, client.SessionToken(), "the fresh token replaces the stale one")
+	require.True(t, client.SessionTokenRejected(),
+		"the caller has no other way to learn that the token it stored is dead")
 }
 
 // TestNewRejectedSessionTokenWithoutPassword covers the same rejection for a
 // caller that has nothing to fall back to.
 func TestNewRejectedSessionTokenWithoutPassword(t *testing.T) {
 	fake, url := newAuthFake(t)
-	fake.setRejectToken(true)
+	fake.setRejectToken()
 
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
@@ -493,7 +502,84 @@ func TestNewRejectedSessionTokenWithoutPassword(t *testing.T) {
 
 	require.ErrorIs(t, err, kuma.ErrInvalidSessionToken)
 	require.Nil(t, client)
+	require.Equal(t, []string{"stale-token"}, fake.receivedTokens())
 	require.Equal(t, 0, fake.loginFrameCount())
+}
+
+// TestNewRejectedSessionTokenAndPassword covers the caller whose stored token
+// and stored password are both stale: the rejected token has to survive in the
+// error, because the password failure alone sends the caller after the wrong
+// credential.
+func TestNewRejectedSessionTokenAndPassword(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setRejectToken()
+	fake.setRejectCreds(true)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(
+		ctx,
+		url,
+		"admin",
+		"outdated",
+		kuma.WithSessionToken("stale-token"),
+		kuma.WithConnectTimeout(5*time.Second),
+	)
+
+	require.Nil(t, client)
+	require.ErrorIs(t, err, kuma.ErrInvalidCredentials)
+	require.ErrorIs(t, err, kuma.ErrInvalidSessionToken,
+		"the rejected token is what sent the login to the password")
+}
+
+// TestNewSessionTokenUserInactive covers the rejection a password cannot
+// recover from, because the server requires an active user for that login too.
+func TestNewSessionTokenUserInactive(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setRejectTokenWith("authUserInactiveOrDeleted")
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(
+		ctx,
+		url,
+		"admin",
+		"admin1",
+		kuma.WithSessionToken("token-of-a-deactivated-user"),
+		kuma.WithConnectTimeout(5*time.Second),
+	)
+
+	require.Nil(t, client)
+	require.ErrorIs(t, err, kuma.ErrUserInactive)
+	require.ErrorIs(t, err, kuma.ErrInvalidSessionToken, "the token is gone either way")
+	require.Equal(t, 0, fake.loginFrameCount(),
+		"a password login for a deactivated user fails just the same")
+}
+
+// TestNewSessionTokenUnknownRejection covers a refusal the client does not
+// recognize, which says nothing about the password and is reported as it is.
+func TestNewSessionTokenUnknownRejection(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setRejectTokenWith("somethingElseEntirely")
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(
+		ctx,
+		url,
+		"admin",
+		"admin1",
+		kuma.WithSessionToken("stale-token"),
+		kuma.WithConnectTimeout(5*time.Second),
+	)
+
+	require.Nil(t, client)
+	require.ErrorContains(t, err, "somethingElseEntirely")
+	require.NotErrorIs(t, err, kuma.ErrInvalidSessionToken)
+	require.Equal(t, 0, fake.loginFrameCount(), "only a rejected token falls back to the password")
 }
 
 // TestSessionTokenAfterAutoLogin covers the server with authentication

--- a/auth_test.go
+++ b/auth_test.go
@@ -3,6 +3,8 @@ package kuma_test
 import (
 	"context"
 	"net/http/httptest"
+	"os"
+	"strconv"
 	"testing"
 	"time"
 
@@ -213,4 +215,179 @@ func TestResyncRejectedToken(t *testing.T) {
 	err = client.Resync(resyncCtx)
 
 	require.ErrorIs(t, err, kuma.ErrInvalidSessionToken)
+}
+
+// TestNewWithTOTPSecret covers the account with two-factor authentication
+// enabled against a client that holds the shared secret: the server asks for a
+// one-time code and the client answers it without a human at the keyboard.
+func TestNewWithTOTPSecret(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setTwoFactorSecret(false)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(
+		ctx,
+		url,
+		"admin",
+		"admin1",
+		kuma.WithTOTPSecret(rfc6238Secret),
+		kuma.WithConnectTimeout(5*time.Second),
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	t.Cleanup(func() { _ = client.Disconnect() })
+
+	// The code is generated only once the server asks for one, because the
+	// server evaluates the fields of a login independently and would verify a
+	// code it never asked for against a secret that does not exist.
+	codes := fake.receivedLoginCodes()
+	require.Len(t, codes, 2)
+	require.Empty(t, codes[0])
+
+	want, err := kuma.TOTPCodeAt(rfc6238Secret, time.Now())
+	require.NoError(t, err)
+	require.Equal(t, want, codes[1])
+}
+
+// TestNewWithTOTPCode covers the caller whose secret lives somewhere the client
+// cannot read it, so it hands over a callback instead.
+func TestNewWithTOTPCode(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setTwoFactorSecret(false)
+
+	calls := 0
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(
+		ctx,
+		url,
+		"admin",
+		"admin1",
+		kuma.WithTOTPCode(func(context.Context) (string, error) {
+			calls++
+
+			return kuma.TOTPCodeAt(rfc6238Secret, time.Now())
+		}),
+		kuma.WithConnectTimeout(5*time.Second),
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	t.Cleanup(func() { _ = client.Disconnect() })
+
+	require.Equal(t, 1, calls, "the code is asked for only once the server wants one")
+}
+
+// TestNewTOTPReplayGuardTightDeadline covers the code the server has accepted
+// before, which it refuses to see again. Recovering means waiting out the
+// current time step, so a caller whose deadline cannot cover that wait has to
+// be told promptly instead of being run into it.
+func TestNewTOTPReplayGuardTightDeadline(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setTwoFactorSecret(true)
+
+	// Use up the code of the current step, the way another client logging in
+	// with the same account just before would have.
+	code, err := kuma.TOTPCodeAt(rfc6238Secret, time.Now())
+	require.NoError(t, err)
+	fake.useCode(code)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	client, err := kuma.New(
+		ctx,
+		url,
+		"admin",
+		"admin1",
+		kuma.WithTOTPSecret(rfc6238Secret),
+		kuma.WithConnectTimeout(3*time.Second),
+	)
+	elapsed := time.Since(start)
+
+	require.ErrorIs(t, err, kuma.ErrInvalidTOTPCode)
+	require.Nil(t, client)
+	require.Less(t, elapsed, 3*time.Second, "must not run into the deadline waiting for the next step")
+}
+
+// TestNewTOTPSecretRejected covers the secret the client cannot decode, which
+// fails the connect rather than the login it would be needed for.
+func TestNewTOTPSecretRejected(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	client, err := kuma.New(ctx, "http://127.0.0.1:1", "admin", "admin1", kuma.WithTOTPSecret("!!!"))
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "totp secret")
+	require.Nil(t, client)
+}
+
+// TestNewTOTPOptionsConflict covers configuring both ways of producing a code.
+func TestNewTOTPOptionsConflict(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	client, err := kuma.New(
+		ctx,
+		"http://127.0.0.1:1",
+		"admin",
+		"admin1",
+		kuma.WithTOTPSecret(rfc6238Secret),
+		kuma.WithTOTPCode(func(context.Context) (string, error) { return "000000", nil }),
+	)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "mutually exclusive")
+	require.Nil(t, client)
+}
+
+// TestNewTOTPReplayGuardRecovers covers the same rejection with a deadline
+// generous enough to wait the time step out: the next step produces a code the
+// server has not seen, so the login goes through without the caller doing
+// anything.
+//
+// Waiting for the step boundary takes up to 30 seconds, so this runs only in
+// the end-to-end suite.
+func TestNewTOTPReplayGuardRecovers(t *testing.T) {
+	e2eTest, _ := strconv.ParseBool(os.Getenv("E2E_TEST"))
+	if !e2eTest {
+		t.Skip("skipping test that waits out a TOTP time step")
+	}
+
+	fake, url := newAuthFake(t)
+	fake.setTwoFactorSecret(true)
+
+	code, err := kuma.TOTPCodeAt(rfc6238Secret, time.Now())
+	require.NoError(t, err)
+	fake.useCode(code)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 90*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(
+		ctx,
+		url,
+		"admin",
+		"admin1",
+		kuma.WithTOTPSecret(rfc6238Secret),
+		kuma.WithConnectTimeout(60*time.Second),
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	t.Cleanup(func() { _ = client.Disconnect() })
+
+	codes := fake.receivedLoginCodes()
+	require.Len(t, codes, 3, "the login without a code, the rejected one and the retry")
+	require.NotEqual(t, codes[1], codes[2], "the retry has to fall into a later time step")
 }

--- a/client.go
+++ b/client.go
@@ -224,6 +224,16 @@ type Client struct {
 	// see Resync.
 	autoLoggedIn bool
 
+	// totpCode produces the one-time code for an account with two-factor
+	// authentication enabled, see WithTOTPSecret and WithTOTPCode.
+	// totpCodeSet tells a configured callback from none, totpSources counts
+	// how many of the two options set one, and totpErr carries a secret New
+	// has to reject.
+	totpCode    func(ctx context.Context) (string, error)
+	totpCodeSet bool
+	totpSources int
+	totpErr     error
+
 	// readyEventsMissing are the best-effort ready events the server did not
 	// emit while New was connecting, see MissingReadyEvents.
 	readyEventsMissing []string
@@ -473,6 +483,14 @@ func New(ctx context.Context, baseURL string, username string, password string, 
 
 	if (username == "") != (password == "") {
 		return nil, errors.New("credentials: username and password have to be set together")
+	}
+
+	if c.totpErr != nil {
+		return nil, c.totpErr
+	}
+
+	if c.totpSources > 1 {
+		return nil, errors.New("totp: WithTOTPSecret and WithTOTPCode are mutually exclusive")
 	}
 
 	ctxWithConnectTimeout := ctx
@@ -1204,6 +1222,12 @@ type ackResponse struct {
 
 	// MsgI18n reports that Msg is a translation key rather than a sentence.
 	MsgI18n bool `json:"msgi18n"`
+
+	// URI is the otpauth:// URI a prepare2FA answers with.
+	URI string `json:"uri"`
+
+	// Status is whether two-factor authentication is on, from a twoFAStatus.
+	Status bool `json:"status"`
 
 	Token           string         `json:"token"`
 	ID              int64          `json:"id"`

--- a/client.go
+++ b/client.go
@@ -219,9 +219,13 @@ type Client struct {
 	// Resync logs in with, see there.
 	sessionToken string
 
-	// sessionTokenPreset is the token WithSessionToken configured, which is
-	// what New authenticates with instead of a password.
+	// sessionTokenPreset is the token WithSessionToken configured, which New
+	// tries before the password login.
 	sessionTokenPreset string
+
+	// sessionTokenRejected records that the server refused sessionTokenPreset
+	// and the password login took over, see Client.SessionTokenRejected.
+	sessionTokenRejected bool
 
 	// autoLoggedIn records that the server has authentication disabled and
 	// logged the client in itself, which leaves it without a session token,
@@ -937,10 +941,12 @@ func (c *Client) Resync(ctx context.Context) error {
 	return nil
 }
 
-// SessionToken returns the session token the server handed out at login, or
-// the empty string for a client that never received one: a client that
-// connected to a server with authentication disabled, and one whose login ack
-// carried no token.
+// SessionToken returns the session token the client is authenticated with: the
+// one the server handed out for the login New performed, or the one
+// WithSessionToken supplied and the server accepted. It is the empty string for
+// a client that was never logged in with credentials - one that connected to a
+// server with authentication disabled or to one that wants to be set up first -
+// and for one whose login ack carried no token.
 //
 // It is the credential WithSessionToken takes, so a caller can persist it and
 // reconnect later without the password and without a one-time code. It is a
@@ -950,6 +956,22 @@ func (c *Client) SessionToken() string {
 	defer c.mu.Unlock()
 
 	return c.sessionToken
+}
+
+// SessionTokenRejected reports whether the server refused the token
+// WithSessionToken configured and New logged in with the username and password
+// instead.
+//
+// It is what tells a caller that its stored token is dead, because nothing else
+// does: the login succeeds either way, and SessionToken then returns the fresh
+// token of the password login, which the caller cannot tell from the one it
+// presented. A caller that persists tokens checks this and writes the new one
+// back, see WithSessionToken.
+func (c *Client) SessionTokenRejected() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.sessionTokenRejected
 }
 
 // MissingReadyEvents returns the best-effort ready events the server did not
@@ -1051,6 +1073,16 @@ func (c *Client) setSessionToken(token string) {
 	defer c.mu.Unlock()
 
 	c.sessionToken = token
+}
+
+// setSessionTokenRejected records that the token WithSessionToken configured
+// was refused and the password login recovered, see
+// Client.SessionTokenRejected.
+func (c *Client) setSessionTokenRejected() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.sessionTokenRejected = true
 }
 
 // splitReadyEvents returns the update events that carry the lists the local

--- a/client.go
+++ b/client.go
@@ -485,12 +485,14 @@ func New(ctx context.Context, baseURL string, username string, password string, 
 		return nil, errors.New("credentials: username and password have to be set together")
 	}
 
-	if c.totpErr != nil {
-		return nil, c.totpErr
+	// The count comes first: a caller who configured two sources is told that
+	// before being sent to fix whichever of them also failed to decode.
+	if c.totpSources > 1 {
+		return nil, errors.New("totp: at most one of WithTOTPSecret and WithTOTPCode may be used")
 	}
 
-	if c.totpSources > 1 {
-		return nil, errors.New("totp: WithTOTPSecret and WithTOTPCode are mutually exclusive")
+	if c.totpErr != nil {
+		return nil, c.totpErr
 	}
 
 	ctxWithConnectTimeout := ctx

--- a/client.go
+++ b/client.go
@@ -219,6 +219,10 @@ type Client struct {
 	// Resync logs in with, see there.
 	sessionToken string
 
+	// sessionTokenPreset is the token WithSessionToken configured, which is
+	// what New authenticates with instead of a password.
+	sessionTokenPreset string
+
 	// autoLoggedIn records that the server has authentication disabled and
 	// logged the client in itself, which leaves it without a session token,
 	// see Resync.
@@ -759,7 +763,7 @@ connectLoop:
 
 	err = c.authenticate(
 		ctxWithConnectTimeout,
-		credentials{username: username, password: password},
+		credentials{username: username, password: password, token: c.sessionTokenPreset},
 		barrier,
 	)
 	if err != nil {
@@ -887,7 +891,9 @@ func (c *Client) Resync(ctx context.Context) error {
 			)
 		}
 
-		return errors.New("resync: no session token, the client was created without credentials")
+		return errors.New(
+			"resync: no session token, the client was created without credentials",
+		)
 	}
 
 	gate := newReadyGate(c.resyncReadyEvents())
@@ -929,6 +935,21 @@ func (c *Client) Resync(ctx context.Context) error {
 	c.awaitOptionalReadyEvents(ctx, "Resync", gate, nil)
 
 	return nil
+}
+
+// SessionToken returns the session token the server handed out at login, or
+// the empty string for a client that never received one: a client that
+// connected to a server with authentication disabled, and one whose login ack
+// carried no token.
+//
+// It is the credential WithSessionToken takes, so a caller can persist it and
+// reconnect later without the password and without a one-time code. It is a
+// bearer credential that does not expire, see WithSessionToken.
+func (c *Client) SessionToken() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.sessionToken
 }
 
 // MissingReadyEvents returns the best-effort ready events the server did not

--- a/client_ack_test.go
+++ b/client_ack_test.go
@@ -93,12 +93,17 @@ type fakeAckServer struct {
 	loginRequiredDelay time.Duration
 	// twoFactorRequired answers a login without a code the way a server does
 	// for an account with two-factor authentication enabled. twoFactorSecret
-	// is the secret the codes are verified against, and acceptedCodes records
-	// the codes already used, which a real server refuses to see again.
+	// is the secret the codes are verified against, replayGuard turns the
+	// server's refusal to see an accepted code twice on, and acceptedCodes is
+	// what that refusal reads.
 	twoFactorRequired bool
 	twoFactorSecret   string
 	replayGuard       bool
 	acceptedCodes     map[string]struct{}
+	// rejectCodedLogin rejects a login carrying a code for a reason that is
+	// not the code, which the client has to hand over as it is instead of
+	// spending its retry on it.
+	rejectCodedLogin bool
 	// loginCodes are the one-time codes the logins carried, in order.
 	loginCodes []string
 	// setupRequired answers the connect with a setup event and rejects the
@@ -238,8 +243,10 @@ func (s *fakeAckServer) setLoginRequiredDelay(d time.Duration) {
 }
 
 // setTwoFactorSecret turns two-factor authentication on and verifies the codes
-// against the shared test secret. With replayGuard set it also refuses a code
-// it has already accepted, the way a real server does.
+// against the shared test secret. With replayGuard set it also refuses every
+// code it has already accepted; the real server only remembers the last one it
+// let through, in twofa_last_token, which is stricter than these tests need to
+// tell apart.
 func (s *fakeAckServer) setTwoFactorSecret(replayGuard bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -265,6 +272,13 @@ func (s *fakeAckServer) receivedLoginCodes() []string {
 	defer s.mu.Unlock()
 
 	return append([]string(nil), s.loginCodes...)
+}
+
+func (s *fakeAckServer) setRejectCodedLogin(reject bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.rejectCodedLogin = reject
 }
 
 func (s *fakeAckServer) setSetupRequired(required bool) {
@@ -402,6 +416,10 @@ func (s *fakeAckServer) loginAck(code string) string {
 	// An ack asking for a one-time code carries neither an ok nor a message.
 	if s.twoFactorRequired && code == "" {
 		return `{"tokenRequired":true}`
+	}
+
+	if s.rejectCodedLogin && code != "" {
+		return `{"ok":false,"msg":"authIncorrectCreds","msgi18n":true}`
 	}
 
 	if s.twoFactorRequired && !s.acceptsCodeLocked(code) {

--- a/client_ack_test.go
+++ b/client_ack_test.go
@@ -51,6 +51,11 @@ const fakeAckCreatedID = 4242
 // expects to see again in a loginByToken.
 const fakeSessionToken = "fake-session-token"
 
+// fakePresetToken is a token a test hands to WithSessionToken. It is distinct
+// from the one the fake server issues at login, so that a test can tell the
+// token that was presented from the one that was handed out.
+const fakePresetToken = "preset-session-token"
+
 // fakeAckServer is a minimal socket.io server over HTTP long-polling that
 // completes the handshake, CONNECT, login and ready phases, so kuma.New()
 // returns a usable client. Unlike fakeSocketIOServer it then keeps serving:
@@ -79,9 +84,14 @@ type fakeAckServer struct {
 	// rejectCreds answers a login the way a server rejecting the username and
 	// password does.
 	rejectCreds bool
-	// rejectToken answers a loginByToken the way a server rejecting the
-	// session token does.
-	rejectToken bool
+	// rejectTokenMsg answers a loginByToken the way a server rejecting the
+	// session token does, with this as the reason. The empty string accepts.
+	rejectTokenMsg string
+	// tokenFrames are the tokens the loginByToken frames carried, in order,
+	// recorded whether the token is accepted or refused. firstTokenAt is when
+	// the first of them arrived, to assert it came before any password login.
+	tokenFrames  []string
+	firstTokenAt time.Time
 	// autoLogin answers the connect the way a server with authentication
 	// disabled does: it logs the client in itself and never asks for a login.
 	autoLogin bool
@@ -133,6 +143,24 @@ func loginCode(payload string) string {
 	}
 
 	return data.Token
+}
+
+// tokenFromFrame extracts the session token a loginByToken frame carries.
+func tokenFromFrame(payload string) string {
+	var frame []json.RawMessage
+
+	start := strings.Index(payload, "[")
+	if start < 0 || json.Unmarshal([]byte(payload[start:]), &frame) != nil || len(frame) < 2 {
+		return ""
+	}
+
+	var token string
+
+	if json.Unmarshal(frame[1], &token) != nil {
+		return ""
+	}
+
+	return token
 }
 
 func (s *fakeAckServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -216,11 +244,17 @@ func (s *fakeAckServer) setRejectCreds(reject bool) {
 	s.rejectCreds = reject
 }
 
-func (s *fakeAckServer) setRejectToken(reject bool) {
+func (s *fakeAckServer) setRejectToken() {
+	s.setRejectTokenWith("authInvalidToken")
+}
+
+// setRejectTokenWith refuses a loginByToken with a specific reason, such as the
+// authUserInactiveOrDeleted the server answers for a deactivated user.
+func (s *fakeAckServer) setRejectTokenWith(msg string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.rejectToken = reject
+	s.rejectTokenMsg = msg
 }
 
 func (s *fakeAckServer) setAutoLogin(auto bool) {
@@ -339,11 +373,45 @@ func (s *fakeAckServer) setSuppressOptionalLists(suppress bool) {
 	s.suppressOptionalLists = suppress
 }
 
-func (s *fakeAckServer) tokenRejected() bool {
+// tokenRejection returns the reason a loginByToken is to be refused with, or
+// the empty string for a token the server accepts.
+func (s *fakeAckServer) tokenRejection() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	return s.rejectToken
+	return s.rejectTokenMsg
+}
+
+// recordToken records the token a loginByToken frame carried. It runs before
+// the rejection is answered, so a refused frame is seen as well.
+func (s *fakeAckServer) recordToken(token string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.tokenFrames = append(s.tokenFrames, token)
+
+	if s.firstTokenAt.IsZero() {
+		s.firstTokenAt = time.Now()
+	}
+}
+
+// receivedTokens returns the tokens the loginByToken frames carried, in order.
+func (s *fakeAckServer) receivedTokens() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return append([]string(nil), s.tokenFrames...)
+}
+
+// loginAfterToken reports whether the password login the client fell back to
+// came after the token it presented first.
+func (s *fakeAckServer) loginAfterToken() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return !s.firstLoginAt.IsZero() &&
+		!s.firstTokenAt.IsZero() &&
+		s.firstLoginAt.After(s.firstTokenAt)
 }
 
 func (s *fakeAckServer) recordResync(payload string) bool {
@@ -490,11 +558,14 @@ func (s *fakeAckServer) handleClientMessage(body []byte) {
 		// A resync logs in again, which is what makes the server resend the
 		// lists. Checked before "login", which is a prefix of it.
 		if strings.Contains(payload, `"loginByToken"`) {
-			if s.tokenRejected() {
+			s.recordToken(tokenFromFrame(payload))
+
+			if msg := s.tokenRejection(); msg != "" {
 				s.messages <- fmt.Appendf(
 					nil,
-					`43%s[{"ok":false,"msg":"authInvalidToken","msgi18n":true}]`,
+					`43%s[{"ok":false,"msg":%q,"msgi18n":true}]`,
 					ackID,
+					msg,
 				)
 
 				return

--- a/client_ack_test.go
+++ b/client_ack_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pquerna/otp"
+	"github.com/pquerna/otp/totp"
 	"github.com/stretchr/testify/require"
 
 	kuma "github.com/breml/go-uptime-kuma-client"
@@ -90,8 +92,15 @@ type fakeAckServer struct {
 	// that registers its handlers after an await does.
 	loginRequiredDelay time.Duration
 	// twoFactorRequired answers a login without a code the way a server does
-	// for an account with two-factor authentication enabled.
+	// for an account with two-factor authentication enabled. twoFactorSecret
+	// is the secret the codes are verified against, and acceptedCodes records
+	// the codes already used, which a real server refuses to see again.
 	twoFactorRequired bool
+	twoFactorSecret   string
+	replayGuard       bool
+	acceptedCodes     map[string]struct{}
+	// loginCodes are the one-time codes the logins carried, in order.
+	loginCodes []string
 	// setupRequired answers the connect with a setup event and rejects the
 	// credentials until the setup ran, as a server without users does.
 	setupRequired bool
@@ -104,6 +113,26 @@ type fakeAckServer struct {
 	firstLoginAt    time.Time
 	// loginFrames counts the login frames received.
 	loginFrames int
+}
+
+// loginCode extracts the one-time code a login frame carries.
+func loginCode(payload string) string {
+	var frame []json.RawMessage
+
+	start := strings.Index(payload, "[")
+	if start < 0 || json.Unmarshal([]byte(payload[start:]), &frame) != nil || len(frame) < 2 {
+		return ""
+	}
+
+	var data struct {
+		Token string `json:"token"`
+	}
+
+	if json.Unmarshal(frame[1], &data) != nil {
+		return ""
+	}
+
+	return data.Token
 }
 
 func (s *fakeAckServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -208,6 +237,36 @@ func (s *fakeAckServer) setLoginRequiredDelay(d time.Duration) {
 	s.loginRequiredDelay = d
 }
 
+// setTwoFactorSecret turns two-factor authentication on and verifies the codes
+// against the shared test secret. With replayGuard set it also refuses a code
+// it has already accepted, the way a real server does.
+func (s *fakeAckServer) setTwoFactorSecret(replayGuard bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.twoFactorRequired = true
+	s.twoFactorSecret = rfc6238Secret
+	s.replayGuard = replayGuard
+	s.acceptedCodes = map[string]struct{}{}
+}
+
+// useCode marks a code as already accepted, the way another client logging in
+// with the same account inside the same time step would.
+func (s *fakeAckServer) useCode(code string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.acceptedCodes[code] = struct{}{}
+}
+
+// receivedLoginCodes returns the one-time codes the logins carried, in order.
+func (s *fakeAckServer) receivedLoginCodes() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return append([]string(nil), s.loginCodes...)
+}
+
 func (s *fakeAckServer) setSetupRequired(required bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -247,11 +306,12 @@ func (s *fakeAckServer) setOmitLoginRequired(omit bool) {
 	s.omitLoginRequired = omit
 }
 
-func (s *fakeAckServer) recordLogin() {
+func (s *fakeAckServer) recordLogin(code string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	s.loginFrames++
+	s.loginCodes = append(s.loginCodes, code)
 
 	if s.firstLoginAt.IsZero() {
 		s.firstLoginAt = time.Now()
@@ -302,7 +362,36 @@ func (s *fakeAckServer) lastResyncPayload() string {
 	return s.resyncPayload
 }
 
-func (s *fakeAckServer) loginAck() string {
+// acceptsCodeLocked verifies a one-time code the way the server does, with the
+// replay guard that refuses a code it has already let through. The caller holds
+// the lock.
+func (s *fakeAckServer) acceptsCodeLocked(code string) bool {
+	if s.twoFactorSecret == "" {
+		return false
+	}
+
+	if s.replayGuard {
+		if _, used := s.acceptedCodes[code]; used {
+			return false
+		}
+	}
+
+	valid, err := totp.ValidateCustom(code, s.twoFactorSecret, time.Now(), totp.ValidateOpts{
+		Period:    30,
+		Skew:      1,
+		Digits:    otp.DigitsSix,
+		Algorithm: otp.AlgorithmSHA1,
+	})
+	if err != nil || !valid {
+		return false
+	}
+
+	s.acceptedCodes[code] = struct{}{}
+
+	return true
+}
+
+func (s *fakeAckServer) loginAck(code string) string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -311,8 +400,12 @@ func (s *fakeAckServer) loginAck() string {
 	}
 
 	// An ack asking for a one-time code carries neither an ok nor a message.
-	if s.twoFactorRequired {
+	if s.twoFactorRequired && code == "" {
 		return `{"tokenRequired":true}`
+	}
+
+	if s.twoFactorRequired && !s.acceptsCodeLocked(code) {
+		return `{"ok":false,"msg":"authInvalidToken","msgi18n":true}`
 	}
 
 	if s.omitLoginToken {
@@ -424,9 +517,10 @@ func (s *fakeAckServer) handleClientMessage(body []byte) {
 		}
 
 		if strings.Contains(payload, `"login"`) {
-			s.recordLogin()
+			code := loginCode(payload)
+			s.recordLogin(code)
 
-			ack := s.loginAck()
+			ack := s.loginAck(code)
 			s.messages <- fmt.Appendf(nil, `43%s[%s]`, ackID, ack)
 
 			if strings.Contains(ack, `"ok":true`) {

--- a/doc.go
+++ b/doc.go
@@ -35,6 +35,34 @@
 //	}
 //	id, err := client.CreateMonitor(ctx, monitor)
 //
+// # Authentication
+//
+// A username and password is the usual way in. An account with two-factor
+// authentication enabled additionally needs the shared secret, which the
+// client turns into the one-time code the server asks for:
+//
+//	client, err := kuma.New(ctx, url, "username", "password",
+//	    kuma.WithTOTPSecret(secret))
+//
+// A successful login answers with a session token. Persisting it lets a later
+// client connect with neither the password nor a one-time code, which is also
+// how several clients start at once against an account with two-factor
+// authentication: the server refuses a one-time code it has already accepted,
+// but takes the same token any number of times.
+//
+//	token := client.SessionToken()
+//	// ... later, in another process
+//	client, err := kuma.New(ctx, url, "", "", kuma.WithSessionToken(token))
+//
+// The token does not expire; the server invalidates it only when the password
+// changes or the user is deactivated. Store it the way the password would be
+// stored.
+//
+// A server with authentication disabled logs the client in by itself, so it
+// takes no credentials at all:
+//
+//	client, err := kuma.New(ctx, url, "", "")
+//
 // # Supported Monitor Types
 //
 // HTTP, TCP, Ping, DNS, gRPC, Redis, PostgreSQL, Real Browser, and more.

--- a/export_test.go
+++ b/export_test.go
@@ -1,0 +1,18 @@
+package kuma
+
+// The two-factor management commands and the code generation are internal:
+// they administer an account rather than authenticate a client, and there is
+// no request for them as public API yet. The end-to-end tests need them to put
+// a real server into the state they exercise, and those live in the external
+// test package, so they are exported for the tests alone.
+//
+//nolint:gochecknoglobals // the standard way to reach internals from an external test package.
+var (
+	Prepare2FA  = (*Client).prepare2FA
+	Save2FA     = (*Client).save2FA
+	Disable2FA  = (*Client).disable2FA
+	TwoFAStatus = (*Client).twoFAStatus
+
+	NormalizeTOTPSecret = normalizeTOTPSecret
+	TOTPCodeAt          = totpCodeAt
+)

--- a/go.mod
+++ b/go.mod
@@ -81,6 +81,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.9.1 // indirect
 	github.com/bombsimon/wsl/v4 v4.7.0 // indirect
 	github.com/bombsimon/wsl/v5 v5.8.0 // indirect
+	github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc // indirect
 	github.com/breml/bidichk v0.3.3 // indirect
 	github.com/breml/errchkjson v0.4.1 // indirect
 	github.com/breml/githooks v0.0.0-20260421174736-44943ba7a400 // indirect
@@ -261,6 +262,7 @@ require (
 	github.com/pjbgf/sha1cd v0.3.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
+	github.com/pquerna/otp v1.5.0 // indirect
 	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.2
 require (
 	github.com/maldikhan/go.socket.io v0.1.1
 	github.com/ory/dockertest/v3 v3.12.0
+	github.com/pquerna/otp v1.5.0
 )
 
 require (
@@ -262,7 +263,6 @@ require (
 	github.com/pjbgf/sha1cd v0.3.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
-	github.com/pquerna/otp v1.5.0 // indirect
 	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -163,6 +163,8 @@ github.com/bombsimon/wsl/v4 v4.7.0 h1:1Ilm9JBPRczjyUs6hvOPKvd7VL1Q++PL8M0SXBDf+j
 github.com/bombsimon/wsl/v4 v4.7.0/go.mod h1:uV/+6BkffuzSAVYD+yGyld1AChO7/EuLrCF/8xTiapg=
 github.com/bombsimon/wsl/v5 v5.8.0 h1:JTkyfs4yl8SPejrCF2GdABXE+mO1WvM7iUYzRWlsxDs=
 github.com/bombsimon/wsl/v5 v5.8.0/go.mod h1:AbOLsulgkqP4ZnitHf9gwPtCOGlrzkk0jb0uNxRSY0o=
+github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc h1:biVzkmvwrH8WK8raXaxBx6fRVTlJILwEwQGL1I/ByEI=
+github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/breml/bidichk v0.3.3 h1:WSM67ztRusf1sMoqH6/c4OBCUlRVTKq+CbSeo0R17sE=
 github.com/breml/bidichk v0.3.3/go.mod h1:ISbsut8OnjB367j5NseXEGGgO/th206dVa427kR8YTE=
 github.com/breml/errchkjson v0.4.1 h1:keFSS8D7A2T0haP9kzZTi7o26r7kE3vymjZNeNDRDwg=
@@ -609,6 +611,8 @@ github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pquerna/otp v1.5.0 h1:NMMR+WrmaqXU4EzdGJEE1aUUI0AMRzsp96fFFWNPwxs=
+github.com/pquerna/otp v1.5.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
 github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h0RJWRi/o0o=
 github.com/prometheus/client_golang v1.23.2/go.mod h1:Tb1a6LWHB3/SPIzCoaDXI4I8UHKeFTEQ1YCr+0Gyqmg=
 github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=

--- a/totp.go
+++ b/totp.go
@@ -1,0 +1,67 @@
+package kuma
+
+import (
+	"encoding/base32"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/pquerna/otp"
+	"github.com/pquerna/otp/totp"
+)
+
+// totpStep is the time step RFC 6238 uses and the one the server verifies
+// with, see twoFAVerifyOptions in the server's server.js.
+const totpStep = 30 * time.Second
+
+// normalizeTOTPSecret returns the secret in the padded upper-case base32 form
+// the code generation expects, and reports a secret it cannot decode.
+//
+// The server hands the secret out in the otpauth:// URI it shows when
+// two-factor authentication is set up, with the base32 padding stripped, so
+// restoring the padding is what makes such a secret usable at all. A secret
+// copied out of a user interface may also carry spaces, hyphens and lower
+// case, all of which are accepted.
+func normalizeTOTPSecret(secret string) (string, error) {
+	normalized := strings.ToUpper(strings.NewReplacer(" ", "", "-", "", "=", "").Replace(secret))
+	if normalized == "" {
+		return "", errors.New("totp secret: empty")
+	}
+
+	if padding := len(normalized) % 8; padding != 0 {
+		normalized += strings.Repeat("=", 8-padding)
+	}
+
+	_, err := base32.StdEncoding.DecodeString(normalized)
+	if err != nil {
+		return "", fmt.Errorf("totp secret: not base32: %w", err)
+	}
+
+	return normalized, nil
+}
+
+// totpCodeAt returns the one-time code for secret at t, with the parameters
+// the server verifies with: HMAC-SHA1, a 30 second step and six digits.
+func totpCodeAt(secret string, t time.Time) (string, error) {
+	code, err := totp.GenerateCodeCustom(secret, t, totp.ValidateOpts{
+		Period:    uint(totpStep / time.Second),
+		Skew:      0,
+		Digits:    otp.DigitsSix,
+		Algorithm: otp.AlgorithmSHA1,
+	})
+	if err != nil {
+		return "", fmt.Errorf("totp code: %w", err)
+	}
+
+	return code, nil
+}
+
+// totpStepStart returns the beginning of the time step t falls into.
+//
+// The server records the last code it accepted and refuses to see it again, so
+// a code that was rejected for that reason is only worth replacing once the
+// step it belongs to is over.
+func totpStepStart(t time.Time) time.Time {
+	return t.Truncate(totpStep)
+}

--- a/totp_test.go
+++ b/totp_test.go
@@ -86,10 +86,15 @@ func TestNormalizeTOTPSecret(t *testing.T) {
 }
 
 // TestNormalizeTOTPSecretServerShape covers the secret Uptime Kuma actually
-// hands out: 64 random bytes, base32 encoded with the padding stripped.
+// hands out: the 64 random alphanumeric characters of genSecret, base32
+// encoded and stripped of the one padding character that leaves. 103 is what
+// makes this the interesting case - a length that is not a multiple of 8, so
+// the padding has to be restored before the secret decodes at all.
 func TestNormalizeTOTPSecretServerShape(t *testing.T) {
-	const serverSecret = "KRUGS4ZANFZSAYJANRQXE6JAOZQWY5LFMRPWG33EMVSA" +
-		"KRUGS4ZANFZSAYJANRQXE6JAOZQWY5LFMRPWG33EMVSAKRUGS4ZANFZSAYJA"
+	const serverSecret = "MRXUIZ2RKI4TMY2JGFGDMWJZONETK5KZGE2WE3SGHBHEUUKIOVMU" +
+		"OSCSHEZUY3BSJF2GUUKXNNVFCWRXJ44DKN3TOBIHK2JSN52DG5Y"
+
+	require.NotZero(t, len(serverSecret)%8, "the fixture has to need the padding restored")
 
 	normalized, err := kuma.NormalizeTOTPSecret(serverSecret)
 

--- a/totp_test.go
+++ b/totp_test.go
@@ -1,0 +1,103 @@
+package kuma_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	kuma "github.com/breml/go-uptime-kuma-client"
+)
+
+// rfc6238Secret is the base32 form of the RFC 6238 test key
+// "12345678901234567890".
+const rfc6238Secret = "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ"
+
+// TestTOTPCodeAtRFC6238 checks the generated codes against the SHA1 test
+// vectors of RFC 6238, appendix B. Uptime Kuma verifies with the same
+// parameters, so a code this agrees with is a code the server accepts.
+func TestTOTPCodeAtRFC6238(t *testing.T) {
+	tests := []struct {
+		name string
+		unix int64
+		want string
+	}{
+		{name: "1970", unix: 59, want: "287082"},
+		{name: "2005", unix: 1111111109, want: "081804"},
+		{name: "2005 next step", unix: 1111111111, want: "050471"},
+		{name: "2009", unix: 1234567890, want: "005924"},
+		{name: "2033", unix: 2000000000, want: "279037"},
+		{name: "2603", unix: 20000000000, want: "353130"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			code, err := kuma.TOTPCodeAt(rfc6238Secret, time.Unix(test.unix, 0).UTC())
+
+			require.NoError(t, err)
+			require.Equal(t, test.want, code)
+		})
+	}
+}
+
+// TestNormalizeTOTPSecret covers the shapes a secret reaches the client in.
+// Uptime Kuma strips the base32 padding from the secret it puts in the
+// otpauth:// URI, so restoring it is what makes such a secret usable at all.
+func TestNormalizeTOTPSecret(t *testing.T) {
+	tests := []struct {
+		name    string
+		secret  string
+		want    string
+		wantErr bool
+	}{
+		{name: "already normalized", secret: rfc6238Secret, want: rfc6238Secret},
+		{name: "lower case", secret: "gezdgnbvgy3tqojqgezdgnbvgy3tqojq", want: rfc6238Secret},
+		{name: "spaced", secret: "GEZD GNBV GY3T QOJQ GEZD GNBV GY3T QOJQ", want: rfc6238Secret},
+		{name: "hyphenated", secret: "GEZD-GNBV-GY3T-QOJQ-GEZD-GNBV-GY3T-QOJQ", want: rfc6238Secret},
+		{
+			name:   "unpadded",
+			secret: "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZA",
+			want:   "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZA====",
+		},
+		{
+			name:   "padded",
+			secret: "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZA====",
+			want:   "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZA====",
+		},
+		{name: "empty", secret: "", wantErr: true},
+		{name: "blank", secret: "   ", wantErr: true},
+		{name: "not base32", secret: "not-a-secret!", wantErr: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := kuma.NormalizeTOTPSecret(test.secret)
+
+			if test.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, test.want, got)
+		})
+	}
+}
+
+// TestNormalizeTOTPSecretServerShape covers the secret Uptime Kuma actually
+// hands out: 64 random bytes, base32 encoded with the padding stripped.
+func TestNormalizeTOTPSecretServerShape(t *testing.T) {
+	const serverSecret = "KRUGS4ZANFZSAYJANRQXE6JAOZQWY5LFMRPWG33EMVSA" +
+		"KRUGS4ZANFZSAYJANRQXE6JAOZQWY5LFMRPWG33EMVSAKRUGS4ZANFZSAYJA"
+
+	normalized, err := kuma.NormalizeTOTPSecret(serverSecret)
+
+	require.NoError(t, err)
+	require.Zero(t, len(normalized)%8, "the decoder needs the padding back")
+
+	code, err := kuma.TOTPCodeAt(normalized, time.Unix(1234567890, 0).UTC())
+
+	require.NoError(t, err)
+	require.Len(t, code, 6)
+}


### PR DESCRIPTION
Let a client log in to an account with two-factor authentication enabled
without a human at the keyboard.

> Stacked on #366. Review that first; the base changes to `master` once it
> merges.

## Why

Such an account could not be used at all: the server answers the login by
asking for a one-time code, and the client had nothing to answer with.

## What

- `WithTOTPSecret` for a caller that holds the shared secret, and
  `WithTOTPCode` for one whose secret lives somewhere the client cannot read
  it. Mutually exclusive; an undecodable secret fails `New` rather than the
  login it would be needed for.
- The four two-factor management commands (`prepare2FA`, `save2FA`,
  `disable2FA`, `twoFAStatus`), unexported and reached from the tests through
  `export_test.go`. They administer an account rather than authenticate a
  client, so they stay out of the public API until something asks for them.

## Two deviations from #20

**The code is generated only once the server asks for one**, rather than sent
with every login as the issue proposes. The server's branches at
`server/server.js:471-517` are three sequential non-exclusive `if`s: a
non-empty `token` sent to an account *without* two-factor authentication runs
the success branch *and* the verify branch, so `callback` is invoked twice, the
second time either with `authInvalidToken` or with an exception thrown inside
an un-`try`'d async handler, because `twofa_secret` is `NULL`. The socket.io
client survives it — the first ack wins — but the client should not provoke it.
Waiting for the request costs one round trip, and only for the accounts that
need it.

**`WithAutosetup(enable2FA bool)` is dropped.** It changes an exported
signature and would break every caller.

## Replay guard

The server records the last code it accepted and refuses to see it again, and
that guard is per user, not per socket, so two clients logging in inside one 30
second step cannot both succeed. A code rejected that way is retried once in
the next step, but only when the caller's deadline can cover the wait;
otherwise the caller is told promptly, with the reason. A caller starting many
clients at once is better served by a session token, which has no such guard.

## Dependency

Adds `github.com/pquerna/otp`, which pulls in `github.com/boombuler/barcode`
for QR generation this client never uses. `totp.go` confines both to one file,
so swapping in ~50 lines of `crypto/hmac` and `encoding/base32` later would not
change any signature.

## Tests

RFC 6238 SHA1 vectors, secret normalization (the server strips the base32
padding, so restoring it is what makes its secret usable at all), and five
tests against a fake that verifies real codes and enforces the replay guard.
A new end-to-end test turns two-factor authentication on for a real
`louislam/uptime-kuma:2.5.0` in its own container — the shared one cannot be
used, since every other test logs in as the same account — and covers the
rejection without a code, the login with one, and the replay guard.
`task lint`, `task test` and `task test-e2e` all pass.

Closes #20
