### PR TITLE
feat(client): authenticate with a session token

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ go get github.com/breml/go-uptime-kuma-client
 - **Maintenance Windows**: Schedule maintenance periods
 - **Status Pages**: Create and manage public status pages
 - **Real-time Updates**: Socket.IO-based event system for state synchronization
+- **Authentication**: Username and password, two-factor authentication without a
+  human at the keyboard, session token reuse, and servers with authentication
+  disabled
 
 ## Usage
 
@@ -92,6 +95,51 @@ func main() {
  log.Printf("Created monitor with ID: %d", monitorID)
 }
 ```
+
+## Authentication
+
+A username and password is the usual way in. An account with two-factor
+authentication enabled additionally needs the shared secret, which the client
+turns into the one-time code the server asks for:
+
+```go
+client, err := kuma.New(ctx, url, "username", "password",
+ kuma.WithTOTPSecret(secret))
+```
+
+`WithTOTPCode` takes a callback instead, for a secret the client cannot read
+itself.
+
+A successful login answers with a session token. Persisting it lets a later
+client connect with neither the password nor a one-time code:
+
+```go
+token := client.SessionToken()
+
+// ... later, in another process
+client, err := kuma.New(ctx, url, "", "", kuma.WithSessionToken(token))
+```
+
+This is also how several clients start at once against an account with
+two-factor authentication: the server refuses a one-time code it has already
+accepted, but takes the same token any number of times.
+
+The token does not expire. The server invalidates it only when the password
+changes or the user is deactivated, and for an account with two-factor
+authentication it is a stronger credential than the password, because it needs
+no second factor. Store it the way the password would be stored.
+
+A server with authentication disabled logs the client in by itself, so it takes
+no credentials at all:
+
+```go
+client, err := kuma.New(ctx, url, "", "")
+```
+
+Uptime Kuma API keys are not an option here: the server accepts them for HTTP
+basic auth on `/metrics` only, never for the Socket.IO API this client speaks.
+There is likewise no OIDC, SSO, LDAP or client-certificate login in any
+released Uptime Kuma version.
 
 ## Documentation
 

--- a/auth.go
+++ b/auth.go
@@ -43,6 +43,30 @@ var ErrInvalidTOTPCode = errors.New("invalid two-factor authentication code")
 // changed password or a user that was deactivated or deleted.
 var ErrInvalidSessionToken = errors.New("session token rejected")
 
+// WithSessionToken authenticates with a session token from an earlier login
+// instead of a password, see Client.SessionToken.
+//
+// The token is what the server hands out on a successful login and what it
+// accepts in place of one. It bypasses two-factor authentication entirely, so
+// a client holding one needs neither the password nor the one-time code, which
+// also makes it the way to start many clients at once against an account with
+// two-factor authentication enabled, see WithTOTPSecret.
+//
+// If a username and password are given as well, the token is tried first and
+// the password login is the fallback for a token the server rejects. Without
+// them a rejected token fails New with ErrInvalidSessionToken.
+//
+// Security: the token is a bearer credential that does not expire. The server
+// invalidates it only when the password changes or the user is deactivated,
+// and it is a stronger credential than the password for an account with
+// two-factor authentication, because it needs no second factor. Store it the
+// way the password would be stored.
+func WithSessionToken(token string) Option {
+	return func(c *Client) {
+		c.sessionTokenPreset = token
+	}
+}
+
 // WithTOTPSecret configures the shared secret of an account with two-factor
 // authentication enabled, so the client can answer the server's request for a
 // one-time code itself and log in without a human at the keyboard.
@@ -152,6 +176,7 @@ type authBarrier struct {
 type credentials struct {
 	username string
 	password string
+	token    string
 }
 
 // loginError translates a rejected login ack into one of the package's sentinel
@@ -209,6 +234,11 @@ func (c credentials) isSet() bool {
 	return c.username != "" && c.password != ""
 }
 
+// hasAny reports whether there is anything at all to authenticate with.
+func (c credentials) hasAny() bool {
+	return c.isSet() || c.token != ""
+}
+
 // authenticate logs the client in the way the server asked for, and records the
 // session token a successful login answers with.
 //
@@ -227,12 +257,12 @@ func (c *Client) authenticate(ctx context.Context, creds credentials, barrier au
 		return nil
 
 	case authModeLoginRequired:
-		if !creds.isSet() {
+		if !creds.hasAny() {
 			return ErrAuthRequired
 		}
 
 	case authModeUnknown:
-		if !creds.isSet() {
+		if !creds.hasAny() {
 			// A server that never said it wants a login is not asked for one.
 			return nil
 		}
@@ -241,7 +271,41 @@ func (c *Client) authenticate(ctx context.Context, creds credentials, barrier au
 		// authMode has no other values.
 	}
 
+	if creds.token != "" {
+		err := c.loginWithToken(ctx, creds.token)
+		if err == nil {
+			return nil
+		}
+
+		if !errors.Is(err, ErrInvalidSessionToken) || !creds.isSet() {
+			return err
+		}
+
+		// A token the server no longer accepts is what a password change
+		// leaves behind, and the password is what recovers from it.
+		c.socketioLogger.Warnf("session token rejected, falling back to the password login")
+	}
+
 	return c.loginWithPassword(ctx, creds.username, creds.password)
+}
+
+// loginWithToken presents a session token from an earlier login, see
+// WithSessionToken.
+func (c *Client) loginWithToken(ctx context.Context, token string) error {
+	response, err := c.emitAck(ctx, "loginByToken", token)
+	if err != nil {
+		return err
+	}
+
+	if !response.OK {
+		return loginError("loginByToken", response)
+	}
+
+	// The server answers a loginByToken without a token of its own, so the one
+	// that worked is the one to keep, see Client.SessionToken.
+	c.setSessionToken(token)
+
+	return nil
 }
 
 // loginWithPassword logs in with a username and password, and answers the

--- a/auth.go
+++ b/auth.go
@@ -43,6 +43,16 @@ var ErrInvalidTOTPCode = errors.New("invalid two-factor authentication code")
 // changed password or a user that was deactivated or deleted.
 var ErrInvalidSessionToken = errors.New("session token rejected")
 
+// ErrUserInactive is returned when the server rejects a session token because
+// the account it names is deactivated or deleted. It wraps
+// ErrInvalidSessionToken as well, so a caller that only cares that the token is
+// gone keeps matching on that one.
+//
+// It is the token rejection a password cannot recover from: the server requires
+// an active user for a password login too, so New reports it instead of falling
+// back, see WithSessionToken.
+var ErrUserInactive = errors.New("user inactive or deleted")
+
 // WithSessionToken authenticates with a session token from an earlier login
 // instead of a password, see Client.SessionToken.
 //
@@ -53,8 +63,13 @@ var ErrInvalidSessionToken = errors.New("session token rejected")
 // two-factor authentication enabled, see WithTOTPSecret.
 //
 // If a username and password are given as well, the token is tried first and
-// the password login is the fallback for a token the server rejects. Without
-// them a rejected token fails New with ErrInvalidSessionToken.
+// the password login is the fallback for a token the server refuses.
+// Client.SessionTokenRejected reports that this happened, because the login
+// succeeds either way and the stored token is dead. The fallback is skipped
+// where the password cannot help: for a deactivated or deleted user, see
+// ErrUserInactive, and for a failure that is not a rejection at all, such as a
+// transport error. Without a username and password a rejected token fails New
+// with ErrInvalidSessionToken.
 //
 // Security: the token is a bearer credential that does not expire. The server
 // invalidates it only when the password changes or the user is deactivated,
@@ -188,7 +203,7 @@ func loginError(command string, response ackResponse) error {
 		return ErrInvalidCredentials
 
 	case "authUserInactiveOrDeleted":
-		return fmt.Errorf("%w: user inactive or deleted", ErrInvalidSessionToken)
+		return fmt.Errorf("%w: %w", ErrInvalidSessionToken, ErrUserInactive)
 
 	case "authInvalidToken":
 		// The server answers two different rejections with this one message: a
@@ -240,7 +255,8 @@ func (c credentials) hasAny() bool {
 }
 
 // authenticate logs the client in the way the server asked for, and records the
-// session token a successful login answers with.
+// session token the connection ends up authenticated with, whether the server
+// handed it out or accepted the one the client presented.
 //
 // It returns nil without logging in for a server that authenticated the client
 // itself, for one that wants to be set up first, and for one that never stated
@@ -272,21 +288,48 @@ func (c *Client) authenticate(ctx context.Context, creds credentials, barrier au
 	}
 
 	if creds.token != "" {
-		err := c.loginWithToken(ctx, creds.token)
-		if err == nil {
+		tokenErr := c.loginWithToken(ctx, creds.token)
+		if tokenErr == nil {
 			return nil
 		}
 
-		if !errors.Is(err, ErrInvalidSessionToken) || !creds.isSet() {
-			return err
+		if !recoverableWithPassword(tokenErr, creds) {
+			return tokenErr
 		}
 
 		// A token the server no longer accepts is what a password change
 		// leaves behind, and the password is what recovers from it.
-		c.socketioLogger.Warnf("session token rejected, falling back to the password login")
+		c.socketioLogger.Warnf(
+			"session token rejected (%v), falling back to the password login for %q",
+			tokenErr,
+			creds.username,
+		)
+
+		err := c.loginWithPassword(ctx, creds.username, creds.password)
+		if err != nil {
+			// The rejected token is what sent the login down this path, which
+			// the password failure on its own does not say.
+			return fmt.Errorf("%w, and the password login that followed: %w", tokenErr, err)
+		}
+
+		c.setSessionTokenRejected()
+
+		return nil
 	}
 
 	return c.loginWithPassword(ctx, creds.username, creds.password)
+}
+
+// recoverableWithPassword reports whether a rejected session token is worth
+// following with a password login: only a token the server refuses, and only
+// when there is a password to offer. A deactivated or deleted user is the
+// rejection the server answers the same way for both credentials, and anything
+// that is not a rejection - a transport failure, a message the client does not
+// know - says nothing about the password either way.
+func recoverableWithPassword(err error, creds credentials) bool {
+	return errors.Is(err, ErrInvalidSessionToken) &&
+		!errors.Is(err, ErrUserInactive) &&
+		creds.isSet()
 }
 
 // loginWithToken presents a session token from an earlier login, see

--- a/auth_e2e_test.go
+++ b/auth_e2e_test.go
@@ -113,6 +113,8 @@ func TestAuthenticationAgainstServer(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, enabled)
 
+	var sessionToken string
+
 	t.Run("a login without a code is told what is missing", func(t *testing.T) {
 		client, newErr := kuma.New(
 			ctx,
@@ -140,6 +142,30 @@ func TestAuthenticationAgainstServer(t *testing.T) {
 		require.NotNil(t, client)
 
 		t.Cleanup(func() { _ = client.Disconnect() })
+
+		sessionToken = client.SessionToken()
+		require.NotEmpty(t, sessionToken, "a login answers with the token it can be repeated with")
+	})
+
+	t.Run("the session token needs neither password nor code", func(t *testing.T) {
+		client, newErr := kuma.New(
+			ctx,
+			baseURL,
+			"",
+			"",
+			kuma.WithSessionToken(sessionToken),
+			kuma.WithConnectTimeout(10*time.Second),
+		)
+
+		require.NoError(t, newErr)
+		require.NotNil(t, client)
+
+		t.Cleanup(func() { _ = client.Disconnect() })
+
+		require.Equal(t, sessionToken, client.SessionToken())
+
+		// The lists come from a login, and the token is what repeats one.
+		require.NoError(t, client.Resync(ctx))
 	})
 
 	t.Run("a code the server has seen is refused", func(t *testing.T) {

--- a/auth_test.go
+++ b/auth_test.go
@@ -391,3 +391,124 @@ func TestNewTOTPReplayGuardRecovers(t *testing.T) {
 	require.Len(t, codes, 3, "the login without a code, the rejected one and the retry")
 	require.NotEqual(t, codes[1], codes[2], "the retry has to fall into a later time step")
 }
+
+// TestNewWithSessionToken covers the client that holds a token from an earlier
+// login: it authenticates with no password and no one-time code at all.
+func TestNewWithSessionToken(t *testing.T) {
+	fake, url := newAuthFake(t)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(
+		ctx,
+		url,
+		"",
+		"",
+		kuma.WithSessionToken(fakeSessionToken),
+		kuma.WithConnectTimeout(5*time.Second),
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	t.Cleanup(func() { _ = client.Disconnect() })
+
+	require.Equal(t, 0, fake.loginFrameCount(), "a token login sends no password login")
+	require.Equal(t, fakeSessionToken, client.SessionToken())
+}
+
+// TestNewSessionTokenBypassesTwoFactor covers the reason a token is worth
+// keeping for an account with two-factor authentication: the server accepts it
+// without ever asking for a one-time code.
+func TestNewSessionTokenBypassesTwoFactor(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setTwoFactorSecret(false)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(
+		ctx,
+		url,
+		"",
+		"",
+		kuma.WithSessionToken(fakeSessionToken),
+		kuma.WithConnectTimeout(5*time.Second),
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	t.Cleanup(func() { _ = client.Disconnect() })
+
+	require.Empty(t, fake.receivedLoginCodes())
+}
+
+// TestNewRejectedSessionTokenFallsBack covers the token the server no longer
+// accepts, which is what a password change leaves behind. A caller that also
+// gave a username and password recovers with it.
+func TestNewRejectedSessionTokenFallsBack(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setRejectToken(true)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(
+		ctx,
+		url,
+		"admin",
+		"admin1",
+		kuma.WithSessionToken("stale-token"),
+		kuma.WithConnectTimeout(5*time.Second),
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	t.Cleanup(func() { _ = client.Disconnect() })
+
+	require.Equal(t, 1, fake.loginFrameCount(), "the password login is the fallback")
+	require.Equal(t, fakeSessionToken, client.SessionToken(), "the fresh token replaces the stale one")
+}
+
+// TestNewRejectedSessionTokenWithoutPassword covers the same rejection for a
+// caller that has nothing to fall back to.
+func TestNewRejectedSessionTokenWithoutPassword(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setRejectToken(true)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(
+		ctx,
+		url,
+		"",
+		"",
+		kuma.WithSessionToken("stale-token"),
+		kuma.WithConnectTimeout(5*time.Second),
+	)
+
+	require.ErrorIs(t, err, kuma.ErrInvalidSessionToken)
+	require.Nil(t, client)
+	require.Equal(t, 0, fake.loginFrameCount())
+}
+
+// TestSessionTokenAfterAutoLogin covers the server with authentication
+// disabled, which logs the client in without handing out a token.
+func TestSessionTokenAfterAutoLogin(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setAutoLogin(true)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(ctx, url, "", "", kuma.WithConnectTimeout(5*time.Second))
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = client.Disconnect() })
+
+	require.Empty(t, client.SessionToken())
+}

--- a/auth_test.go
+++ b/auth_test.go
@@ -207,7 +207,7 @@ func TestResyncRejectedToken(t *testing.T) {
 
 	t.Cleanup(func() { _ = client.Disconnect() })
 
-	fake.setRejectToken(true)
+	fake.setRejectToken()
 
 	resyncCtx, resyncCancel := context.WithTimeout(ctx, 2*time.Second)
 	defer resyncCancel()
@@ -405,7 +405,7 @@ func TestNewWithSessionToken(t *testing.T) {
 		url,
 		"",
 		"",
-		kuma.WithSessionToken(fakeSessionToken),
+		kuma.WithSessionToken(fakePresetToken),
 		kuma.WithConnectTimeout(5*time.Second),
 	)
 
@@ -415,7 +415,11 @@ func TestNewWithSessionToken(t *testing.T) {
 	t.Cleanup(func() { _ = client.Disconnect() })
 
 	require.Equal(t, 0, fake.loginFrameCount(), "a token login sends no password login")
-	require.Equal(t, fakeSessionToken, client.SessionToken())
+	require.Equal(t, []string{fakePresetToken}, fake.receivedTokens(),
+		"the configured token is what goes on the wire")
+	require.Equal(t, fakePresetToken, client.SessionToken(),
+		"a loginByToken is answered without a token, so the one that worked is kept")
+	require.False(t, client.SessionTokenRejected())
 }
 
 // TestNewSessionTokenBypassesTwoFactor covers the reason a token is worth
@@ -433,7 +437,7 @@ func TestNewSessionTokenBypassesTwoFactor(t *testing.T) {
 		url,
 		"",
 		"",
-		kuma.WithSessionToken(fakeSessionToken),
+		kuma.WithSessionToken(fakePresetToken),
 		kuma.WithConnectTimeout(5*time.Second),
 	)
 
@@ -442,6 +446,7 @@ func TestNewSessionTokenBypassesTwoFactor(t *testing.T) {
 
 	t.Cleanup(func() { _ = client.Disconnect() })
 
+	require.Equal(t, 0, fake.loginFrameCount(), "the token login never asks for a code")
 	require.Empty(t, fake.receivedLoginCodes())
 }
 
@@ -450,7 +455,7 @@ func TestNewSessionTokenBypassesTwoFactor(t *testing.T) {
 // gave a username and password recovers with it.
 func TestNewRejectedSessionTokenFallsBack(t *testing.T) {
 	fake, url := newAuthFake(t)
-	fake.setRejectToken(true)
+	fake.setRejectToken()
 
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
@@ -469,15 +474,19 @@ func TestNewRejectedSessionTokenFallsBack(t *testing.T) {
 
 	t.Cleanup(func() { _ = client.Disconnect() })
 
+	require.Equal(t, []string{"stale-token"}, fake.receivedTokens(), "the token is tried first")
 	require.Equal(t, 1, fake.loginFrameCount(), "the password login is the fallback")
+	require.True(t, fake.loginAfterToken(), "the password login follows the rejected token")
 	require.Equal(t, fakeSessionToken, client.SessionToken(), "the fresh token replaces the stale one")
+	require.True(t, client.SessionTokenRejected(),
+		"the caller has no other way to learn that the token it stored is dead")
 }
 
 // TestNewRejectedSessionTokenWithoutPassword covers the same rejection for a
 // caller that has nothing to fall back to.
 func TestNewRejectedSessionTokenWithoutPassword(t *testing.T) {
 	fake, url := newAuthFake(t)
-	fake.setRejectToken(true)
+	fake.setRejectToken()
 
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
@@ -493,7 +502,84 @@ func TestNewRejectedSessionTokenWithoutPassword(t *testing.T) {
 
 	require.ErrorIs(t, err, kuma.ErrInvalidSessionToken)
 	require.Nil(t, client)
+	require.Equal(t, []string{"stale-token"}, fake.receivedTokens())
 	require.Equal(t, 0, fake.loginFrameCount())
+}
+
+// TestNewRejectedSessionTokenAndPassword covers the caller whose stored token
+// and stored password are both stale: the rejected token has to survive in the
+// error, because the password failure alone sends the caller after the wrong
+// credential.
+func TestNewRejectedSessionTokenAndPassword(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setRejectToken()
+	fake.setRejectCreds(true)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(
+		ctx,
+		url,
+		"admin",
+		"outdated",
+		kuma.WithSessionToken("stale-token"),
+		kuma.WithConnectTimeout(5*time.Second),
+	)
+
+	require.Nil(t, client)
+	require.ErrorIs(t, err, kuma.ErrInvalidCredentials)
+	require.ErrorIs(t, err, kuma.ErrInvalidSessionToken,
+		"the rejected token is what sent the login to the password")
+}
+
+// TestNewSessionTokenUserInactive covers the rejection a password cannot
+// recover from, because the server requires an active user for that login too.
+func TestNewSessionTokenUserInactive(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setRejectTokenWith("authUserInactiveOrDeleted")
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(
+		ctx,
+		url,
+		"admin",
+		"admin1",
+		kuma.WithSessionToken("token-of-a-deactivated-user"),
+		kuma.WithConnectTimeout(5*time.Second),
+	)
+
+	require.Nil(t, client)
+	require.ErrorIs(t, err, kuma.ErrUserInactive)
+	require.ErrorIs(t, err, kuma.ErrInvalidSessionToken, "the token is gone either way")
+	require.Equal(t, 0, fake.loginFrameCount(),
+		"a password login for a deactivated user fails just the same")
+}
+
+// TestNewSessionTokenUnknownRejection covers a refusal the client does not
+// recognize, which says nothing about the password and is reported as it is.
+func TestNewSessionTokenUnknownRejection(t *testing.T) {
+	fake, url := newAuthFake(t)
+	fake.setRejectTokenWith("somethingElseEntirely")
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	client, err := kuma.New(
+		ctx,
+		url,
+		"admin",
+		"admin1",
+		kuma.WithSessionToken("stale-token"),
+		kuma.WithConnectTimeout(5*time.Second),
+	)
+
+	require.Nil(t, client)
+	require.ErrorContains(t, err, "somethingElseEntirely")
+	require.NotErrorIs(t, err, kuma.ErrInvalidSessionToken)
+	require.Equal(t, 0, fake.loginFrameCount(), "only a rejected token falls back to the password")
 }
 
 // TestSessionTokenAfterAutoLogin covers the server with authentication

--- a/client.go
+++ b/client.go
@@ -219,9 +219,13 @@ type Client struct {
 	// Resync logs in with, see there.
 	sessionToken string
 
-	// sessionTokenPreset is the token WithSessionToken configured, which is
-	// what New authenticates with instead of a password.
+	// sessionTokenPreset is the token WithSessionToken configured, which New
+	// tries before the password login.
 	sessionTokenPreset string
+
+	// sessionTokenRejected records that the server refused sessionTokenPreset
+	// and the password login took over, see Client.SessionTokenRejected.
+	sessionTokenRejected bool
 
 	// autoLoggedIn records that the server has authentication disabled and
 	// logged the client in itself, which leaves it without a session token,
@@ -937,10 +941,12 @@ func (c *Client) Resync(ctx context.Context) error {
 	return nil
 }
 
-// SessionToken returns the session token the server handed out at login, or
-// the empty string for a client that never received one: a client that
-// connected to a server with authentication disabled, and one whose login ack
-// carried no token.
+// SessionToken returns the session token the client is authenticated with: the
+// one the server handed out for the login New performed, or the one
+// WithSessionToken supplied and the server accepted. It is the empty string for
+// a client that was never logged in with credentials - one that connected to a
+// server with authentication disabled or to one that wants to be set up first -
+// and for one whose login ack carried no token.
 //
 // It is the credential WithSessionToken takes, so a caller can persist it and
 // reconnect later without the password and without a one-time code. It is a
@@ -950,6 +956,22 @@ func (c *Client) SessionToken() string {
 	defer c.mu.Unlock()
 
 	return c.sessionToken
+}
+
+// SessionTokenRejected reports whether the server refused the token
+// WithSessionToken configured and New logged in with the username and password
+// instead.
+//
+// It is what tells a caller that its stored token is dead, because nothing else
+// does: the login succeeds either way, and SessionToken then returns the fresh
+// token of the password login, which the caller cannot tell from the one it
+// presented. A caller that persists tokens checks this and writes the new one
+// back, see WithSessionToken.
+func (c *Client) SessionTokenRejected() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.sessionTokenRejected
 }
 
 // MissingReadyEvents returns the best-effort ready events the server did not
@@ -1051,6 +1073,16 @@ func (c *Client) setSessionToken(token string) {
 	defer c.mu.Unlock()
 
 	c.sessionToken = token
+}
+
+// setSessionTokenRejected records that the token WithSessionToken configured
+// was refused and the password login recovered, see
+// Client.SessionTokenRejected.
+func (c *Client) setSessionTokenRejected() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.sessionTokenRejected = true
 }
 
 // splitReadyEvents returns the update events that carry the lists the local

--- a/client.go
+++ b/client.go
@@ -219,6 +219,10 @@ type Client struct {
 	// Resync logs in with, see there.
 	sessionToken string
 
+	// sessionTokenPreset is the token WithSessionToken configured, which is
+	// what New authenticates with instead of a password.
+	sessionTokenPreset string
+
 	// autoLoggedIn records that the server has authentication disabled and
 	// logged the client in itself, which leaves it without a session token,
 	// see Resync.
@@ -759,7 +763,7 @@ connectLoop:
 
 	err = c.authenticate(
 		ctxWithConnectTimeout,
-		credentials{username: username, password: password},
+		credentials{username: username, password: password, token: c.sessionTokenPreset},
 		barrier,
 	)
 	if err != nil {
@@ -887,7 +891,9 @@ func (c *Client) Resync(ctx context.Context) error {
 			)
 		}
 
-		return errors.New("resync: no session token, the client was created without credentials")
+		return errors.New(
+			"resync: no session token, the client was created without credentials",
+		)
 	}
 
 	gate := newReadyGate(c.resyncReadyEvents())
@@ -929,6 +935,21 @@ func (c *Client) Resync(ctx context.Context) error {
 	c.awaitOptionalReadyEvents(ctx, "Resync", gate, nil)
 
 	return nil
+}
+
+// SessionToken returns the session token the server handed out at login, or
+// the empty string for a client that never received one: a client that
+// connected to a server with authentication disabled, and one whose login ack
+// carried no token.
+//
+// It is the credential WithSessionToken takes, so a caller can persist it and
+// reconnect later without the password and without a one-time code. It is a
+// bearer credential that does not expire, see WithSessionToken.
+func (c *Client) SessionToken() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.sessionToken
 }
 
 // MissingReadyEvents returns the best-effort ready events the server did not

--- a/client_ack_test.go
+++ b/client_ack_test.go
@@ -51,6 +51,11 @@ const fakeAckCreatedID = 4242
 // expects to see again in a loginByToken.
 const fakeSessionToken = "fake-session-token"
 
+// fakePresetToken is a token a test hands to WithSessionToken. It is distinct
+// from the one the fake server issues at login, so that a test can tell the
+// token that was presented from the one that was handed out.
+const fakePresetToken = "preset-session-token"
+
 // fakeAckServer is a minimal socket.io server over HTTP long-polling that
 // completes the handshake, CONNECT, login and ready phases, so kuma.New()
 // returns a usable client. Unlike fakeSocketIOServer it then keeps serving:
@@ -79,9 +84,14 @@ type fakeAckServer struct {
 	// rejectCreds answers a login the way a server rejecting the username and
 	// password does.
 	rejectCreds bool
-	// rejectToken answers a loginByToken the way a server rejecting the
-	// session token does.
-	rejectToken bool
+	// rejectTokenMsg answers a loginByToken the way a server rejecting the
+	// session token does, with this as the reason. The empty string accepts.
+	rejectTokenMsg string
+	// tokenFrames are the tokens the loginByToken frames carried, in order,
+	// recorded whether the token is accepted or refused. firstTokenAt is when
+	// the first of them arrived, to assert it came before any password login.
+	tokenFrames  []string
+	firstTokenAt time.Time
 	// autoLogin answers the connect the way a server with authentication
 	// disabled does: it logs the client in itself and never asks for a login.
 	autoLogin bool
@@ -133,6 +143,24 @@ func loginCode(payload string) string {
 	}
 
 	return data.Token
+}
+
+// tokenFromFrame extracts the session token a loginByToken frame carries.
+func tokenFromFrame(payload string) string {
+	var frame []json.RawMessage
+
+	start := strings.Index(payload, "[")
+	if start < 0 || json.Unmarshal([]byte(payload[start:]), &frame) != nil || len(frame) < 2 {
+		return ""
+	}
+
+	var token string
+
+	if json.Unmarshal(frame[1], &token) != nil {
+		return ""
+	}
+
+	return token
 }
 
 func (s *fakeAckServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -216,11 +244,17 @@ func (s *fakeAckServer) setRejectCreds(reject bool) {
 	s.rejectCreds = reject
 }
 
-func (s *fakeAckServer) setRejectToken(reject bool) {
+func (s *fakeAckServer) setRejectToken() {
+	s.setRejectTokenWith("authInvalidToken")
+}
+
+// setRejectTokenWith refuses a loginByToken with a specific reason, such as the
+// authUserInactiveOrDeleted the server answers for a deactivated user.
+func (s *fakeAckServer) setRejectTokenWith(msg string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.rejectToken = reject
+	s.rejectTokenMsg = msg
 }
 
 func (s *fakeAckServer) setAutoLogin(auto bool) {
@@ -339,11 +373,45 @@ func (s *fakeAckServer) setSuppressOptionalLists(suppress bool) {
 	s.suppressOptionalLists = suppress
 }
 
-func (s *fakeAckServer) tokenRejected() bool {
+// tokenRejection returns the reason a loginByToken is to be refused with, or
+// the empty string for a token the server accepts.
+func (s *fakeAckServer) tokenRejection() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	return s.rejectToken
+	return s.rejectTokenMsg
+}
+
+// recordToken records the token a loginByToken frame carried. It runs before
+// the rejection is answered, so a refused frame is seen as well.
+func (s *fakeAckServer) recordToken(token string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.tokenFrames = append(s.tokenFrames, token)
+
+	if s.firstTokenAt.IsZero() {
+		s.firstTokenAt = time.Now()
+	}
+}
+
+// receivedTokens returns the tokens the loginByToken frames carried, in order.
+func (s *fakeAckServer) receivedTokens() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return append([]string(nil), s.tokenFrames...)
+}
+
+// loginAfterToken reports whether the password login the client fell back to
+// came after the token it presented first.
+func (s *fakeAckServer) loginAfterToken() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return !s.firstLoginAt.IsZero() &&
+		!s.firstTokenAt.IsZero() &&
+		s.firstLoginAt.After(s.firstTokenAt)
 }
 
 func (s *fakeAckServer) recordResync(payload string) bool {
@@ -490,11 +558,14 @@ func (s *fakeAckServer) handleClientMessage(body []byte) {
 		// A resync logs in again, which is what makes the server resend the
 		// lists. Checked before "login", which is a prefix of it.
 		if strings.Contains(payload, `"loginByToken"`) {
-			if s.tokenRejected() {
+			s.recordToken(tokenFromFrame(payload))
+
+			if msg := s.tokenRejection(); msg != "" {
 				s.messages <- fmt.Appendf(
 					nil,
-					`43%s[{"ok":false,"msg":"authInvalidToken","msgi18n":true}]`,
+					`43%s[{"ok":false,"msg":%q,"msgi18n":true}]`,
 					ackID,
+					msg,
 				)
 
 				return

--- a/doc.go
+++ b/doc.go
@@ -35,6 +35,34 @@
 //	}
 //	id, err := client.CreateMonitor(ctx, monitor)
 //
+// # Authentication
+//
+// A username and password is the usual way in. An account with two-factor
+// authentication enabled additionally needs the shared secret, which the
+// client turns into the one-time code the server asks for:
+//
+//	client, err := kuma.New(ctx, url, "username", "password",
+//	    kuma.WithTOTPSecret(secret))
+//
+// A successful login answers with a session token. Persisting it lets a later
+// client connect with neither the password nor a one-time code, which is also
+// how several clients start at once against an account with two-factor
+// authentication: the server refuses a one-time code it has already accepted,
+// but takes the same token any number of times.
+//
+//	token := client.SessionToken()
+//	// ... later, in another process
+//	client, err := kuma.New(ctx, url, "", "", kuma.WithSessionToken(token))
+//
+// The token does not expire; the server invalidates it only when the password
+// changes or the user is deactivated. Store it the way the password would be
+// stored.
+//
+// A server with authentication disabled logs the client in by itself, so it
+// takes no credentials at all:
+//
+//	client, err := kuma.New(ctx, url, "", "")
+//
 // # Supported Monitor Types
 //
 // HTTP, TCP, Ping, DNS, gRPC, Redis, PostgreSQL, Real Browser, and more.

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.2
 require (
 	github.com/maldikhan/go.socket.io v0.1.1
 	github.com/ory/dockertest/v3 v3.12.0
+	github.com/pquerna/otp v1.5.0
 )
 
 require (
@@ -262,7 +263,6 @@ require (
 	github.com/pjbgf/sha1cd v0.3.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
-	github.com/pquerna/otp v1.5.0 // indirect
 	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect


### PR DESCRIPTION
Let a client authenticate with the session token the server hands out at login,
instead of a password.

> Stacked on #367, which is stacked on #366. Review those first; the base moves
> down as they merge.

## Why

`Resync` already logs in again with `loginByToken`, so the path is proven — it
is just not reachable at construction time. That left no way to reconnect
without the password, and no way at all to start several clients at once
against an account with two-factor authentication, because the server refuses a
one-time code it has accepted before and that guard is per user, not per
socket. The token has no such guard.

## What

- `WithSessionToken(token)` presents a token from an earlier login.
- `SessionToken()` returns the one the server just handed out, so a caller can
  persist it.
- Given a username and password as well, the token is tried first and the
  password login is the fallback for a token the server rejects — which is what
  a password change leaves behind. The fallback is logged, because a stale
  token followed by a successful password login otherwise looks like a plain
  success. Without them, a rejected token fails `New` with
  `ErrInvalidSessionToken`.

## Security

The token is a bearer credential with no expiry: `User.createJWT` passes
neither `expiresIn` nor an algorithm, and the server invalidates it only when
the password changes or the user is deactivated. It also bypasses two-factor
authentication entirely, which makes it a *stronger* credential than the
password for such an account. Both doc comments, the README and the package doc
say so.

## Tests

Five tests against the fake: a token alone sends no password login; a token
authenticates against a two-factor server with no code sent; a rejected token
falls back to the password and the fresh token replaces the stale one; a
rejected token without a password reports `ErrInvalidSessionToken`; and
`SessionToken` is empty after an `autoLogin`. The end-to-end test gains a
subtest that connects to a real two-factor-enabled server with the token alone
— no password, no code — and resyncs on it. `task lint`, `task test` and
`task test-e2e` all pass.

Also documents authentication in the README and the package doc, including why
Uptime Kuma API keys are not an option here.

Closes #365
